### PR TITLE
Add custom width option for Drop Caps

### DIFF
--- a/src/components/DropCap.vue
+++ b/src/components/DropCap.vue
@@ -55,6 +55,7 @@ export default class DropCap extends Vue {
   get containerStyle() {
     return {
       direction: this.pageSetup.melkiteRtl ? 'rtl' : undefined,
+      width: this.element.customWidth ?? undefined,
     } as StyleValue;
   }
 

--- a/src/components/DropCap.vue
+++ b/src/components/DropCap.vue
@@ -55,7 +55,6 @@ export default class DropCap extends Vue {
   get containerStyle() {
     return {
       direction: this.pageSetup.melkiteRtl ? 'rtl' : undefined,
-      width: this.element.customWidth ?? undefined,
     } as StyleValue;
   }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -690,6 +690,7 @@
       <ToolbarDropCap
         :element="selectedElement"
         :fonts="fonts"
+        :pageSetup="score.pageSetup"
         @update:useDefaultStyle="
           updateDropCapUseDefaultStyle(
             selectedElement as DropCapElement,
@@ -716,6 +717,9 @@
         "
         @update:lineHeight="
           updateDropCapLineHeight(selectedElement as DropCapElement, $event)
+        "
+        @update:customWidth="
+          updateDropCapWidth(selectedElement as DropCapElement, $event)
         "
       />
     </template>
@@ -5375,6 +5379,10 @@ export default class Editor extends Vue {
 
   updateDropCapLineHeight(element: DropCapElement, lineHeight: number | null) {
     this.updateDropCap(element, { lineHeight });
+  }
+
+  updateDropCapWidth(element: DropCapElement, customWidth: number | null) {
+    this.updateDropCap(element, { customWidth });
   }
 
   updateImageBox(

--- a/src/components/ToolbarDropCap.vue
+++ b/src/components/ToolbarDropCap.vue
@@ -70,7 +70,21 @@
         :modelValue="element.strokeWidth"
         @update:modelValue="$emit('update:strokeWidth', $event)"
       />
+      <span class="divider" />
     </template>
+    <label class="right-space">{{ $t('toolbar:common.width') }}</label>
+    <InputUnit
+      class="drop-caps-input-width"
+      unit="pt"
+      :nullable="true"
+      :min="4"
+      :max="maxWidth"
+      :step="0.5"
+      :modelValue="element.customWidth"
+      :precision="1"
+      placeholder="auto"
+      @update:modelValue="$emit('update:customWidth', $event)"
+    />
   </div>
 </template>
 
@@ -82,12 +96,15 @@ import InputFontSize from '@/components/InputFontSize.vue';
 import InputStrokeWidth from '@/components/InputStrokeWidth.vue';
 import InputUnit from '@/components/InputUnit.vue';
 import { DropCapElement } from '@/models/Element';
+import { PageSetup } from '@/models/PageSetup';
+import { Unit } from '@/utils/Unit';
 
 @Component({
   components: { ColorPicker, InputFontSize, InputStrokeWidth, InputUnit },
   emits: [
     'update:bold',
     'update:color',
+    'update:customWidth',
     'update:fontFamily',
     'update:fontSize',
     'update:italic',
@@ -99,6 +116,7 @@ import { DropCapElement } from '@/models/Element';
 export default class ToolbarDropCap extends Vue {
   @Prop() element!: DropCapElement;
   @Prop() fonts!: string[];
+  @Prop() pageSetup!: PageSetup;
 
   get bold() {
     return this.element.fontWeight === '700';
@@ -119,6 +137,10 @@ export default class ToolbarDropCap extends Vue {
       ...this.fonts,
     ];
   }
+
+  get maxWidth() {
+    return Unit.toPt(this.pageSetup.innerPageWidth);
+  }
 }
 </script>
 
@@ -132,6 +154,10 @@ export default class ToolbarDropCap extends Vue {
   background-color: lightgray;
 
   padding: 0.25rem;
+}
+
+.drop-caps-input-width {
+  width: 8ch;
 }
 
 .icon-btn {

--- a/src/i18n/en/toolbar.json
+++ b/src/i18n/en/toolbar.json
@@ -18,7 +18,8 @@
     "generalSharpDisabled": "General sharp may only be placed on Ga",
     "zygosDisabled": "Zygos may only be placed on Di",
     "klitonDisabled": "Kliton may only be placed on Di",
-    "spathiDisabled": "Spathi may only be placed on Ke or Ga"
+    "spathiDisabled": "Spathi may only be placed on Ke or Ga",
+    "width": "Width"
   },
   "main": {
     "auto": "Auto",

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -962,6 +962,7 @@ export class DropCapElement extends ScoreElement {
   public strokeWidth: number = 0;
   public color: string = '#000000';
   public useDefaultStyle: boolean = true;
+  public customWidth: number | null = null;
 
   // Values computed by the layout service
   public computedFontFamily: string = '';

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -999,8 +999,13 @@ export class DropCapElement extends ScoreElement {
       color: this.color,
       content: this.content,
       fontSize: this.fontSize,
+      fontStyle: this.fontStyle,
       fontFamily: this.fontFamily,
+      fontWeight: this.fontWeight,
       lineHeight: this.lineHeight,
+      strokeWidth: this.strokeWidth,
+      customWidth: this.customWidth,
+      useDefaultStyle: this.useDefaultStyle,
     } as Partial<DropCapElement>;
   }
 }

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -248,6 +248,7 @@ export class DropCapElement extends ScoreElement {
   public strokeWidth: number = 0;
   public color: string = '#000000';
   public useDefaultStyle: boolean | undefined = undefined;
+  public customWidth: number | undefined = undefined;
 }
 
 export class ImageBoxElement extends ScoreElement {

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -416,10 +416,14 @@ export class LayoutService {
             ? pageSetup.dropCapDefaultLineHeight
             : dropCapElement.lineHeight;
 
-          elementWidthPx = TextMeasurementService.getTextWidth(
-            dropCapElement.content,
-            dropCapElement.computedFont,
-          );
+          if (dropCapElement.customWidth != null) {
+            elementWidthPx = dropCapElement.customWidth;
+          } else {
+            elementWidthPx = TextMeasurementService.getTextWidth(
+              dropCapElement.content,
+              dropCapElement.computedFont,
+            );
+          }
           break;
         }
         case ElementType.Empty: {
@@ -1143,6 +1147,7 @@ export class LayoutService {
       const dropCap = element as DropCapElement;
 
       dropCap.updated =
+        dropCap.widthPrevious !== dropCap.width ||
         dropCap.computedFontFamilyPrevious !== dropCap.computedFontFamily ||
         dropCap.computedFontSizePrevious !== dropCap.computedFontSize ||
         dropCap.computedFontWeightPrevious !== dropCap.computedFontWeight ||

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -308,6 +308,7 @@ export class SaveService {
     element.fontStyle = e.fontStyle;
     element.lineHeight = e.lineHeight ?? undefined;
     element.strokeWidth = e.strokeWidth;
+    element.customWidth = e.customWidth ?? undefined;
     element.useDefaultStyle = e.useDefaultStyle || undefined;
   }
 
@@ -963,6 +964,7 @@ export class SaveService {
     element.fontWeight = e.fontWeight ?? pageSetup.dropCapDefaultFontWeight;
     element.fontStyle = e.fontStyle ?? pageSetup.dropCapDefaultFontStyle;
     element.strokeWidth = e.strokeWidth ?? pageSetup.dropCapDefaultStrokeWidth;
+    element.customWidth = e.customWidth ?? null;
     element.useDefaultStyle = e.useDefaultStyle === true;
   }
 


### PR DESCRIPTION
This PR adds a custom width option to drop caps that makes it easier to add a specific amount of space between a drop cap and the following neume. This is useful for using drop caps as line numbers.

<img width="244" alt="image" src="https://github.com/neanes/neanes/assets/4132779/a3936de8-4773-47ae-bfe1-6693f33117fa">


This PR also fixes an oversight related to drop cap copy/paste where not all the properties were being copied.

#733 