### PR TITLE
Fix shifting selected elements

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -6997,7 +6997,7 @@ export default class Editor extends Vue {
 }
 
 .selectedTextbox {
-  border: 1px solid goldenrod;
+  outline: 1px solid goldenrod;
 }
 
 .selectedTextbox:deep(.handle) {

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -208,7 +208,7 @@ export default class TextBox extends Vue {
 
 <style scoped>
 .text-box-container {
-  border: 1px dotted black;
+  outline: 1px dotted black;
   box-sizing: border-box;
   min-height: 10px;
 }
@@ -228,7 +228,7 @@ export default class TextBox extends Vue {
 }
 
 .text-box:focus:not(.multipanel) {
-  border: var(--ck-focus-ring);
+  outline: var(--ck-focus-ring);
   background-color: white;
   position: relative;
   z-index: 1;


### PR DESCRIPTION
When textboxes and drop caps are selected, they shift because a CSS border is applied and this space is not accounted for in the element height. To fix this, the CSS outline property is used instead.