### PR TITLE
Add custom height to text box

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -682,6 +682,9 @@
           updateTextBoxLineHeight(selectedTextBoxElement, $event)
         "
         @update:customWidth="updateTextBoxWidth(selectedTextBoxElement, $event)"
+        @update:customHeight="
+          updateTextBoxHeight(selectedTextBoxElement, $event)
+        "
         @insert:gorthmikon="insertGorthmikon"
         @insert:pelastikon="insertPelastikon"
       />
@@ -5031,6 +5034,10 @@ export default class Editor extends Vue {
 
   updateTextBoxWidth(element: TextBoxElement, customWidth: number | null) {
     this.updateTextBox(element, { customWidth });
+  }
+
+  updateTextBoxHeight(element: TextBoxElement, customHeight: number | null) {
+    this.updateTextBox(element, { customHeight });
   }
 
   updateModeKey(element: ModeKeyElement, newValues: Partial<ModeKeyElement>) {

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -159,8 +159,24 @@
       />
       <label for="toolbar-text-box-multipanel">{{
         $t('toolbar:textbox.multipanel')
-      }}</label></template
-    >
+      }}</label>
+      <template v-if="!element.multipanel">
+        <span class="divider" />
+        <label class="right-space">{{ $t('toolbar:common.height') }}</label>
+        <InputUnit
+          class="text-box-input-width"
+          unit="pt"
+          :nullable="true"
+          :min="0.5"
+          :max="maxWidth"
+          :step="0.5"
+          :modelValue="element.customHeight"
+          :precision="1"
+          placeholder="auto"
+          @update:modelValue="$emit('update:customHeight', $event)"
+        />
+      </template>
+    </template>
     <template v-else>
       <span class="divider" />
       <label class="right-space">{{ $t('toolbar:common.width') }}</label>
@@ -199,6 +215,7 @@ import { Unit } from '@/utils/Unit';
     'update:alignment',
     'update:bold',
     'update:color',
+    'update:customHeight',
     'update:customWidth',
     'update:fontFamily',
     'update:fontSize',

--- a/src/i18n/en/toolbar.json
+++ b/src/i18n/en/toolbar.json
@@ -19,7 +19,8 @@
     "zygosDisabled": "Zygos may only be placed on Di",
     "klitonDisabled": "Kliton may only be placed on Di",
     "spathiDisabled": "Spathi may only be placed on Ke or Ga",
-    "width": "Width"
+    "width": "Width",
+    "height": "Height"
   },
   "main": {
     "auto": "Auto",

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -742,6 +742,7 @@ export class TextBoxElement extends ScoreElement {
   public useDefaultStyle: boolean = true;
   public height: number = 20;
   public customWidth: number | null = null;
+  public customHeight: number | null = null;
 
   // Values computed by the layout service
   public computedFontFamily: string = '';
@@ -786,6 +787,7 @@ export class TextBoxElement extends ScoreElement {
       fontFamily: this.fontFamily,
       strokeWidth: this.strokeWidth,
       customWidth: this.customWidth,
+      customHeight: this.customHeight,
       inline: this.inline,
       bold: this.bold,
       italic: this.italic,

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -190,6 +190,7 @@ export class TextBoxElement extends ScoreElement {
   public lineHeight: number | undefined = undefined;
   public height: number = 20;
   public customWidth: number | undefined = undefined;
+  public customHeight: number | undefined = undefined;
   public useDefaultStyle: boolean | undefined = undefined;
 }
 

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1001,6 +1001,8 @@ export class LayoutService {
       );
 
       textBoxElement.height = Math.max(height, fontHeight);
+    } else if (textBoxElement.customHeight != null) {
+      textBoxElement.height = textBoxElement.customHeight;
     } else {
       let height = 0;
 

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -521,6 +521,7 @@ export class SaveService {
     element.lineHeight = e.lineHeight ?? undefined;
     element.height = e.height;
     element.customWidth = e.customWidth ?? undefined;
+    element.customHeight = e.customHeight ?? undefined;
     element.useDefaultStyle = e.useDefaultStyle || undefined;
   }
 
@@ -1220,6 +1221,7 @@ export class SaveService {
     element.strokeWidth = e.strokeWidth ?? element.strokeWidth;
     element.lineHeight = e.lineHeight ?? pageSetup.textBoxDefaultLineHeight;
     element.customWidth = e.customWidth ?? null;
+    element.customHeight = e.customHeight ?? null;
 
     if (scoreVersion === '1.0') {
       // In this version, use default was incorrectly set to true


### PR DESCRIPTION
This PR adds a custom height property to text boxes that allows them to be used as arbitrary vertical spacers.