### PR TITLE
Fix measure bar jitters

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -354,8 +354,10 @@ export class LayoutService {
           ];
 
           const noteTied =
-            ties.includes(noteElement.vocalExpressionNeume!) ||
-            ties.includes(noteElement.tie!);
+            !noteElement.pageBreak &&
+            !noteElement.lineBreak &&
+            (ties.includes(noteElement.vocalExpressionNeume!) ||
+              ties.includes(noteElement.tie!));
 
           if (nextElement?.elementType === ElementType.Martyria) {
             additionalWidth =

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -58,12 +58,7 @@ const emptyElementWidth = 39;
 interface GetNoteWidthArgs {
   lyricsVerticalOffset: number;
   vareiaWidth: number;
-  measureBarRightWidth: number;
-  measureBarTopWidth: number;
-  measureBarDoubleWidth: number;
-  measureBarTheseosWidth: number;
-  measureBarShortDoubleWidth: number;
-  measureBarShortTheseosWidth: number;
+  measureBarWidthMap: Map<MeasureBar, number>;
   runningElaphronWidth: number;
   elaphronWidth: number;
 }
@@ -182,6 +177,23 @@ export class LayoutService {
       `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
     );
 
+    const measureBarWidthMap = new Map<MeasureBar, number>();
+    measureBarWidthMap.set(MeasureBar.MeasureBarRight, measureBarRightWidth);
+    measureBarWidthMap.set(MeasureBar.MeasureBarTop, measureBarTopWidth);
+    measureBarWidthMap.set(MeasureBar.MeasureBarDouble, measureBarDoubleWidth);
+    measureBarWidthMap.set(
+      MeasureBar.MeasureBarTheseos,
+      measureBarTheseosWidth,
+    );
+    measureBarWidthMap.set(
+      MeasureBar.MeasureBarShortDouble,
+      measureBarShortDoubleWidth,
+    );
+    measureBarWidthMap.set(
+      MeasureBar.MeasureBarShortTheseos,
+      measureBarShortTheseosWidth,
+    );
+
     const elaphronMapping = NeumeMappingService.getMapping(
       QuantitativeNeume.Elaphron,
     )!;
@@ -206,12 +218,7 @@ export class LayoutService {
     const noteWidthArgs: GetNoteWidthArgs = {
       lyricsVerticalOffset,
       vareiaWidth,
-      measureBarRightWidth,
-      measureBarTopWidth,
-      measureBarDoubleWidth,
-      measureBarTheseosWidth,
-      measureBarShortDoubleWidth,
-      measureBarShortTheseosWidth,
+      measureBarWidthMap,
       runningElaphronWidth,
       elaphronWidth,
     };
@@ -1181,12 +1188,7 @@ export class LayoutService {
     const {
       lyricsVerticalOffset,
       vareiaWidth,
-      measureBarRightWidth,
-      measureBarTopWidth,
-      measureBarDoubleWidth,
-      measureBarTheseosWidth,
-      measureBarShortDoubleWidth,
-      measureBarShortTheseosWidth,
+      measureBarWidthMap,
       runningElaphronWidth,
       elaphronWidth,
     } = args;
@@ -1229,46 +1231,24 @@ export class LayoutService {
     // are centered under the main neume
     const measureBarLeft =
       noteElement.measureBarLeft || noteElement.computedMeasureBarLeft;
-    if (measureBarLeft === MeasureBar.MeasureBarRight) {
-      noteElement.lyricsHorizontalOffset += measureBarRightWidth;
-      noteElement.neumeWidth += measureBarRightWidth;
-    } else if (measureBarLeft === MeasureBar.MeasureBarTop) {
-      noteElement.lyricsHorizontalOffset += measureBarTopWidth;
-      noteElement.neumeWidth += measureBarTopWidth;
-    } else if (measureBarLeft === MeasureBar.MeasureBarDouble) {
-      noteElement.lyricsHorizontalOffset += measureBarDoubleWidth;
-      noteElement.neumeWidth += measureBarDoubleWidth;
-    } else if (measureBarLeft === MeasureBar.MeasureBarTheseos) {
-      noteElement.lyricsHorizontalOffset += measureBarTheseosWidth;
-      noteElement.neumeWidth += measureBarTheseosWidth;
-    } else if (measureBarLeft === MeasureBar.MeasureBarShortDouble) {
-      noteElement.lyricsHorizontalOffset += measureBarShortDoubleWidth;
-      noteElement.neumeWidth += measureBarShortDoubleWidth;
-    } else if (measureBarLeft === MeasureBar.MeasureBarShortTheseos) {
-      noteElement.lyricsHorizontalOffset += measureBarShortTheseosWidth;
-      noteElement.neumeWidth += measureBarShortTheseosWidth;
+
+    const measureBarLeftWidth =
+      measureBarLeft != null ? measureBarWidthMap.get(measureBarLeft) : null;
+
+    if (measureBarLeftWidth != null) {
+      noteElement.lyricsHorizontalOffset += measureBarLeftWidth;
+      noteElement.neumeWidth += measureBarLeftWidth;
     }
 
     const measureBarRight =
       noteElement.measureBarRight || noteElement.computedMeasureBarRight;
-    if (measureBarRight === MeasureBar.MeasureBarRight) {
+
+    const measureBarRightWidth =
+      measureBarRight != null ? measureBarWidthMap.get(measureBarRight) : null;
+
+    if (measureBarRightWidth != null) {
       noteElement.lyricsHorizontalOffset -= measureBarRightWidth;
       noteElement.neumeWidth += measureBarRightWidth;
-    } else if (measureBarRight === MeasureBar.MeasureBarTop) {
-      noteElement.lyricsHorizontalOffset -= measureBarTopWidth;
-      noteElement.neumeWidth += measureBarTopWidth;
-    } else if (measureBarRight === MeasureBar.MeasureBarDouble) {
-      noteElement.lyricsHorizontalOffset -= measureBarDoubleWidth;
-      noteElement.neumeWidth += measureBarDoubleWidth;
-    } else if (measureBarRight === MeasureBar.MeasureBarTheseos) {
-      noteElement.lyricsHorizontalOffset -= measureBarTheseosWidth;
-      noteElement.neumeWidth += measureBarTheseosWidth;
-    } else if (measureBarRight === MeasureBar.MeasureBarShortDouble) {
-      noteElement.lyricsHorizontalOffset -= measureBarShortDoubleWidth;
-      noteElement.neumeWidth += measureBarShortDoubleWidth;
-    } else if (measureBarRight === MeasureBar.MeasureBarShortTheseos) {
-      noteElement.lyricsHorizontalOffset -= measureBarShortTheseosWidth;
-      noteElement.neumeWidth += measureBarShortTheseosWidth;
     }
 
     // Handle special case for running elaphron:

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -359,7 +359,11 @@ export class LayoutService {
             (ties.includes(noteElement.vocalExpressionNeume!) ||
               ties.includes(noteElement.tie!));
 
-          if (nextElement?.elementType === ElementType.Martyria) {
+          if (
+            nextElement?.elementType === ElementType.Martyria &&
+            !noteElement.pageBreak &&
+            !noteElement.lineBreak
+          ) {
             additionalWidth =
               this.getMartyriaWidth(nextElement as MartyriaElement, pageSetup) +
               pageSetup.neumeDefaultSpacing;


### PR DESCRIPTION
This PR uses the "additional width" feature in the layout processor to account for the additional width of a measure bar that will be added due to the presence of a measure bar at the beginning of the next line. This prevents the jitters seen in #812.

It also fixes another issue where notes where considered tied to other notes or martyria even when a page or line break was present.