### PR TITLE
Font-independent Melismata

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -235,16 +235,14 @@
                         <template
                           v-else-if="
                             isMelisma(element as NoteElement) &&
-                            !(element as NoteElement).isHyphen
+                            !(element as NoteElement).isHyphen &&
+                            !rtl
                           "
                         >
                           <div
                             class="melisma-underscore"
                             :class="{
-                              full:
-                                (element as NoteElement).isFullMelisma && !rtl,
-                              fullRtl:
-                                (element as NoteElement).isFullMelisma && rtl,
+                              full: (element as NoteElement).isFullMelisma,
                             }"
                             :style="
                               getMelismaUnderscoreStyleOuter(
@@ -261,6 +259,22 @@
                               "
                             ></div>
                           </div>
+                        </template>
+                        <template
+                          v-else-if="
+                            isMelisma(element as NoteElement) &&
+                            !(element as NoteElement).isHyphen &&
+                            rtl
+                          "
+                        >
+                          <div
+                            class="melisma"
+                            :class="{
+                              fullRtl: (element as NoteElement).isFullMelisma,
+                            }"
+                            :style="getMelismaStyle(element as NoteElement)"
+                            v-text="(element as NoteElement).melismaText"
+                          ></div>
                         </template>
                       </div>
                     </div>

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1736,7 +1736,8 @@ export default class Editor extends Vue {
   }
 
   getMelismaUnderscoreStyleOuter(element: NoteElement) {
-    const thickness = 1;
+    const thickness = this.score.pageSetup.lyricsMelismaThickeness;
+
     return {
       top: withZoom(element.melismaOffsetTop),
       height: withZoom(element.melismaHeight - thickness / 2),
@@ -1745,10 +1746,10 @@ export default class Editor extends Vue {
   }
 
   getMelismaUnderscoreStyleInner(element: NoteElement) {
-    const thickness = 1;
+    const thickness = this.score.pageSetup.lyricsMelismaThickeness;
 
     const spacing = !element.isFullMelisma
-      ? this.score.pageSetup.lyricsMinimumSpacing
+      ? this.score.pageSetup.lyricsMelismaSpacing
       : 0;
 
     return {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -6521,6 +6521,10 @@ export default class Editor extends Vue {
   left: 0;
 }
 
+.melisma-underscore.full {
+  left: 0;
+}
+
 .melisma.fullRtl {
   right: 0;
 }

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -6532,6 +6532,7 @@ export default class Editor extends Vue {
 .melisma-inner {
   height: 100%;
   position: relative;
+  box-sizing: border-box;
 }
 
 .page-break {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -246,8 +246,9 @@
                               fullRtl:
                                 (element as NoteElement).isFullMelisma && rtl,
                             }"
-                            :style="getMelismaStyle(element as NoteElement)"
-                            v-text="(element as NoteElement).melismaText"
+                            :style="
+                              getMelismaUnderscoreStyle(element as NoteElement)
+                            "
                           ></div>
                         </template>
                       </div>
@@ -1707,6 +1708,20 @@ export default class Editor extends Vue {
         ? withZoom(this.score.pageSetup.lyricsDefaultFontSize)
         : withZoom(element.lyricsFontSize),
     } as StyleValue;
+  }
+
+  getMelismaUnderscoreStyle(element: NoteElement) {
+    const thickness = 1;
+    return {
+      borderBottom: `${withZoom(thickness)} solid ${
+        element.lyricsUseDefaultStyle
+          ? this.score.pageSetup.lyricsDefaultColor
+          : element.lyricsColor
+      }`,
+      top: withZoom(element.melismaOffsetTop),
+      height: withZoom(element.melismaHeight - thickness / 2),
+      width: withZoom(element.melismaWidth!),
+    };
   }
 
   getMelismaHyphenStyle(element: NoteElement, index: number) {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -239,7 +239,7 @@
                           "
                         >
                           <div
-                            class="melisma"
+                            class="melisma-underscore"
                             :class="{
                               full:
                                 (element as NoteElement).isFullMelisma && !rtl,
@@ -247,9 +247,20 @@
                                 (element as NoteElement).isFullMelisma && rtl,
                             }"
                             :style="
-                              getMelismaUnderscoreStyle(element as NoteElement)
+                              getMelismaUnderscoreStyleOuter(
+                                element as NoteElement,
+                              )
                             "
-                          ></div>
+                          >
+                            <div
+                              class="melisma-inner"
+                              :style="
+                                getMelismaUnderscoreStyleInner(
+                                  element as NoteElement,
+                                )
+                              "
+                            ></div>
+                          </div>
                         </template>
                       </div>
                     </div>
@@ -1710,17 +1721,30 @@ export default class Editor extends Vue {
     } as StyleValue;
   }
 
-  getMelismaUnderscoreStyle(element: NoteElement) {
+  getMelismaUnderscoreStyleOuter(element: NoteElement) {
     const thickness = 1;
+    return {
+      top: withZoom(element.melismaOffsetTop),
+      height: withZoom(element.melismaHeight - thickness / 2),
+      width: withZoom(element.melismaWidth!),
+    };
+  }
+
+  getMelismaUnderscoreStyleInner(element: NoteElement) {
+    const thickness = 1;
+
+    const spacing = !element.isFullMelisma
+      ? this.score.pageSetup.lyricsMinimumSpacing
+      : 0;
+
     return {
       borderBottom: `${withZoom(thickness)} solid ${
         element.lyricsUseDefaultStyle
           ? this.score.pageSetup.lyricsDefaultColor
           : element.lyricsColor
       }`,
-      top: withZoom(element.melismaOffsetTop),
-      height: withZoom(element.melismaHeight - thickness / 2),
-      width: withZoom(element.melismaWidth!),
+      left: withZoom(spacing),
+      width: `calc(100% - ${withZoom(spacing)})`,
     };
   }
 
@@ -6473,6 +6497,12 @@ export default class Editor extends Vue {
   white-space: pre;
 }
 
+.melisma-underscore {
+  position: absolute;
+  display: inline;
+  white-space: pre;
+}
+
 .melisma.full {
   left: 0;
 }
@@ -6483,6 +6513,11 @@ export default class Editor extends Vue {
 
 .melisma-hyphen {
   position: absolute;
+}
+
+.melisma-inner {
+  height: 100%;
+  position: relative;
 }
 
 .page-break {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1736,11 +1736,9 @@ export default class Editor extends Vue {
   }
 
   getMelismaUnderscoreStyleOuter(element: NoteElement) {
-    const thickness = this.score.pageSetup.lyricsMelismaThickeness;
-
     return {
       top: withZoom(element.melismaOffsetTop),
-      height: withZoom(element.melismaHeight - thickness / 2),
+      height: withZoom(element.melismaHeight),
       width: withZoom(element.melismaWidth!),
     };
   }

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -388,6 +388,8 @@ export class NoteElement extends ScoreElement {
 
   // Used for display
   public melismaText: string = '';
+  public melismaOffsetTop: number = 0;
+  public melismaHeight: number = 0;
   public hyphenOffsets: number[] = [];
   public isFullMelisma: boolean = false;
   public melismaWidth: number = 0;

--- a/src/models/PageSetup.ts
+++ b/src/models/PageSetup.ts
@@ -76,6 +76,9 @@ export class PageSetup {
   public lyricsDefaultStrokeWidth = 0;
   public lyricsVerticalOffset = -Unit.fromInch(0.05);
   public lyricsMinimumSpacing = Unit.fromInch(0.05);
+
+  // These two melisma properties are currently not exposed in the UI or saved
+  // as part of the byzx format.
   public lyricsMelismaSpacing = Unit.fromInch(0.025);
   public lyricsMelismaThickeness = 1;
 

--- a/src/models/PageSetup.ts
+++ b/src/models/PageSetup.ts
@@ -76,6 +76,8 @@ export class PageSetup {
   public lyricsDefaultStrokeWidth = 0;
   public lyricsVerticalOffset = -Unit.fromInch(0.05);
   public lyricsMinimumSpacing = Unit.fromInch(0.05);
+  public lyricsMelismaSpacing = Unit.fromInch(0.025);
+  public lyricsMelismaThickeness = 1;
 
   public get lyricsFont() {
     return `${this.lyricsDefaultFontStyle} normal ${this.lyricsDefaultFontWeight} ${this.lyricsDefaultFontSize}px "${this.lyricsDefaultFontFamily}"`;

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -47,6 +47,8 @@ import { TATWEEL } from '@/utils/constants';
 
 import { TextMeasurementService } from './TextMeasurementService';
 
+const fontHeightCache = new Map<string, number>();
+const fontBoundingBoxDescentCache = new Map<string, number>();
 const textWidthCache = new Map<string, number>();
 const neumeWidthCache = new Map<string, number>();
 const emptyElementWidth = 39;
@@ -617,7 +619,6 @@ export class LayoutService {
         );
         const fontBoundingBoxDescent =
           TextMeasurementService.getFontBoundingBoxDescent(
-            dropCapElement.content,
             dropCapElement.computedFont,
           );
         const adjustment =
@@ -1588,13 +1589,19 @@ export class LayoutService {
                 widthOfUnderscoreForThisElement,
               );
 
-              const numberOfUnderScoresNeeded = Math.ceil(
-                element.melismaWidth / widthOfUnderscoreForThisElement,
-              );
+              // Calculate the distance from the alphabetic baseline to the bottom of the font bounding box
+              element.melismaOffsetTop =
+                -this.getFontBoundingBoxDescentFromCache(
+                  fontBoundingBoxDescentCache,
+                  element,
+                  pageSetup,
+                );
 
-              for (let i = 0; i < numberOfUnderScoresNeeded; i++) {
-                element.melismaText += '_';
-              }
+              element.melismaHeight = this.getFontHeightFromCache(
+                fontHeightCache,
+                element,
+                pageSetup,
+              );
             } else if (pageSetup.melkiteRtl) {
               const nextNoteElement = nextElement as NoteElement;
 
@@ -2218,6 +2225,50 @@ export class LayoutService {
     }
 
     return width;
+  }
+
+  private static getFontBoundingBoxDescentFromCache(
+    cache: Map<string, number>,
+    element: NoteElement,
+    pageSetup: PageSetup,
+  ) {
+    const font = element.lyricsUseDefaultStyle
+      ? pageSetup.lyricsFont
+      : element.lyricsFont;
+
+    const key = font;
+
+    let descent = cache.get(key);
+
+    if (descent == null) {
+      descent = TextMeasurementService.getFontBoundingBoxDescent(font);
+
+      cache.set(key, descent);
+    }
+
+    return descent;
+  }
+
+  private static getFontHeightFromCache(
+    cache: Map<string, number>,
+    element: NoteElement,
+    pageSetup: PageSetup,
+  ) {
+    const font = element.lyricsUseDefaultStyle
+      ? pageSetup.lyricsFont
+      : element.lyricsFont;
+
+    const key = font;
+
+    let height = cache.get(key);
+
+    if (height == null) {
+      height = TextMeasurementService.getFontHeight(font);
+
+      cache.set(key, height);
+    }
+
+    return height;
   }
 }
 

--- a/src/services/TextMeasurementService.ts
+++ b/src/services/TextMeasurementService.ts
@@ -25,11 +25,11 @@ export class TextMeasurementService {
     return metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
   }
 
-  public static getFontBoundingBoxDescent(text: string, font: string) {
+  public static getFontBoundingBoxDescent(font: string) {
     const canvas = this.canvas || document.createElement('canvas');
     const context = canvas.getContext('2d')!;
     context.font = font;
-    const metrics = context.measureText(text);
+    const metrics = context.measureText('');
     return metrics.fontBoundingBoxDescent;
   }
 }

--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -1001,7 +1001,7 @@ export class ByzHtmlExporter {
     } "${pageSetup.dropCapDefaultFontFamily}"`;
 
     const fontBoundingBoxDescent =
-      TextMeasurementService.getFontBoundingBoxDescent('R', font);
+      TextMeasurementService.getFontBoundingBoxDescent(font);
 
     // TODO this doesn't work correctly for every font
     return (


### PR DESCRIPTION
This PR removes the use of font-based underscores as melisma lines and replaces them with lines drawn by CSS the `border` property. 

The tricky part is the aligning of the melisma with the alphabetic baseline of the chosen lyrics font. To accomplish this, we first measure the height of the font. We then draw a "melisma box" with the same height next to the lyrics. This box is given a bottom border. The bottom border of this box is rendered by Chromium at roughly the bottom baseline of the font. Next, we calculate the distance between the alphabetic baseline and the bottom of the font. We use this offset to raise the bottom border to be roughly level with the alphabetic baseline. See [this article](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/textBaseline) for an illustration of the meanings of these baselines. Font metrics are calculated via [TextMetrics](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics).

Fixes #643. 