### PR TITLE
Multipanel text boxes

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -485,7 +485,9 @@
       <ToolbarTextBox
         :element="selectedTextBoxElement"
         :fonts="fonts"
-        @update:multi="updateTextBoxMulti(selectedTextBoxElement, $event)"
+        @update:multipanel="
+          updateTextBoxMultipanel(selectedTextBoxElement, $event)
+        "
         @update:useDefaultStyle="
           updateTextBoxUseDefaultStyle(selectedTextBoxElement, $event)
         "
@@ -4580,8 +4582,8 @@ export default class Editor extends Vue {
     this.updateTextBox(element, { useDefaultStyle });
   }
 
-  updateTextBoxMulti(element: TextBoxElement, multi: boolean) {
-    this.updateTextBox(element, { multi });
+  updateTextBoxMultipanel(element: TextBoxElement, multipanel: boolean) {
+    this.updateTextBox(element, { multipanel });
   }
 
   updateTextBoxFontSize(element: TextBoxElement, fontSize: number) {
@@ -6222,7 +6224,7 @@ export default class Editor extends Vue {
   border: none;
 }
 
-.page.print :deep(.text-box.multi) {
+.page.print :deep(.text-box.multipanel) {
   border: none;
 }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -122,6 +122,24 @@
                       $event,
                     )
                   "
+                  @update:contentLeft="
+                    updateTextBoxContentLeft(
+                      getHeaderForPageIndex(pageIndex)!,
+                      $event,
+                    )
+                  "
+                  @update:contentCenter="
+                    updateTextBoxContentCenter(
+                      getHeaderForPageIndex(pageIndex)!,
+                      $event,
+                    )
+                  "
+                  @update:contentRight="
+                    updateTextBoxContentRight(
+                      getHeaderForPageIndex(pageIndex)!,
+                      $event,
+                    )
+                  "
                 />
               </template>
               <div
@@ -420,6 +438,24 @@
                       $event,
                     )
                   "
+                  @update:contentLeft="
+                    updateTextBoxContentLeft(
+                      getFooterForPageIndex(pageIndex)!,
+                      $event,
+                    )
+                  "
+                  @update:contentCenter="
+                    updateTextBoxContentCenter(
+                      getFooterForPageIndex(pageIndex)!,
+                      $event,
+                    )
+                  "
+                  @update:contentRight="
+                    updateTextBoxContentRight(
+                      getFooterForPageIndex(pageIndex)!,
+                      $event,
+                    )
+                  "
                 />
               </template>
             </template>
@@ -431,6 +467,7 @@
       <ToolbarTextBox
         :element="selectedTextBoxElement"
         :fonts="fonts"
+        @update:multi="updateTextBoxMulti(selectedTextBoxElement, $event)"
         @update:useDefaultStyle="
           updateTextBoxUseDefaultStyle(selectedTextBoxElement, $event)
         "
@@ -4506,11 +4543,27 @@ export default class Editor extends Vue {
     this.updateTextBox(element, { content });
   }
 
+  updateTextBoxContentLeft(element: TextBoxElement, contentLeft: string) {
+    this.updateTextBox(element, { contentLeft });
+  }
+
+  updateTextBoxContentCenter(element: TextBoxElement, contentCenter: string) {
+    this.updateTextBox(element, { contentCenter });
+  }
+
+  updateTextBoxContentRight(element: TextBoxElement, contentRight: string) {
+    this.updateTextBox(element, { contentRight });
+  }
+
   updateTextBoxUseDefaultStyle(
     element: TextBoxElement,
     useDefaultStyle: boolean,
   ) {
     this.updateTextBox(element, { useDefaultStyle });
+  }
+
+  updateTextBoxMulti(element: TextBoxElement, multi: boolean) {
+    this.updateTextBox(element, { multi });
   }
 
   updateTextBoxFontSize(element: TextBoxElement, fontSize: number) {
@@ -6148,6 +6201,10 @@ export default class Editor extends Vue {
 }
 
 .page.print .text-box-container {
+  border: none;
+}
+
+.page.print :deep(.text-box.multi) {
   border: none;
 }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -336,6 +336,24 @@
                       @update:content="
                         updateTextBoxContent(element as TextBoxElement, $event)
                       "
+                      @update:contentLeft="
+                        updateTextBoxContentLeft(
+                          element as TextBoxElement,
+                          $event,
+                        )
+                      "
+                      @update:contentCenter="
+                        updateTextBoxContentCenter(
+                          element as TextBoxElement,
+                          $event,
+                        )
+                      "
+                      @update:contentRight="
+                        updateTextBoxContentRight(
+                          element as TextBoxElement,
+                          $event,
+                        )
+                      "
                     />
                   </template>
                   <template v-if="isModeKeyElement(element)">

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -5,10 +5,10 @@
     @click="$emit('select-single')"
   >
     <span class="handle"></span>
-    <div class="text-box-multi-container" v-if="element.multi">
+    <div class="text-box-multipanel-container" v-if="element.multipanel">
       <ContentEditable
         ref="text"
-        class="text-box multi left"
+        class="text-box multipanel left"
         :class="textBoxClass"
         :style="textBoxStyle"
         :content="contentLeft"
@@ -17,7 +17,7 @@
       ></ContentEditable>
       <ContentEditable
         ref="text"
-        class="text-box multi center"
+        class="text-box multipanel center"
         :class="textBoxClass"
         :style="textBoxStyle"
         :content="contentCenter"
@@ -26,7 +26,7 @@
       ></ContentEditable>
       <ContentEditable
         ref="text"
-        class="text-box multi right"
+        class="text-box multipanel right"
         :class="textBoxClass"
         :style="textBoxStyle"
         :content="contentRight"
@@ -142,7 +142,7 @@ export default class TextBox extends Vue {
 
   get textBoxStyle() {
     const style: any = {
-      width: !this.element.multi ? this.width : undefined,
+      width: !this.element.multipanel ? this.width : undefined,
       height: withZoom(this.element.height),
     };
 
@@ -209,7 +209,7 @@ export default class TextBox extends Vue {
   min-height: 10px;
 }
 
-.text-box-multi-container {
+.text-box-multipanel-container {
   display: flex;
 }
 
@@ -233,7 +233,7 @@ export default class TextBox extends Vue {
   text-decoration: underline;
 }
 
-.text-box.multi {
+.text-box.multipanel {
   border: 1px dotted black;
   box-sizing: border-box;
   min-width: 2.5rem;
@@ -269,7 +269,7 @@ export default class TextBox extends Vue {
     display: none !important;
   }
 
-  .text-box.multi {
+  .text-box.multipanel {
     border: none !important;
   }
 }

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -5,7 +5,37 @@
     @click="$emit('select-single')"
   >
     <span class="handle"></span>
+    <div class="text-box-multi-container" v-if="element.multi">
+      <ContentEditable
+        ref="text"
+        class="text-box multi left"
+        :class="textBoxClass"
+        :style="textBoxStyle"
+        :content="contentLeft"
+        :editable="editMode"
+        @blur="updateContentLeft($event)"
+      ></ContentEditable>
+      <ContentEditable
+        ref="text"
+        class="text-box multi center"
+        :class="textBoxClass"
+        :style="textBoxStyle"
+        :content="contentCenter"
+        :editable="editMode"
+        @blur="updateContentCenter($event)"
+      ></ContentEditable>
+      <ContentEditable
+        ref="text"
+        class="text-box multi right"
+        :class="textBoxClass"
+        :style="textBoxStyle"
+        :content="contentRight"
+        :editable="editMode"
+        @blur="updateContentRight($event)"
+      ></ContentEditable>
+    </div>
     <ContentEditable
+      v-else
       ref="text"
       class="text-box"
       :class="textBoxClass"
@@ -22,7 +52,7 @@ import { StyleValue } from 'vue';
 import { Component, Prop, Vue } from 'vue-facing-decorator';
 
 import ContentEditable from '@/components/ContentEditable.vue';
-import { TextBoxElement } from '@/models/Element';
+import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
 import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
 import { replaceTokens, TokenMetadata } from '@/utils/replaceTokens';
@@ -30,7 +60,13 @@ import { withZoom } from '@/utils/withZoom';
 
 @Component({
   components: { ContentEditable },
-  emits: ['update:content', 'select-single'],
+  emits: [
+    'update:content',
+    'update:contentLeft',
+    'update:contentCenter',
+    'update:contentRight',
+    'select-single',
+  ],
 })
 export default class TextBox extends Vue {
   @Prop() element!: TextBoxElement;
@@ -49,6 +85,36 @@ export default class TextBox extends Vue {
           this.element.content,
           this.metadata,
           this.element.alignment,
+        );
+  }
+
+  get contentLeft() {
+    return this.editMode
+      ? this.element.contentLeft
+      : replaceTokens(
+          this.element.contentLeft,
+          this.metadata,
+          TextBoxAlignment.Left,
+        );
+  }
+
+  get contentCenter() {
+    return this.editMode
+      ? this.element.contentCenter
+      : replaceTokens(
+          this.element.contentCenter,
+          this.metadata,
+          TextBoxAlignment.Center,
+        );
+  }
+
+  get contentRight() {
+    return this.editMode
+      ? this.element.contentRight
+      : replaceTokens(
+          this.element.contentRight,
+          this.metadata,
+          TextBoxAlignment.Right,
         );
   }
 
@@ -76,7 +142,7 @@ export default class TextBox extends Vue {
 
   get textBoxStyle() {
     const style: any = {
-      width: this.width,
+      width: !this.element.multi ? this.width : undefined,
       height: withZoom(this.element.height),
     };
 
@@ -99,6 +165,33 @@ export default class TextBox extends Vue {
     this.$emit('update:content', content);
   }
 
+  updateContentLeft(content: string) {
+    // Nothing actually changed, so do nothing
+    if (this.element.contentLeft === content) {
+      return;
+    }
+
+    this.$emit('update:contentLeft', content);
+  }
+
+  updateContentCenter(content: string) {
+    // Nothing actually changed, so do nothing
+    if (this.element.contentCenter === content) {
+      return;
+    }
+
+    this.$emit('update:contentCenter', content);
+  }
+
+  updateContentRight(content: string) {
+    // Nothing actually changed, so do nothing
+    if (this.element.contentRight === content) {
+      return;
+    }
+
+    this.$emit('update:contentRight', content);
+  }
+
   blur() {
     this.textElement.blur();
   }
@@ -114,6 +207,10 @@ export default class TextBox extends Vue {
   border: 1px dotted black;
   box-sizing: border-box;
   min-height: 10px;
+}
+
+.text-box-multi-container {
+  display: flex;
 }
 
 .text-box {
@@ -136,6 +233,28 @@ export default class TextBox extends Vue {
   text-decoration: underline;
 }
 
+.text-box.multi {
+  border: 1px dotted black;
+  box-sizing: border-box;
+  min-width: 2.5rem;
+}
+
+.text-box.left {
+  position: absolute;
+  left: 0;
+}
+
+.text-box.center {
+  flex: 1;
+  text-align: center;
+}
+
+.text-box.right {
+  position: absolute;
+  right: 0;
+  text-align: right;
+}
+
 .text-box-container .handle {
   bottom: calc(50% - 5px);
   left: -10px;
@@ -148,6 +267,10 @@ export default class TextBox extends Vue {
 @media print {
   .text-box-container .handle {
     display: none !important;
+  }
+
+  .text-box.multi {
+    border: none !important;
   }
 }
 </style>

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -78,43 +78,45 @@
     >
       <u>U</u>
     </button>
-    <span class="space"></span>
-    <button
-      class="icon-btn"
-      :class="{ selected: element.alignment === TextBoxAlignment.Left }"
-      @click="$emit('update:alignment', TextBoxAlignment.Left)"
-    >
-      <img
-        src="@/assets/icons/alignleft.svg"
-        width="32"
-        height="32"
-        :title="$t('toolbar:common.alignLeft')"
-      />
-    </button>
-    <button
-      class="icon-btn"
-      :class="{ selected: element.alignment === TextBoxAlignment.Center }"
-      @click="$emit('update:alignment', TextBoxAlignment.Center)"
-    >
-      <img
-        src="@/assets/icons/aligncenter.svg"
-        width="32"
-        height="32"
-        :title="$t('toolbar:common.alignCenter')"
-      />
-    </button>
-    <button
-      class="icon-btn"
-      :class="{ selected: element.alignment === TextBoxAlignment.Right }"
-      @click="$emit('update:alignment', TextBoxAlignment.Right)"
-    >
-      <img
-        src="@/assets/icons/alignright.svg"
-        width="32"
-        height="32"
-        :title="$t('toolbar:common.alignRight')"
-      />
-    </button>
+    <template v-if="!element.multi">
+      <span class="space"></span>
+      <button
+        class="icon-btn"
+        :class="{ selected: element.alignment === TextBoxAlignment.Left }"
+        @click="$emit('update:alignment', TextBoxAlignment.Left)"
+      >
+        <img
+          src="@/assets/icons/alignleft.svg"
+          width="32"
+          height="32"
+          :title="$t('toolbar:common.alignLeft')"
+        />
+      </button>
+      <button
+        class="icon-btn"
+        :class="{ selected: element.alignment === TextBoxAlignment.Center }"
+        @click="$emit('update:alignment', TextBoxAlignment.Center)"
+      >
+        <img
+          src="@/assets/icons/aligncenter.svg"
+          width="32"
+          height="32"
+          :title="$t('toolbar:common.alignCenter')"
+        />
+      </button>
+      <button
+        class="icon-btn"
+        :class="{ selected: element.alignment === TextBoxAlignment.Right }"
+        @click="$emit('update:alignment', TextBoxAlignment.Right)"
+      >
+        <img
+          src="@/assets/icons/alignright.svg"
+          width="32"
+          height="32"
+          :title="$t('toolbar:common.alignRight')"
+        />
+      </button>
+    </template>
     <template v-if="!element.useDefaultStyle">
       <span class="space" />
       <label class="right-space">{{ $t('toolbar:common.outline') }}</label>

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -140,6 +140,22 @@
         :title="$t('toolbar:common.insertGorthmikon')"
       />
     </button>
+
+    <template v-if="!element.inline">
+      <span class="divider" />
+
+      <input
+        id="toolbar-text-box-multi"
+        type="checkbox"
+        :checked="element.multi"
+        @change="
+          $emit('update:multi', ($event.target as HTMLInputElement).checked)
+        "
+      />
+      <label for="toolbar-text-box-multi">{{
+        $t('toolbar:textbox.multi')
+      }}</label></template
+    >
   </div>
 </template>
 
@@ -164,6 +180,7 @@ import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
     'update:fontSize',
     'update:italic',
     'update:lineHeight',
+    'update:multi',
     'update:strokeWidth',
     'update:underline',
     'update:useDefaultStyle',

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -78,7 +78,7 @@
     >
       <u>U</u>
     </button>
-    <template v-if="!element.multi">
+    <template v-if="!element.multipanel">
       <span class="space"></span>
       <button
         class="icon-btn"
@@ -147,15 +147,18 @@
       <span class="divider" />
 
       <input
-        id="toolbar-text-box-multi"
+        id="toolbar-text-box-multipanel"
         type="checkbox"
-        :checked="element.multi"
+        :checked="element.multipanel"
         @change="
-          $emit('update:multi', ($event.target as HTMLInputElement).checked)
+          $emit(
+            'update:multipanel',
+            ($event.target as HTMLInputElement).checked,
+          )
         "
       />
-      <label for="toolbar-text-box-multi">{{
-        $t('toolbar:textbox.multi')
+      <label for="toolbar-text-box-multipanel">{{
+        $t('toolbar:textbox.multipanel')
       }}</label></template
     >
   </div>
@@ -182,7 +185,7 @@ import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
     'update:fontSize',
     'update:italic',
     'update:lineHeight',
-    'update:multi',
+    'update:multipanel',
     'update:strokeWidth',
     'update:underline',
     'update:useDefaultStyle',

--- a/src/i18n/en/toolbar.json
+++ b/src/i18n/en/toolbar.json
@@ -68,6 +68,6 @@
     "isonIndicator": "Ison Indicator"
   },
   "textbox": {
-    "multi": "Multipanel"
+    "multipanel": "Multipanel"
   }
 }

--- a/src/i18n/en/toolbar.json
+++ b/src/i18n/en/toolbar.json
@@ -66,5 +66,8 @@
     "measureNumber": "Measure Number",
     "noteIndicator": "Note Indicator",
     "isonIndicator": "Ison Indicator"
+  },
+  "textbox": {
+    "multi": "Multipanel"
   }
 }

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -714,9 +714,13 @@ export class TextBoxElement extends ScoreElement {
   public alignment: TextBoxAlignment = TextBoxAlignment.Left;
   public color: string = '#000000';
   public content: string = '';
+  public contentLeft: string = '';
+  public contentCenter: string = '';
+  public contentRight: string = '';
   public fontSize: number = 16;
   public fontFamily: string = 'Source Serif';
   public strokeWidth: number = 0;
+  public multi: boolean = false;
   public inline: boolean = false;
   public bold: boolean = false;
   public italic: boolean = false;

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -720,7 +720,7 @@ export class TextBoxElement extends ScoreElement {
   public fontSize: number = 16;
   public fontFamily: string = 'Source Serif';
   public strokeWidth: number = 0;
-  public multi: boolean = false;
+  public multipanel: boolean = false;
   public inline: boolean = false;
   public bold: boolean = false;
   public italic: boolean = false;

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -765,6 +765,9 @@ export class TextBoxElement extends ScoreElement {
       alignment: this.alignment,
       color: this.color,
       content: this.content,
+      contentLeft: this.contentLeft,
+      contentCenter: this.contentCenter,
+      contentRight: this.contentRight,
       fontSize: this.fontSize,
       fontFamily: this.fontFamily,
       strokeWidth: this.strokeWidth,
@@ -773,6 +776,7 @@ export class TextBoxElement extends ScoreElement {
       italic: this.italic,
       underline: this.underline,
       useDefaultStyle: this.useDefaultStyle,
+      multipanel: this.multipanel,
     } as Partial<TextBoxElement>;
   }
 

--- a/src/models/Footer.ts
+++ b/src/models/Footer.ts
@@ -2,4 +2,10 @@ import { ScoreElement, TextBoxElement } from './Element';
 
 export class Footer {
   public elements: ScoreElement[] = [new TextBoxElement()];
+
+  constructor() {
+    const textbox = new TextBoxElement();
+    textbox.multi = true;
+    this.elements = [textbox];
+  }
 }

--- a/src/models/Footer.ts
+++ b/src/models/Footer.ts
@@ -5,7 +5,7 @@ export class Footer {
 
   constructor() {
     const textbox = new TextBoxElement();
-    textbox.multi = true;
+    textbox.multipanel = true;
     this.elements = [textbox];
   }
 }

--- a/src/models/Header.ts
+++ b/src/models/Header.ts
@@ -5,7 +5,7 @@ export class Header {
 
   constructor() {
     const textbox = new TextBoxElement();
-    textbox.multi = true;
+    textbox.multipanel = true;
     this.elements = [textbox];
   }
 }

--- a/src/models/Header.ts
+++ b/src/models/Header.ts
@@ -1,5 +1,11 @@
 import { ScoreElement, TextBoxElement } from './Element';
 
 export class Header {
-  public elements: ScoreElement[] = [new TextBoxElement()];
+  public elements: ScoreElement[];
+
+  constructor() {
+    const textbox = new TextBoxElement();
+    textbox.multi = true;
+    this.elements = [textbox];
+  }
 }

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -173,7 +173,7 @@ export class TextBoxElement extends ScoreElement {
   public fontSize: number = 16;
   public fontFamily: string = 'Omega';
   public strokeWidth: number = 0;
-  public multi: boolean | undefined = undefined;
+  public multipanel: boolean | undefined = undefined;
   public inline: boolean | undefined = undefined;
   public bold: boolean | undefined = undefined;
   public italic: boolean | undefined = undefined;

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -167,9 +167,13 @@ export class TextBoxElement extends ScoreElement {
   public alignment: TextBoxAlignment = TextBoxAlignment.Left;
   public color: string = '#000000';
   public content: string = '';
+  public contentLeft: string = '';
+  public contentCenter: string = '';
+  public contentRight: string = '';
   public fontSize: number = 16;
   public fontFamily: string = 'Omega';
   public strokeWidth: number = 0;
+  public multi: boolean | undefined = undefined;
   public inline: boolean | undefined = undefined;
   public bold: boolean | undefined = undefined;
   public italic: boolean | undefined = undefined;

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -899,7 +899,22 @@ export class LayoutService {
     if (textBoxElement.inline) {
       textBoxElement.height = neumeHeight;
     } else if (textBoxElement.multi) {
-      textBoxElement.height = fontHeight;
+      const height = Math.max(
+        LayoutService.calculateTextBoxHeight(
+          textBoxElement.contentLeft,
+          fontHeight,
+        ),
+        LayoutService.calculateTextBoxHeight(
+          textBoxElement.contentCenter,
+          fontHeight,
+        ),
+        LayoutService.calculateTextBoxHeight(
+          textBoxElement.contentRight,
+          fontHeight,
+        ),
+      );
+
+      textBoxElement.height = Math.max(height, fontHeight);
     } else {
       let height = 0;
 
@@ -931,6 +946,22 @@ export class LayoutService {
     }
 
     return elementWidthPx;
+  }
+
+  private static calculateTextBoxHeight(content: string, fontHeight: number) {
+    const lines = content.split(/(?:\r\n|\r|\n)/g);
+
+    let height = 0;
+
+    for (let i = 0; i < lines.length; i++) {
+      // If the last line is blank, don't include the height
+      if (i === lines.length - 1 && lines[i] === '') {
+        continue;
+      }
+      height += fontHeight;
+    }
+
+    return height;
   }
 
   private static saveElementState(element: ScoreElement) {

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -898,7 +898,7 @@ export class LayoutService {
 
     if (textBoxElement.inline) {
       textBoxElement.height = neumeHeight;
-    } else if (textBoxElement.multi) {
+    } else if (textBoxElement.multipanel) {
       const height = Math.max(
         LayoutService.calculateTextBoxHeight(
           textBoxElement.contentLeft,

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -898,6 +898,8 @@ export class LayoutService {
 
     if (textBoxElement.inline) {
       textBoxElement.height = neumeHeight;
+    } else if (textBoxElement.multi) {
+      textBoxElement.height = fontHeight;
     } else {
       let height = 0;
 

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -448,6 +448,12 @@ export class SaveService {
     element.alignment = e.alignment;
     element.color = e.color;
     element.content = e.content;
+    if (e.multi) {
+      element.contentLeft = e.contentLeft;
+      element.contentCenter = e.contentCenter;
+      element.contentRight = e.contentRight;
+      element.multi = true;
+    }
     element.fontFamily = e.fontFamily;
     element.fontSize = e.fontSize;
     element.strokeWidth = e.strokeWidth;
@@ -1067,6 +1073,15 @@ export class SaveService {
     element.alignment = e.alignment;
     element.color = e.color;
     element.content = e.content;
+
+    if (e.multi) {
+      element.contentLeft = e.contentLeft;
+      element.contentCenter = e.contentCenter;
+      element.contentRight = e.contentRight;
+    }
+
+    element.multi = e.multi === true;
+
     element.fontFamily = e.fontFamily;
     element.fontSize = e.fontSize;
     element.inline = e.inline === true;

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -448,11 +448,11 @@ export class SaveService {
     element.alignment = e.alignment;
     element.color = e.color;
     element.content = e.content;
-    if (e.multi) {
+    if (e.multipanel) {
       element.contentLeft = e.contentLeft;
       element.contentCenter = e.contentCenter;
       element.contentRight = e.contentRight;
-      element.multi = true;
+      element.multipanel = true;
     }
     element.fontFamily = e.fontFamily;
     element.fontSize = e.fontSize;
@@ -1074,13 +1074,13 @@ export class SaveService {
     element.color = e.color;
     element.content = e.content;
 
-    if (e.multi) {
+    if (e.multipanel) {
       element.contentLeft = e.contentLeft;
       element.contentCenter = e.contentCenter;
       element.contentRight = e.contentRight;
     }
 
-    element.multi = e.multi === true;
+    element.multipanel = e.multipanel === true;
 
     element.fontFamily = e.fontFamily;
     element.fontSize = e.fontSize;


### PR DESCRIPTION
This PR adds a `multipanel` option to non-inline text boxes. When this option is enabled, three panels appear in the text box. The leftmost panel is left aligned, the center panel is center aligned, and the rightmost panel is right-aligned. The primary use for this is in the headers where users would want to center a page title, but right or left align the page numbers.