### PR TITLE
Fix drop cap alignment

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -6441,7 +6441,7 @@ export default class Editor extends Vue {
 
     this.currentFilePath = null;
     this.score.staff.elements.unshift(
-      ...(TestFileGenerator.generateTestFile(testFileType) || []),
+      ...(TestFileGenerator.generateTestFile(testFileType, this.fonts) || []),
     );
     this.save();
   }

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -641,6 +641,11 @@ export class LayoutService {
         const adjustment =
           fontHeight - distanceFromTopToBottomOfLyrics - fontBoundingBoxDescent;
 
+        if (dropCapElement.computedLineHeight == null) {
+          dropCapElement.computedLineHeight =
+            fontHeight / dropCapElement.computedFontSize;
+        }
+
         element.y -= adjustment;
       }
 

--- a/src/utils/TestFileGenerator.ts
+++ b/src/utils/TestFileGenerator.ts
@@ -1,6 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { ModeKeyElement, NoteElement, ScoreElement } from '@/models/Element';
+import {
+  DropCapElement,
+  LineBreakType,
+  ModeKeyElement,
+  NoteElement,
+  ScoreElement,
+} from '@/models/Element';
 import { modeKeyTemplates } from '@/models/ModeKeys';
 import {
   Accidental,
@@ -16,7 +22,7 @@ import {
 import { TestFileType } from './TestFileType';
 
 export abstract class TestFileGenerator {
-  public static generateTestFile(type: TestFileType) {
+  public static generateTestFile(type: TestFileType, fonts: string[]) {
     switch (type) {
       case TestFileType.FthoraTop:
         return this.generateTestFile_Fthora('Top');
@@ -42,6 +48,8 @@ export abstract class TestFileGenerator {
         return this.generateTestFile_ModeKey();
       case TestFileType.Random:
         return this.generateTestFile_Random();
+      case TestFileType.DropCaps:
+        return this.generateTestFile_DropCaps(fonts);
       default:
         console.error(`Unknown test file type: ${type}`);
         return null;
@@ -589,6 +597,27 @@ export abstract class TestFileGenerator {
       const note = new NoteElement();
       note.quantitativeNeume = values[Math.floor(Math.random() * max)];
       note.lyrics = uuidv4();
+      elements.push(note);
+    }
+
+    return elements;
+  }
+
+  private static generateTestFile_DropCaps(fonts: string[]) {
+    const elements: ScoreElement[] = [];
+
+    for (const font of fonts) {
+      const dropCap = new DropCapElement();
+      dropCap.useDefaultStyle = false;
+      dropCap.fontFamily = font;
+      dropCap.fontSize = 80;
+      elements.push(dropCap);
+
+      const note = new NoteElement();
+      note.quantitativeNeume = QuantitativeNeume.Ison;
+      note.lyrics = 'A';
+      note.lineBreak = true;
+      note.lineBreakType = LineBreakType.Left;
       elements.push(note);
     }
 

--- a/src/utils/TestFileType.ts
+++ b/src/utils/TestFileType.ts
@@ -11,4 +11,5 @@ export enum TestFileType {
   Ison = 'Ison',
   ModeKey = 'ModeKey',
   Random = 'Random',
+  DropCaps = 'DropCaps',
 }


### PR DESCRIPTION
This PR fixes a lingering drop cap alignment issue. 

For some reason, Chromium sometimes renders fonts with a line height that is shorter than the containing div, which is equal to the height of the font as calculated by `TextMetrics`. See the below screenshot for an illustration. The containing div is outlined in red, while the text region is outlined in blue. In the first case, the line height is equal to the div height, but in the second case it is not.

<img width="76" alt="image" src="https://github.com/neanes/neanes/assets/4132779/9f202c53-63b1-4028-b38b-14e3af5594c1">

When it is not, the drop cap alignment calculation does not provide the correct vertical adjustment. To fix this, the line height is set to the font height, which should guarantee that the text is vertically aligned with the top of the containing div.

[DropCapTest - Before.pdf](https://github.com/user-attachments/files/16059385/DropCapTest.-.Before.pdf)

[DropCapTest - After.pdf](https://github.com/user-attachments/files/16059375/DropCapTest.-.After.pdf)

Note that this will not fix some drop cap fonts, such as Vilnius, where the glyphs are not aligned along the Roman baseline (as can be seen by opening the font in FontForge, for example).
