### PR TITLE
Fix lyric round-tripping bug

### DIFF
--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -69,14 +69,18 @@ export class LyricService {
           for (let j = i + 1; j < filteredElements.length; j++) {
             if (filteredElements[j].elementType === ElementType.Note) {
               nextNote = filteredElements[j] as NoteElement;
+            } else if (
+              filteredElements[j].elementType !== ElementType.Martyria
+            ) {
+              break;
             }
           }
           if (
             this.getEffectiveAcceptsLyrics(note, previousNote) !==
               AcceptsLyricsOption.MelismaOnly &&
-            nextNote &&
-            this.getEffectiveAcceptsLyrics(nextNote, note) !==
-              AcceptsLyricsOption.MelismaOnly
+            (!nextNote ||
+              this.getEffectiveAcceptsLyrics(nextNote, note) !==
+                AcceptsLyricsOption.MelismaOnly)
           ) {
             lyrics += '_';
           }


### PR DESCRIPTION
Amends #660, which still didn't cover the case where a score ended in a melisma with a martyria and no next note. With this PR, the vast majority of my scores successfully go through the lyric round-trip process.

Ones that don't:

- Axion Estins with a rest in the final melismatic syllable. I guess I'll have to go through and manually mark these as "Accepts Lyrics: Melisma Only"
- Greek scores. The round-trip process doesn't seem to work well in non-English languages pending #352 / #512.