### PR TITLE
Add custom width to text box

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -654,6 +654,7 @@
       <ToolbarTextBox
         :element="selectedTextBoxElement"
         :fonts="fonts"
+        :pageSetup="score.pageSetup"
         @update:multipanel="
           updateTextBoxMultipanel(selectedTextBoxElement, $event)
         "
@@ -680,6 +681,7 @@
         @update:lineHeight="
           updateTextBoxLineHeight(selectedTextBoxElement, $event)
         "
+        @update:customWidth="updateTextBoxWidth(selectedTextBoxElement, $event)"
         @insert:gorthmikon="insertGorthmikon"
         @insert:pelastikon="insertPelastikon"
       />
@@ -5025,6 +5027,10 @@ export default class Editor extends Vue {
 
   updateTextBoxLineHeight(element: TextBoxElement, lineHeight: number | null) {
     this.updateTextBox(element, { lineHeight });
+  }
+
+  updateTextBoxWidth(element: TextBoxElement, customWidth: number | null) {
+    this.updateTextBox(element, { customWidth });
   }
 
   updateModeKey(element: ModeKeyElement, newValues: Partial<ModeKeyElement>) {

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -161,6 +161,22 @@
         $t('toolbar:textbox.multipanel')
       }}</label></template
     >
+    <template v-else>
+      <span class="divider" />
+      <label class="right-space">{{ $t('toolbar:common.width') }}</label>
+      <InputUnit
+        class="text-box-input-width"
+        unit="pt"
+        :nullable="true"
+        :min="0.5"
+        :max="maxWidth"
+        :step="0.5"
+        :modelValue="element.customWidth"
+        :precision="1"
+        placeholder="auto"
+        @update:modelValue="$emit('update:customWidth', $event)"
+      />
+    </template>
   </div>
 </template>
 
@@ -172,6 +188,8 @@ import InputFontSize from '@/components/InputFontSize.vue';
 import InputStrokeWidth from '@/components/InputStrokeWidth.vue';
 import InputUnit from '@/components/InputUnit.vue';
 import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
