### PR TITLE
Only allow primary gorgons on hyporoe

### DIFF
--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -1132,7 +1132,10 @@ export default class ToolbarNeume extends Vue {
   }
 
   updateGorgon(args: string | string[]) {
-    if (this.innerNeume === 'Secondary') {
+    if (
+      this.innerNeume === 'Secondary' &&
+      this.element.quantitativeNeume !== QuantitativeNeume.Hyporoe
+    ) {
       if (Array.isArray(args)) {
         this.$emit('update:secondaryGorgon', GorgonNeume.GorgonSecondary);
       } else {


### PR DESCRIPTION
Choosing a gorgon in the neume toolbar when an hyporoe is selected now always assigns the gorgon to the primary gorgon neume and never to the secondary gorgon neume.

#1007 