### PR TITLE
Look ahead past martyriae, drop caps, and mode keys

### DIFF
--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -65,14 +65,16 @@ export class LyricService {
             lyrics += '-';
           }
         } else if (note.isMelisma) {
-          const nextNote =
-            i + 1 < filteredElements.length
-              ? (filteredElements[i + 1] as NoteElement)
-              : null;
+          let nextNote: NoteElement | null = null;
+          for (let j = i + 1; j < filteredElements.length; j++) {
+            if (filteredElements[j].elementType === ElementType.Note) {
+              nextNote = filteredElements[j] as NoteElement;
+            }
+          }
           if (
             this.getEffectiveAcceptsLyrics(note, previousNote) !==
               AcceptsLyricsOption.MelismaOnly &&
-            nextNote?.elementType === ElementType.Note &&
+            nextNote &&
             this.getEffectiveAcceptsLyrics(nextNote, note) !==
               AcceptsLyricsOption.MelismaOnly
           ) {


### PR DESCRIPTION
Even after fixing #659, my Dormition Exaposteilaria weren't round-tripping properly through the lyrics tokenizer. I tracked down the problem to a martyria, which was stopping the extraction process from adding the last underscore. Fixed by looking ahead past martyriae. With this change and #659 my Dormition Exaposteilaria round-trips correctly.