### PR TITLE
Fix lyric height bug when using gorthmikon/pelastikon

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1708,6 +1708,7 @@ export default class Editor extends Vue {
       webkitTextStrokeWidth: element.lyricsUseDefaultStyle
         ? withZoom(this.score.pageSetup.lyricsDefaultStrokeWidth)
         : withZoom(element.lyricsStrokeWidth),
+      lineHeight: withZoom(element.lyricsFontHeight),
     } as StyleValue;
   }
 
@@ -1738,7 +1739,7 @@ export default class Editor extends Vue {
   getMelismaUnderscoreStyleOuter(element: NoteElement) {
     return {
       top: withZoom(element.melismaOffsetTop),
-      height: withZoom(element.melismaHeight),
+      height: withZoom(element.lyricsFontHeight),
       width: withZoom(element.melismaWidth!),
     };
   }

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -389,7 +389,7 @@ export class NoteElement extends ScoreElement {
   // Used for display
   public melismaText: string = '';
   public melismaOffsetTop: number = 0;
-  public melismaHeight: number = 0;
+  public lyricsFontHeight: number = 0;
   public hyphenOffsets: number[] = [];
   public isFullMelisma: boolean = false;
   public melismaWidth: number = 0;

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -316,6 +316,12 @@ export class LayoutService {
         case ElementType.Note: {
           const noteElement = element as NoteElement;
 
+          noteElement.lyricsFontHeight = this.getLyricsFontHeightFromCache(
+            fontHeightCache,
+            noteElement,
+            pageSetup,
+          );
+
           elementWidthPx = this.getNoteWidth(
             noteElement,
             pageSetup,
@@ -1603,17 +1609,11 @@ export class LayoutService {
 
               // Calculate the distance from the alphabetic baseline to the bottom of the font bounding box
               element.melismaOffsetTop =
-                -this.getFontBoundingBoxDescentFromCache(
+                -this.getLyricsFontBoundingBoxDescentFromCache(
                   fontBoundingBoxDescentCache,
                   element,
                   pageSetup,
                 );
-
-              element.melismaHeight = this.getFontHeightFromCache(
-                fontHeightCache,
-                element,
-                pageSetup,
-              );
             } else if (pageSetup.melkiteRtl) {
               const nextNoteElement = nextElement as NoteElement;
 
@@ -2239,7 +2239,7 @@ export class LayoutService {
     return width;
   }
 
-  private static getFontBoundingBoxDescentFromCache(
+  private static getLyricsFontBoundingBoxDescentFromCache(
     cache: Map<string, number>,
     element: NoteElement,
     pageSetup: PageSetup,
@@ -2261,7 +2261,7 @@ export class LayoutService {
     return descent;
   }
 
-  private static getFontHeightFromCache(
+  private static getLyricsFontHeightFromCache(
     cache: Map<string, number>,
     element: NoteElement,
     pageSetup: PageSetup,


### PR DESCRIPTION
Fixes #665.

The addition of the Stathis Series font necessitated a new way of displaying the Gorthmikon and Pelastikon. Previously, these neumes had been implemented as part of the Omega font and the Omega font was always specified as a fallback font for lyrics. This worked because only one font was supported. Now we must support the Stathis Series gorthmikon/pelastikon. This was accomplished by falling back to the selected neume font instead of to Omega. But the neume fonts have drastically different font heights. This PR fixes that by forcing the line height of the lyrics box to be that of the lyrics font.

