### PR TITLE
Fix hyphen position at line start

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -182,6 +182,9 @@
                         >
                           <div
                             class="melisma"
+                            :class="{
+                              full: (element as NoteElement).isFullMelisma,
+                            }"
                             :style="getMelismaStyle(element as NoteElement)"
                           >
                             <span


### PR DESCRIPTION
This fixes the alignment of the hyphen at the start of a new line.

Before
<img width="485" alt="image" src="https://github.com/neanes/neanes/assets/4132779/d351ea4a-dbf3-41ca-83f5-a2eb5524e72d">

After
<img width="448" alt="image" src="https://github.com/neanes/neanes/assets/4132779/bf83e1d9-5c1f-4935-8641-644aa0b15a24">
