### PR TITLE
Add speed slider

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -5132,6 +5132,9 @@ export default class Editor extends Vue {
     speed = Math.min(3, speed);
     speed = +speed.toFixed(2);
 
+    this.selectedWorkspace.playbackBpm /= this.audioOptions.speed;
+    this.selectedWorkspace.playbackBpm *= speed;
+
     this.audioOptions.speed = speed;
 
     this.saveAudioOptions();

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1317,6 +1317,7 @@ export default class Editor extends Vue {
 
         if (event) {
           this.audioService.jumpToEvent(event);
+          this.selectedWorkspace.playbackTime = event.absoluteTime;
         }
       } else if (this.audioService.state === AudioState.Paused) {
         this.stopAudio();
@@ -5059,6 +5060,10 @@ export default class Editor extends Vue {
         );
 
         this.audioService.play(this.playbackEvents, this.audioOptions, startAt);
+
+        if (startAt) {
+          this.selectedWorkspace.playbackTime = startAt.absoluteTime;
+        }
 
         this.startPlaybackClock();
       } else {

--- a/src/components/InputUnit.vue
+++ b/src/components/InputUnit.vue
@@ -21,7 +21,7 @@ import { Unit } from '@/utils/Unit';
 })
 export default class InputUnit extends Vue {
   @Prop() modelValue!: number;
-  @Prop() unit!: 'pt' | 'in' | 'mm' | 'unitless';
+  @Prop() unit!: 'pt' | 'in' | 'mm' | 'percent' | 'unitless';
   @Prop({ default: false }) nullable!: boolean;
   /**
    * The minimum value allowed, in display units.
@@ -112,6 +112,8 @@ export default class InputUnit extends Vue {
         return Unit.fromInch(value);
       case 'mm':
         return Unit.fromMm(value);
+      case 'percent':
+        return Unit.fromPercent(value);
       case 'unitless':
         return value;
       default:
@@ -128,6 +130,8 @@ export default class InputUnit extends Vue {
         return Unit.toInch(value!);
       case 'mm':
         return Unit.toMm(value!);
+      case 'percent':
+        return Unit.toPercent(value!);
       case 'unitless':
         return value;
       default:

--- a/src/components/ToolbarMain.vue
+++ b/src/components/ToolbarMain.vue
@@ -196,30 +196,37 @@
 
       <span>{{ playbackTimeDisplay }}</span>
       <span class="space" />
-      <span>BPM = {{ playbackBpm }}</span>
+      <span>BPM = {{ playbackBpmDisplay }}</span>
 
       <span class="space" />
       <label class="right-space">{{ $t('toolbar:main.speed') }}</label>
-      <select
-        class="audio-speed"
-        :value="audioOptions.speed"
+      <input
+        class="audio-speed-slider"
+        type="range"
+        min=".1"
+        max="3"
+        step=".05"
         :disabled="audioState === AudioState.Playing"
-        @change="
+        :value="audioOptions.speed"
+        @input="
           $emit(
             'update:audioOptionsSpeed',
             ($event.target as HTMLInputElement).value,
           )
         "
-      >
-        <option value="0.25">0.25x</option>
-        <option value="0.5">0.5x</option>
-        <option value="0.75">0.75x</option>
-        <option value="1">1x</option>
-        <option value="1.25">1.25x</option>
-        <option value="1.5">1.5x</option>
-        <option value="1.75">1.75x</option>
-        <option value="2">2x</option>
-      </select>
+      />
+      <InputUnit
+        class="audio-speed"
+        unit="percent"
+        :min="10"
+        :max="300"
+        :step="1"
+        :precision="0"
+        :modelValue="audioOptions.speed"
+        :disabled="audioState === AudioState.Playing"
+        @update:modelValue="$emit('update:audioOptionsSpeed', $event)"
+      />
+      <span>%</span>
     </div>
     <span class="space"></span>
     <span class="space"></span>
@@ -232,6 +239,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-facing-decorator';
 
+import InputUnit from '@/components/InputUnit.vue';
 import { LineBreakType } from '@/models/Element';
 import { EntryMode } from '@/models/EntryMode';
 import { Note, RootSign, TempoSign } from '@/models/Neumes';
@@ -242,7 +250,7 @@ import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 import Neume from './Neume.vue';
 
 @Component({
-  components: { Neume },
+  components: { InputUnit, Neume },
   emits: [
     'add-auto-martyria',
     'add-drop-cap',
@@ -278,8 +286,8 @@ export default class ToolbarMain extends Vue {
   AudioState = AudioState;
   LineBreakType = LineBreakType;
 
-  showZoomMenu: boolean = false;
   showTempoMenu: boolean = false;
+  showZoomMenu: boolean = false;
 
   selectedTempoNeume: TempoSign | null = null;
 
@@ -289,6 +297,10 @@ export default class ToolbarMain extends Vue {
     return this.zoomToFit ? 'Fit' : (this.zoom * 100).toFixed(0) + '%';
   }
 
+  get speedDisplay() {
+    return (this.audioOptions.speed * 100).toFixed(0) + '%';
+  }
+
   get playbackTimeDisplay() {
     const hours = Math.floor(this.playbackTime / 3600);
     const minutes = Math.floor((this.playbackTime % 3600) / 60);
@@ -296,6 +308,10 @@ export default class ToolbarMain extends Vue {
     const tenths = this.playbackTime.toFixed(1).split('.')[1];
 
     return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}:${tenths}`;
+  }
+
+  get playbackBpmDisplay() {
+    return this.playbackBpm.toFixed(0);
   }
 
   get martyriaTooltip() {
@@ -494,6 +510,10 @@ label.right-space {
 }
 
 .audio-speed {
-  width: 3.5rem;
+  width: 2.5rem;
+}
+
+.audio-speed-slider {
+  width: 58px;
 }
 </style>

--- a/src/utils/Unit.ts
+++ b/src/utils/Unit.ts
@@ -11,6 +11,10 @@ export class Unit {
     return (mm / 25.4) * 96;
   }
 
+  public static fromPercent(percent: number) {
+    return percent / 100;
+  }
+
   public static toMm(pixels: number) {
     return (pixels / 96) * 25.4;
   }
@@ -21,5 +25,9 @@ export class Unit {
 
   public static toPt(points: number) {
     return (points * 72) / 96;
+  }
+
+  public static toPercent(value: number) {
+    return value * 100;
   }
 }


### PR DESCRIPTION
This PR changes the speed selection from a dropdown with limited options to a combination of a slider, which allows increments of 5%, and a free text box, which allows any percentage.

As before, the speed option works by multiplying the original BPM of each note by the selected percentage. This change is temporary and only applies to playback. The tempo markers saved in the score remain unchanged. 

This setting is not saved in the `byz` file. To alter the tempo of a score, the tempo markings throughout the score should be set to the desired tempo.

#221