### PR TITLE
Revert "Handle whole-word drop caps"

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -4738,14 +4738,12 @@ export default class Editor extends Vue {
       if (filteredElements[i].elementType === ElementType.DropCap) {
         const dropCap = filteredElements[i] as DropCapElement;
         const token = tokenizer.getNextCharacter();
-        const nextToken = tokenizer.peekNextToken();
-        const content = nextToken === '_' ? `${token} ` : token;
 
-        if (dropCap.content !== content) {
+        if (dropCap.content !== token) {
           updateCommands.push(
             this.dropCapCommandFactory.create('update-properties', {
               target: dropCap,
-              newValues: { content },
+              newValues: { content: token },
             }),
           );
         }

--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -179,13 +179,6 @@ export class LyricTokenizer {
     return token.trim();
   }
 
-  peekNextToken() {
-    const orig = this.index;
-    const result = this.getNextToken();
-    this.index = orig;
-    return result;
-  }
-
   getNextCharacter() {
     let c = '';
     while (c.trim() === '' && this.index < this.lyrics.length) {


### PR DESCRIPTION
Reverts neanes/neanes#659. After doing more research into the 19th-century publications, I have reversed my position on this, changing all my scores in https://github.com/basil/byzantine-music/commit/a0bf8f6635ca4ff78a6e2dcb40832240d491b03d to follow the convention I found there:

![image](https://github.com/neanes/neanes/assets/29850/11a453ee-a33b-41f7-93e4-0b03734cadf1)

I suppose this can be justified because the musical notation already requires a space between the drop cap and the second syllable, so adding additional whitespace results in something too detached and separated – there’s too much white space there.