### PR TITLE
Fix center break before text box and mode key

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1425,7 +1425,9 @@ export class LayoutService {
         if (
           !line.elements.some(
             (x) =>
-              x.lineBreak == true && x.lineBreakType === LineBreakType.Justify,
+              x.lineBreak == true &&
+              (x.lineBreakType === LineBreakType.Justify ||
+                x.lineBreakType === LineBreakType.Center),
           ) &&
           nextLine?.elements.some(
             (x) =>


### PR DESCRIPTION
Fixes a bug introduced by #1126. A centered page break no longer worked before text boxes and mode keys.