### PR TITLE
Fix focus bug for drop caps when lyrics are locked

### DIFF
--- a/src/components/DropCap.vue
+++ b/src/components/DropCap.vue
@@ -61,7 +61,9 @@ export default class DropCap extends Vue {
   }
 
   focus() {
-    this.textElement.focus(true);
+    if (this.editable) {
+      this.textElement.focus(true);
+    }
   }
 
   blur() {


### PR DESCRIPTION
When a drop cap is added, the element is automatically focused and the text is highlighted so the user can immediately type of letter. When lyrics are locked, however, the drop cap is not editable and the attempt to "select the text" results in all the text on screen being focused. This PR fixes that issue by not attempting to "select the text" if the lyrics are locked.