### PR TITLE
Set application category

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -16,6 +16,9 @@
       "role": "Editor"
     }
   ],
+  "mac": {
+    "category": "public.app-category.graphics-design"
+  },
   "linux": {
     "target": ["AppImage"]
   }


### PR DESCRIPTION
Fixes

> application Linux category is set to default "Utility"  reason=`linux.category` is not set and cannot map from macOS docs=https://www.electron.build/configuration/linux

by setting the application category for macOS so that it can be mapped to the Linux build.