### PR TITLE
Stop ignoring Electron updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,6 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore'
-    ignore:
-      # Electron 25 does not support printing. See:
-      # https://github.com/electron/electron/issues/39025
-      - dependency-name: 'electron'
-        versions: ['>=25.0.0']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
We had started ignoring Electron updates because printing on Linux was broken (see https://github.com/electron/electron/issues/39025), but I tested the latest version of Electron and printing once again works on Linux, and a newer version is needed for #503. Since the exclusion is no longer warranted, remove it to unblock #503.