### PR TITLE
Fix export to HTML for greek lyrics

### DIFF
--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -24,6 +24,7 @@ import { GORTHMIKON, PELASTIKON } from '@/utils/constants';
 import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
 import { Unit } from '@/utils/Unit';
 
+import { MelismaHelperGreek } from '../MelismaHelperGreek';
 import { NeumeMappingService, SbmuflGlyphName } from '../NeumeMappingService';
 import { TextMeasurementService } from '../TextMeasurementService';
 
@@ -616,7 +617,10 @@ export class ByzHtmlExporter {
         this.config.tagLyric
       }\n${this.getIndentationString(indentation)}>`;
 
-      if (element.isMelismaStart) {
+      if (
+        element.isMelismaStart &&
+        !MelismaHelperGreek.isGreek(element.lyrics)
+      ) {
         const hyphenAttribute = element.isHyphen
           ? ` ${this.config.attributeMelismaHyphen}`
           : '';
@@ -627,6 +631,10 @@ export class ByzHtmlExporter {
           this.config.tagMelisma
         }\n${this.getIndentationString(indentation)}>`;
       }
+    } else if (element.melismaText.trim() != '') {
+      inner += `<${this.config.tagLyric}>${element.melismaText}</${
+        this.config.tagLyric
+      }\n${this.getIndentationString(indentation)}>`;
     }
 
     return `<${this.config.tagNote}\n${this.getIndentationString(


### PR DESCRIPTION
This PR fixes the export to HTML for Greek scores that use the new melismata feature. Previously, export resulted in English-style hyphens and underscores. This fixes it to use the `melismaText` property to insert the correct text.