+import { PageSetup } from '@/models/PageSetup';
+import { Unit } from '@/utils/Unit';
 
 @Component({
   components: { ColorPicker, InputFontSize, InputUnit, InputStrokeWidth },
@@ -181,6 +199,7 @@ import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
     'update:alignment',
     'update:bold',
     'update:color',
+    'update:customWidth',
     'update:fontFamily',
     'update:fontSize',
     'update:italic',
@@ -194,8 +213,13 @@ import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
 export default class ToolbarTextBox extends Vue {
   @Prop() element!: TextBoxElement;
   @Prop() fonts!: string;
+  @Prop() pageSetup!: PageSetup;
 
   TextBoxAlignment = TextBoxAlignment;
+
+  get maxWidth() {
+    return Unit.toPt(this.pageSetup.innerPageWidth);
+  }
 }
 </script>
 
@@ -235,5 +259,9 @@ label.right-space {
 
 .space {
   width: 16px;
+}
+
+.text-box-input-width {
+  width: 8ch;
 }
 </style>

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -741,6 +741,7 @@ export class TextBoxElement extends ScoreElement {
   public lineHeight: number | null = null;
   public useDefaultStyle: boolean = true;
   public height: number = 20;
+  public customWidth: number | null = null;
 
   // Values computed by the layout service
   public computedFontFamily: string = '';
@@ -784,6 +785,7 @@ export class TextBoxElement extends ScoreElement {
       fontSize: this.fontSize,
       fontFamily: this.fontFamily,
       strokeWidth: this.strokeWidth,
+      customWidth: this.customWidth,
       inline: this.inline,
       bold: this.bold,
       italic: this.italic,

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -189,6 +189,7 @@ export class TextBoxElement extends ScoreElement {
   public underline: boolean | undefined = undefined;
   public lineHeight: number | undefined = undefined;
   public height: number = 20;
+  public customWidth: number | undefined = undefined;
   public useDefaultStyle: boolean | undefined = undefined;
 }
 

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -887,57 +887,61 @@ export class LayoutService {
     let elementWidthPx = 0;
 
     if (textBoxElement.inline) {
-      textBoxElement.computedFontFamily = textBoxElement.useDefaultStyle
-        ? pageSetup.lyricsDefaultFontFamily
-        : textBoxElement.fontFamily;
+      if (textBoxElement.customWidth != null) {
+        elementWidthPx = textBoxElement.customWidth;
+      } else {
+        textBoxElement.computedFontFamily = textBoxElement.useDefaultStyle
+          ? pageSetup.lyricsDefaultFontFamily
+          : textBoxElement.fontFamily;
 
-      textBoxElement.computedFontSize = textBoxElement.useDefaultStyle
-        ? pageSetup.lyricsDefaultFontSize
-        : textBoxElement.fontSize;
+        textBoxElement.computedFontSize = textBoxElement.useDefaultStyle
+          ? pageSetup.lyricsDefaultFontSize
+          : textBoxElement.fontSize;
 
-      textBoxElement.computedColor = textBoxElement.useDefaultStyle
-        ? pageSetup.lyricsDefaultColor
-        : textBoxElement.color;
+        textBoxElement.computedColor = textBoxElement.useDefaultStyle
+          ? pageSetup.lyricsDefaultColor
+          : textBoxElement.color;
 
-      textBoxElement.computedStrokeWidth = textBoxElement.useDefaultStyle
-        ? pageSetup.lyricsDefaultStrokeWidth
-        : textBoxElement.strokeWidth;
+        textBoxElement.computedStrokeWidth = textBoxElement.useDefaultStyle
+          ? pageSetup.lyricsDefaultStrokeWidth
+          : textBoxElement.strokeWidth;
 
-      textBoxElement.computedFontWeight = textBoxElement.useDefaultStyle
-        ? pageSetup.lyricsDefaultFontWeight
-        : textBoxElement.bold
-          ? '700'
-          : '400';
+        textBoxElement.computedFontWeight = textBoxElement.useDefaultStyle
+          ? pageSetup.lyricsDefaultFontWeight
+          : textBoxElement.bold
+            ? '700'
+            : '400';
 
-      textBoxElement.computedFontStyle = textBoxElement.useDefaultStyle
-        ? pageSetup.lyricsDefaultFontStyle
-        : textBoxElement.italic
-          ? 'italic'
-          : 'normal';
+        textBoxElement.computedFontStyle = textBoxElement.useDefaultStyle
+          ? pageSetup.lyricsDefaultFontStyle
+          : textBoxElement.italic
+            ? 'italic'
+            : 'normal';
 
-      const lines = textBoxElement.content.split(/(?:\r\n|\r|\n)/g);
+        const lines = textBoxElement.content.split(/(?:\r\n|\r|\n)/g);
 
-      let maxWidth = 0;
+        let maxWidth = 0;
 
-      for (const line of lines) {
-        const lineWidth = TextMeasurementService.getTextWidth(
-          line,
+        for (const line of lines) {
+          const lineWidth = TextMeasurementService.getTextWidth(
+            line,
+            textBoxElement.computedFont,
+          );
+
+          if (lineWidth > maxWidth) {
+            maxWidth = lineWidth;
+          }
+        }
+
+        elementWidthPx = maxWidth;
+
+        const minimumWidth = TextMeasurementService.getTextWidth(
+          ' ',
           textBoxElement.computedFont,
         );
 
-        if (lineWidth > maxWidth) {
-          maxWidth = lineWidth;
-        }
+        elementWidthPx = Math.max(elementWidthPx, minimumWidth);
       }
-
-      elementWidthPx = maxWidth;
-
-      const minimumWidth = TextMeasurementService.getTextWidth(
-        ' ',
-        textBoxElement.computedFont,
-      );
-
-      elementWidthPx = Math.max(elementWidthPx, minimumWidth);
     } else {
       elementWidthPx = pageSetup.innerPageWidth;
 

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -520,6 +520,7 @@ export class SaveService {
     element.underline = e.underline || undefined;
     element.lineHeight = e.lineHeight ?? undefined;
     element.height = e.height;
+    element.customWidth = e.customWidth ?? undefined;
     element.useDefaultStyle = e.useDefaultStyle || undefined;
   }
 
@@ -1218,6 +1219,7 @@ export class SaveService {
     element.height = e.height;
     element.strokeWidth = e.strokeWidth ?? element.strokeWidth;
     element.lineHeight = e.lineHeight ?? pageSetup.textBoxDefaultLineHeight;
+    element.customWidth = e.customWidth ?? null;
 
     if (scoreVersion === '1.0') {
       // In this version, use default was incorrectly set to true


### PR DESCRIPTION
This PR adds a custom width property to inline text boxes which allows them to act as spacers of arbitrary length.