### PR TITLE
Upgrade NPM from 10.2.3 to 10.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,5 +109,5 @@
     }
   },
   "license": "GPL-3.0",
-  "packageManager": "npm@10.2.3"
+  "packageManager": "npm@10.7.0"
 }


### PR DESCRIPTION
Per https://nodejs.org/en/download/package-manager, Node.js v20.15.0 (LTS) now includes npm 10.7.0.