### PR TITLE
Add CLI to silently prevent PDFs

### DIFF
--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -80,6 +80,11 @@ export interface FileMenuOpenScoreArgs {
   success: boolean;
 }
 
+export interface OpenWorkspaceFromArgvArgs {
+  files: FileMenuOpenScoreArgs[];
+  silentPdf: boolean;
+}
+
 export interface FileMenuOpenImageArgs {
   data: string;
   imageWidth: number;

--- a/src/services/ipc/BrowserIpcService.ts
+++ b/src/services/ipc/BrowserIpcService.ts
@@ -2,7 +2,7 @@ import JSZip from 'jszip';
 
 import {
   ExportWorkspaceAsImageReplyArgs,
-  FileMenuOpenScoreArgs,
+  OpenWorkspaceFromArgvArgs,
   SaveWorkspaceAsReplyArgs,
   SaveWorkspaceReplyArgs,
   ShowMessageBoxReplyArgs,
@@ -97,8 +97,8 @@ export class BrowserIpcService implements IIpcService {
     });
   }
 
-  public async openWorkspaceFromArgv(): Promise<FileMenuOpenScoreArgs[]> {
-    return [];
+  public async openWorkspaceFromArgv(): Promise<OpenWorkspaceFromArgvArgs> {
+    return { files: [], silentPdf: false };
   }
 
   public async showMessageBox(): Promise<ShowMessageBoxReplyArgs> {

--- a/src/services/ipc/IIpcService.ts
+++ b/src/services/ipc/IIpcService.ts
@@ -1,7 +1,7 @@
 import {
   ExportWorkspaceAsImageReplyArgs,
-  FileMenuOpenScoreArgs,
   OpenContextMenuForTabArgs,
+  OpenWorkspaceFromArgvArgs,
   SaveWorkspaceAsReplyArgs,
   SaveWorkspaceReplyArgs,
   ShowMessageBoxArgs,
@@ -34,7 +34,7 @@ export interface IIpcService {
 
   printWorkspace(workspace: Workspace): Promise<void>;
 
-  openWorkspaceFromArgv(): Promise<FileMenuOpenScoreArgs[]>;
+  openWorkspaceFromArgv(): Promise<OpenWorkspaceFromArgvArgs>;
 
   showMessageBox(args: ShowMessageBoxArgs): Promise<ShowMessageBoxReplyArgs>;
 

--- a/src/services/ipc/IpcService.ts
+++ b/src/services/ipc/IpcService.ts
@@ -4,9 +4,9 @@ import {
   ExportWorkspaceAsImageArgs,
   ExportWorkspaceAsMusicXmlArgs,
   ExportWorkspaceAsPdfArgs,
-  FileMenuOpenScoreArgs,
   IpcRendererChannels,
   OpenContextMenuForTabArgs,
+  OpenWorkspaceFromArgvArgs,
   PrintWorkspaceArgs,
   SaveWorkspaceArgs,
   SaveWorkspaceAsArgs,
@@ -128,7 +128,7 @@ export class IpcService implements IIpcService {
     } as PrintWorkspaceArgs);
   }
 
-  public async openWorkspaceFromArgv(): Promise<FileMenuOpenScoreArgs[]> {
+  public async openWorkspaceFromArgv(): Promise<OpenWorkspaceFromArgvArgs> {
     return await window.ipcRenderer.invoke(
       IpcRendererChannels.OpenWorkspaceFromArgv,
     );


### PR DESCRIPTION
Adds a command line flag to silently create PDFs.

E.g. the following will generate `file1.pdf` and `file2.pdf`.
`neanes --silent-pdf file1.byz file2.byz`