### PR TITLE
Correctly calculate note indicator for multi-neume spread

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1750,7 +1750,7 @@ export class LayoutService {
             );
 
             note.noteIndicatorNeume = noteIndicatorMap.get(
-              (((currentNote + currentShift) % 7) + 7) % 7,
+              (((fthoraNote + currentShift) % 7) + 7) % 7,
             )!;
             note.fthoraCarry = null;
           } else {
@@ -1781,7 +1781,7 @@ export class LayoutService {
             );
 
             note.noteIndicatorNeume = noteIndicatorMap.get(
-              (((currentNote + currentShift) % 7) + 7) % 7,
+              (((fthoraNote + currentShift) % 7) + 7) % 7,
             )!;
             note.secondaryFthoraCarry = null;
           } else {
@@ -1812,7 +1812,7 @@ export class LayoutService {
             );
 
             note.noteIndicatorNeume = noteIndicatorMap.get(
-              (((currentNote + currentShift) % 7) + 7) % 7,
+              (((fthoraNote + currentShift) % 7) + 7) % 7,
             )!;
             note.tertiaryFthoraCarry = null;
           } else {


### PR DESCRIPTION
Fixes #652

### Testing done

The example from https://github.com/neanes/neanes/issues/652#issuecomment-2073335751 was erroneously calculating a Ni note indicator before this PR; after this PR, it correctly calculates a Zo note indicator.