### PR TITLE
prevent navigation to lyric boxes for no-lyric note elements

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -3994,7 +3994,14 @@ export default class Editor extends Vue {
       // Find the index of the next note
       for (let i = currentIndex + 1; i < this.elements.length; i++) {
         if (this.elements[i].elementType === ElementType.Note) {
-          return i;
+          if (
+            this.lyricService.getEffectiveAcceptsLyrics(
+              this.elements[i] as NoteElement,
+              null,
+            ) != AcceptsLyricsOption.No
+          ) {
+            return i;
+          }
         }
       }
     }
@@ -4044,7 +4051,13 @@ export default class Editor extends Vue {
 
       // Find the index of the previous note
       for (let i = currentIndex - 1; i >= 0; i--) {
-        if (this.elements[i].elementType === ElementType.Note) {
+        if (
+          this.elements[i].elementType === ElementType.Note &&
+          this.lyricService.getEffectiveAcceptsLyrics(
+            this.elements[i] as NoteElement,
+            null,
+          ) != AcceptsLyricsOption.No
+        ) {
           nextIndex = i;
           break;
         }


### PR DESCRIPTION
Hi, this is my attempt to fix the issue reported at #1017

I couldn't reproduce this issue using the lyrics toolbar; I observed the issue when entering lyrics directly in the lyrics container beneath the neume.

This fix should skip over the lyrics containers beneath the cross, apostrophe and dotted vareia while entering lyrics in that way, when navigating using the left/right arrow keys, spacebar, or hyphen/underscore melisma.  It is still possible to select the lyrics container on these neumes with the mouse, or with the ctrl/cmd+arrowDown command from the neume.

**Consideration:** 

Without this fix, it is possible to bridge over breath marks and crosses with western-style melisma using this entry method.  

With this fix applied, it will be necessary for the user to change the "Accepts Lyrics" setting for the neume to "Melisma Only" or "Yes" in order to bridge the symbol with a melisma, which matches the behavior we see when using the lyrics toolbar.

I had considered applying this behavior to the "Melisma Only" characters as well, but I thought this might cause problems in some cases, and I wasn't sure how to get it to render the melisma as it was passing over the note.