### PR TITLE
Add license key for CKEditor

### DIFF
--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -104,6 +104,7 @@ export default class TextBoxRich extends Vue {
       language: {
         content: this.element.rtl ? 'ar' : 'en',
       },
+      licenseKey: 'GPL',
     };
   }
 


### PR DESCRIPTION
CKEditor now requires a `licenseKey` field in the config.

https://ckeditor.com/docs/ckeditor5/latest/updating/guides/update-to-44.html