### PR TITLE
Fix some measure bar issues in ByzHtmlExporter

### DIFF
--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -478,10 +478,17 @@ export class ByzHtmlExporter {
     let inner = '';
 
     if (element.measureBarLeft) {
-      inner += this.exportNeume(MeasureBar.MeasureBarRight, indentation + 2, {
-        x: element.measureBarRightOffsetX,
-        y: element.measureBarRightOffsetY,
-      });
+      if (ScoreElement.isShort(element.measureBarLeft)) {
+        inner += this.exportNeume(MeasureBar.MeasureBarTop, indentation + 2, {
+          x: element.measureBarRightOffsetX,
+          y: element.measureBarRightOffsetY,
+        });
+      } else {
+        inner += this.exportNeume(MeasureBar.MeasureBarRight, indentation + 2, {
+          x: element.measureBarRightOffsetX,
+          y: element.measureBarRightOffsetY,
+        });
+      }
     }
 
     if (element.vareia) {

--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -478,17 +478,10 @@ export class ByzHtmlExporter {
     let inner = '';
 
     if (element.measureBarLeft) {
-      if (ScoreElement.isShort(element.measureBarLeft)) {
-        inner += this.exportNeume(MeasureBar.MeasureBarTop, indentation + 2, {
-          x: element.measureBarRightOffsetX,
-          y: element.measureBarRightOffsetY,
-        });
-      } else {
-        inner += this.exportNeume(MeasureBar.MeasureBarRight, indentation + 2, {
-          x: element.measureBarRightOffsetX,
-          y: element.measureBarRightOffsetY,
-        });
-      }
+      inner += this.exportNeume(element.measureBarLeft, indentation + 2, {
+        x: element.measureBarRightOffsetX,
+        y: element.measureBarRightOffsetY,
+      });
     }
 
     if (element.vareia) {

--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -477,17 +477,17 @@ export class ByzHtmlExporter {
   exportNote(element: NoteElement, pageSetup: PageSetup, indentation: number) {
     let inner = '';
 
-    if (element.vareia) {
-      inner += this.exportNeume(VocalExpressionNeume.Vareia, indentation + 2, {
-        x: element.vareiaOffsetX,
-        y: element.vareiaOffsetY,
-      });
-    }
-
     if (element.measureBarLeft) {
       inner += this.exportNeume(MeasureBar.MeasureBarRight, indentation + 2, {
         x: element.measureBarRightOffsetX,
         y: element.measureBarRightOffsetY,
+      });
+    }
+
+    if (element.vareia) {
+      inner += this.exportNeume(VocalExpressionNeume.Vareia, indentation + 2, {
+        x: element.vareiaOffsetX,
+        y: element.vareiaOffsetY,
       });
     }
 

--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -479,8 +479,8 @@ export class ByzHtmlExporter {
 
     if (element.measureBarLeft) {
       inner += this.exportNeume(element.measureBarLeft, indentation + 2, {
-        x: element.measureBarRightOffsetX,
-        y: element.measureBarRightOffsetY,
+        x: element.measureBarLeftOffsetX,
+        y: element.measureBarLeftOffsetY,
       });
     }
 


### PR DESCRIPTION
I'm trying to fix the following bugs:

- [x] vareias are added after measure bars in the exported .html
- [x] the exporter doesn't support short measure bars
- [ ] the exporter doesn't support measure bars above martyria (I don't think that I can solve this, actually)