### PR TITLE
add support for all the chromatic fthora notes

### DIFF
--- a/src/components/ToolbarMartyria.vue
+++ b/src/components/ToolbarMartyria.vue
@@ -398,6 +398,7 @@ export default class ToolbarMartyria extends Vue {
       this.element.fthora === Fthora.SoftChromaticThi_Bottom
     ) {
       return [
+        { label: 'model:note.zoHigh', value: ScaleNote.ZoHigh },
         { label: 'model:note.di', value: ScaleNote.Thi },
         { label: 'model:note.vou', value: ScaleNote.Vou },
       ];
@@ -409,12 +410,14 @@ export default class ToolbarMartyria extends Vue {
         { label: `model:note.niHigh`, value: ScaleNote.NiHigh },
         { label: 'model:note.ke', value: ScaleNote.Ke },
         { label: 'model:note.ga', value: ScaleNote.Ga },
+        { label: 'model:note.pa', value: ScaleNote.Pa },
       ];
     } else if (
       this.element.fthora === Fthora.HardChromaticThi_Top ||
       this.element.fthora === Fthora.HardChromaticThi_Bottom
     ) {
       return [
+        { label: 'model:note.zoHigh', value: ScaleNote.ZoHigh },
         { label: 'model:note.di', value: ScaleNote.Thi },
         { label: 'model:note.vou', value: ScaleNote.Vou },
       ];
@@ -423,8 +426,10 @@ export default class ToolbarMartyria extends Vue {
       this.element.fthora === Fthora.HardChromaticPa_Bottom
     ) {
       return [
-        { label: 'model:note.pa', value: ScaleNote.Pa },
+        { label: `model:note.niHigh`, value: ScaleNote.NiHigh },
+        { label: 'model:note.ke', value: ScaleNote.Ke },
         { label: 'model:note.ga', value: ScaleNote.Ga },
+        { label: 'model:note.pa', value: ScaleNote.Pa },
       ];
     }
 

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -883,6 +883,7 @@ export default class ToolbarNeume extends Vue {
       this.element.fthora === Fthora.SoftChromaticThi_Bottom
     ) {
       return [
+        { label: 'model:note.zoHigh', value: ScaleNote.ZoHigh },
         { label: 'model:note.di', value: ScaleNote.Thi },
         { label: 'model:note.vou', value: ScaleNote.Vou },
       ];
@@ -894,12 +895,14 @@ export default class ToolbarNeume extends Vue {
         { label: `model:note.niHigh`, value: ScaleNote.NiHigh },
         { label: 'model:note.ke', value: ScaleNote.Ke },
         { label: 'model:note.ga', value: ScaleNote.Ga },
+        { label: 'model:note.pa', value: ScaleNote.Pa },
       ];
     } else if (
       this.element.fthora === Fthora.HardChromaticThi_Top ||
       this.element.fthora === Fthora.HardChromaticThi_Bottom
     ) {
       return [
+        { label: 'model:note.zoHigh', value: ScaleNote.ZoHigh },
         { label: 'model:note.di', value: ScaleNote.Thi },
         { label: 'model:note.vou', value: ScaleNote.Vou },
       ];
@@ -908,8 +911,10 @@ export default class ToolbarNeume extends Vue {
       this.element.fthora === Fthora.HardChromaticPa_Bottom
     ) {
       return [
-        { label: 'model:note.pa', value: ScaleNote.Pa },
+        { label: `model:note.niHigh`, value: ScaleNote.NiHigh },
+        { label: 'model:note.ke', value: ScaleNote.Ke },
         { label: 'model:note.ga', value: ScaleNote.Ga },
+        { label: 'model:note.pa', value: ScaleNote.Pa },
       ];
     }
 


### PR DESCRIPTION
From the theory books, the chromatic fthoras can be applied to all the following notes:
soft chromatic Di: Vou, Di, Zo'
soft chromatic Pa/Ga: Pa, Ga, Ke, Ni' ( Ni' recently added by #834 )
hard chromatic Pa: Pa, Ga, Ke Ni'
hard chromatic Di: Vou, Di, Zo'

Based on #834, I am adding the rest of the notes.