### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,11 +84,6 @@
     "vitest": "^2.0.2",
     "vue-tsc": "^2.0.26"
   },
-  "overrides": {
-    "vite-plugin-electron": {
-      "electron": "$electron"
-    }
-  },
   "license": "GPL-3.0",
   "packageManager": "npm@10.7.0"
 }


### PR DESCRIPTION
This workaround was added in #560 but is no longer necessary after [recent changes to `vite-plugin-electron`](https://github.com/electron-vite/vite-plugin-electron/blob/main/CHANGELOG.md).