### PR TITLE
Use font height to size top pane in positioning dialog

### DIFF
--- a/src/components/SyllablePositioningDialog.vue
+++ b/src/components/SyllablePositioningDialog.vue
@@ -663,6 +663,7 @@ import { ElementType, NoteElement, ScoreElementOffset } from '@/models/Element';
 import { VocalExpressionNeume } from '@/models/Neumes';
 import { PageSetup } from '@/models/PageSetup';
 import { TimeNeume } from '@/models/save/v1/Neumes';
+import { TextMeasurementService } from '@/services/TextMeasurementService';
 
 @Component({
   components: {
@@ -799,8 +800,12 @@ export default class SyllablePositioningDialog extends Vue {
   }
 
   get topPaneStyle() {
+    const neumeHeight = TextMeasurementService.getFontHeight(
+      `${this.pageSetup.neumeDefaultFontSize}px ${this.pageSetup.neumeDefaultFontFamily}`,
+    );
+
     return {
-      height: this.pageSetup.lineHeight * this.zoom + 'px',
+      height: neumeHeight * this.zoom + 'px',
     } as StyleValue;
   }
 


### PR DESCRIPTION
Not sure why line height was ever being used here. It's more correct to use the font height. This fixes a bug where someone could put in a small line height and the top pane of the positioning dialog would be too small. Or a really large line height could make the top pane too large.