### PR TITLE
Escape HTML in text boxes

### DIFF
--- a/src/components/ContentEditable.vue
+++ b/src/components/ContentEditable.vue
@@ -47,7 +47,7 @@ export default class ContentEditable extends Vue {
   }
 
   onBlur() {
-    this.$emit('blur', this.htmlElement.innerText);
+    this.$emit('blur', this.escapeHtml(this.htmlElement.innerText));
   }
 
   focus(selectAll: boolean) {
@@ -64,6 +64,12 @@ export default class ContentEditable extends Vue {
 
   setInnerText(text: string) {
     this.htmlElement.innerText = text;
+  }
+
+  escapeHtml(text: string) {
+    const p = document.createElement('p');
+    p.appendChild(document.createTextNode(text));
+    return p.innerHTML;
   }
 }
 </script>


### PR DESCRIPTION
This PR fixes a bug where if you type `<` or `>` into text boxes, the characters disappear and the text box is replaced with HTML.