### PR TITLE
Fix `@typescript-eslint/await-thenable` violation

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -690,7 +690,7 @@ async function exportWorkspaceAsMusicXml(args: ExportWorkspaceAsMusicXmlArgs) {
         await fs.writeFile(filePath, args.data);
 
         if (args.openFolder) {
-          await shell.showItemInFolder(filePath);
+          shell.showItemInFolder(filePath);
         }
       }
     }


### PR DESCRIPTION
Fixes a violation of https://typescript-eslint.io/rules/await-thenable/ in preparation for perhaps someday enabling https://github.com/vuejs/eslint-config-typescript?tab=readme-ov-file#linting-with-type-information / https://typescript-eslint.io/getting-started/typed-linting