### PR TITLE
Adapt to issue tracker triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[BUG] My Bug'
-labels: bug
-assignees: danielgarthur
+title: 'My bug'
+labels:
+  - 'Type: Bug'
 ---
 
 **This bug was found in**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[ENHANCEMENT] My Feature Request"
-labels: enhancement
-assignees: danielgarthur
-
+title: 'My feature request'
+labels:
+  - 'Type: Feature'
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore'
+    labels:
+      - 'Type: Dependencies'
     ignore:
       # Electron 30 segfaults on Linux. See:
       # https://github.com/electron/electron/issues/41839
@@ -19,3 +21,5 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore'
+    labels:
+      - 'Type: Dependencies'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,37 +1,48 @@
-name-template: '$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+# https://github.com/release-drafter/release-drafter
+---
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+
+# Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
+  - title: '🔒 Security Fixes'
+    labels:
+      - 'Type: Security'
+  - title: '💥 Breaking Changes'
+    labels:
+      - 'Type: Breaking Change'
   - title: '🚀 Features'
     labels:
-      - 'feat'
-      - 'feature'
-      - 'enhancement'
+      - 'Type: Feature'
   - title: '🐛 Bug Fixes'
     labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
+      - 'Type: Bug'
+  - title: '📝 Documentation'
+    labels:
+      - 'Type: Documentation'
+  - title: '♻️ Refactoring'
+    labels:
+      - 'Type: Refactoring'
+  - title: '✅ Testing'
+    labels:
+      - 'Type: Testing'
   - title: '🧰 Maintenance'
     labels:
-      - 'chore'
-      - 'dependencies'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
+      - 'Type: Maintenance'
+  - title: '👷 CI'
     labels:
-      - 'major'
-  minor:
+      - 'Type: CI'
+  - title: '📦 Dependency Updates'
     labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
+      - 'Type: Dependencies'
+    collapse-after: 5
+  - title: '✍ Other changes'
 exclude-labels:
   - 'skip-changelog'
-  - 'docs'
-template: |
-  ## Changes
+  - 'Type: Meta'
+  - 'Type: Question'
+  - 'Type: Release'
 
+template: |
+  <!-- Optional: add a release summary here -->
   $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,11 @@
+# https://github.com/release-drafter/release-drafter
+---
 name: Release Drafter
-on: workflow_dispatch
+
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
- Consistently denote issue type with labels rather than an inconsistent mix of labels and issue titles
- Remove default assignees, as they often do not reflect the reality of whether or not an issue is being worked on
- Use new label for Dependabot PRs
- Update Release Drafter configuration to use new labels
- Run Release Drafter on every commit to the `master` branch