### PR TITLE
Handle hyphens after drop caps

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1651,11 +1651,20 @@ export class LayoutService {
           (x) => x.elementType === ElementType.Note,
         ) as NoteElement[];
 
+        const indexOfFirstNote = line.elements.findIndex(
+          (x) => x.elementType === ElementType.Note,
+        );
+
         for (const element of noteElements) {
           const index = line.elements.indexOf(element);
 
+          // We do not simply check for index === 0 because we also want
+          // to include the case where the first letter of the melisma
+          // is a drop cap at the beginning of the line
           const isIntermediateMelismaAtStartOfLine =
-            index === 0 && element.isMelisma && !element.isMelismaStart;
+            index === indexOfFirstNote &&
+            element.isMelisma &&
+            !element.isMelismaStart;
 
           // First, clear melisma fields, since
           // they may be stale


### PR DESCRIPTION
This PR addresses the case #1050. It does not handle the case of drop caps in the middle of a line, although that could be accomplished by the following means.

- In the Layout Service, check whether an element is a hyphen but not the start of the melisma. If the previous element on the line is a drop cap, then set isMelismaStart = true.
- To handle the case where a drop cap is deleted, the note element can be flagged with a "isMelsimaStartFromDropCap" property. If this property is found to be true, and the lyrics are empty, and there is no drop cap before it, the layout processor can set isMelismaStart = false.

For now that seems like overkill. So until someone asks for it, I'm keeping it as the simple case of a drop cap at the beginning of the line.