### PR TITLE
Add melisma cutoff setting

### DIFF
--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -355,6 +355,19 @@
               $t('dialog:pageSetup.melkiteRtl')
             }}</label>
           </div>
+          <div class="form-group">
+            <label class="melisma-label">{{
+              $t('dialog:pageSetup.lyricsMelismaCutoffWidth')
+            }}</label>
+            <InputUnit
+              class="melisma-input"
+              unit="pt"
+              :min="0"
+              :step="1"
+              :precision="0"
+              v-model="form.lyricsMelismaCutoffWidth"
+            />
+          </div>
         </div>
         <div class="right-pane">
           <div class="subheader">{{ $t('dialog:pageSetup.dropCaps') }}</div>
@@ -1405,5 +1418,13 @@ export default class PageSetupDialog extends Vue {
 .ok-btn,
 .reset-btn {
   margin-right: 2rem;
+}
+
+.melisma-label {
+  margin-right: 0.5rem;
+}
+
+.melisma-input {
+  width: 2rem;
 }
 </style>

--- a/src/i18n/en/dialog.json
+++ b/src/i18n/en/dialog.json
@@ -75,6 +75,7 @@
     "useChrysanthineAccidentals": "Use Chrysanthine Accidentals",
     "disableFthoraRestrictions": "Disable Fthora Restrictions",
     "melkiteRtl": "Melkite RTL",
+    "lyricsMelismaCutoffWidth": "Melisma Cutoff",
     "dropCaps": "Drop Caps",
     "color": "Color",
     "size": "Size",

--- a/src/models/PageSetup.ts
+++ b/src/models/PageSetup.ts
@@ -77,6 +77,7 @@ export class PageSetup {
   public lyricsDefaultStrokeWidth = 0;
   public lyricsVerticalOffset = -Unit.fromInch(0.05);
   public lyricsMinimumSpacing = Unit.fromInch(0.05);
+  public lyricsMelismaCutoffWidth = Unit.fromPt(5);
 
   // These two melisma properties are currently not exposed in the UI or saved
   // as part of the byzx format.

--- a/src/models/save/v1/PageSetup.ts
+++ b/src/models/save/v1/PageSetup.ts
@@ -37,6 +37,7 @@ export class PageSetup {
   public lyricsDefaultStrokeWidth = 0;
   public lyricsVerticalOffset = -Unit.fromInch(0.05);
   public lyricsMinimumSpacing = Unit.fromInch(0.05);
+  public lyricsMelismaCutoffWidth = Unit.fromPt(5);
 
   public neumeDefaultFontFamily = 'Neanes';
   public neumeDefaultFontSize = Unit.fromPt(20);

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1772,6 +1772,10 @@ export class LayoutService {
 
               element.melismaWidth = Math.max(end - start, 0);
 
+              if (element.melismaWidth < pageSetup.lyricsMelismaCutoffWidth) {
+                element.melismaWidth = 0;
+              }
+
               // Calculate the distance from the alphabetic baseline to the bottom of the font bounding box
               element.melismaOffsetTop =
                 -this.getLyricsFontBoundingBoxDescentFromCache(

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -174,6 +174,7 @@ export class SaveService {
     pageSetup.lyricsDefaultStrokeWidth = p.lyricsDefaultStrokeWidth;
     pageSetup.lyricsVerticalOffset = p.lyricsVerticalOffset;
     pageSetup.lyricsMinimumSpacing = p.lyricsMinimumSpacing;
+    pageSetup.lyricsMelismaCutoffWidth = p.lyricsMelismaCutoffWidth;
 
     pageSetup.textBoxDefaultColor = p.textBoxDefaultColor;
     pageSetup.textBoxDefaultFontFamily = p.textBoxDefaultFontFamily;
@@ -791,6 +792,8 @@ export class SaveService {
     pageSetup.lyricsVerticalOffset = p.lyricsVerticalOffset;
     pageSetup.lyricsMinimumSpacing =
       p.lyricsMinimumSpacing ?? pageSetup.lyricsMinimumSpacing;
+    pageSetup.lyricsMelismaCutoffWidth =
+      p.lyricsMelismaCutoffWidth ?? pageSetup.lyricsMelismaCutoffWidth;
 
     pageSetup.martyriaDefaultColor =
       p.martyriaDefaultColor ?? pageSetup.martyriaDefaultColor;


### PR DESCRIPTION
This PR adds a setting that filters out small melisma lines from being displayed. By default, lines smaller than 5pt are filtered out. This prevents small lines that can be confused with a period.

Incidentally, it can also be used to "disable" melisma lines altogether, if one were so inclined.