### PR TITLE
Fix line height default value in html exporter.

### DIFF
--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -636,7 +636,7 @@ export class ByzHtmlExporter {
       style += `font-size: ${Unit.toPt(element.computedFontSize)}pt;`;
       style += `font-weight: ${element.computedFontWeight};`;
       style += `font-style: ${element.computedFontStyle};`;
-      style += `line-height: ${element.computedLineHeight};`;
+      style += `line-height: ${element.computedLineHeight ?? 'normal'};`;
       style += `-webkit-text-stroke-width: ${element.computedStrokeWidth};`;
 
       styleAttribute = ` style="${style}"`;
@@ -671,7 +671,7 @@ export class ByzHtmlExporter {
       style += `font-size: ${Unit.toPt(element.computedFontSize)}pt;`;
       style += `font-weight: ${element.computedFontWeight};`;
       style += `font-style: ${element.computedFontStyle};`;
-      style += `line-height: ${element.computedLineHeight};`;
+      style += `line-height: ${element.computedLineHeight ?? 'normal'};`;
       style += `-webkit-text-stroke-width: ${element.computedStrokeWidth};`;
       //style += `width: ${element.width};`;
       //style += `height: ${element.height};`;


### PR DESCRIPTION
From this commit line height default value in html exporter was `null` and not `normal` as should be.

https://github.com/neanes/neanes/compare/v0.4.16...v0.4.17#diff-11e341c6fd69b7a2c8c163efd3af870e57f59dd84403d2c6af2b3ea358909452R639
https://github.com/neanes/neanes/compare/v0.4.16...v0.4.17#diff-11e341c6fd69b7a2c8c163efd3af870e57f59dd84403d2c6af2b3ea358909452R674

Logic copied from this line:
https://github.com/neanes/neanes/compare/v0.4.16...v0.4.17#diff-3a56b30d2d308544e7af185748c907cf6e21f43ef91d753d871eb171a8243fe5R70