### PR TITLE
Fix lyrics look-ahead logic

### DIFF
--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -79,7 +79,6 @@ export class LyricService {
               this.getEffectiveAcceptsLyrics(nextNote, note) !==
                 AcceptsLyricsOption.MelismaOnly)
           ) {
-            console.log(note, previousNote, nextNote);
             lyrics += '_';
           }
           needSpace = true;

--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -69,9 +69,6 @@ export class LyricService {
           for (let j = i + 1; j < filteredElements.length; j++) {
             if (filteredElements[j].elementType === ElementType.Note) {
               nextNote = filteredElements[j] as NoteElement;
-            } else if (
-              filteredElements[j].elementType !== ElementType.Martyria
-            ) {
               break;
             }
           }
@@ -82,6 +79,7 @@ export class LyricService {
               this.getEffectiveAcceptsLyrics(nextNote, note) !==
                 AcceptsLyricsOption.MelismaOnly)
           ) {
+            console.log(note, previousNote, nextNote);
             lyrics += '_';
           }
           needSpace = true;

--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -68,7 +68,13 @@ export class LyricService {
           let nextNote: NoteElement | null = null;
           for (let j = i + 1; j < filteredElements.length; j++) {
             if (filteredElements[j].elementType === ElementType.Note) {
+              // We found a note. Stop.
               nextNote = filteredElements[j] as NoteElement;
+              break;
+            } else if (
+              filteredElements[j].elementType !== ElementType.Martyria
+            ) {
+              // Look past martyria, but stop at any other element (e.g. a mode key)
               break;
             }
           }


### PR DESCRIPTION
Amends #660, which appears to be missing a `break;` statement. This caused the `nextNote` to be always the last note.
After:
<img width="242" alt="image" src="https://github.com/neanes/neanes/assets/4132779/64833cdb-635f-4309-9142-51a4d787081e">

Before:
<img width="194" alt="image" src="https://github.com/neanes/neanes/assets/4132779/1bc4b2d9-7f88-43e8-a259-aa52569c380a">
