### PR TITLE
Fix zoom bug in page setup dialog

### DIFF
--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -1474,6 +1474,7 @@ export default class PageSetupDialog extends Vue {
   border-bottom: 1px solid lightgray;
   padding-bottom: 0.5rem;
   margin-bottom: 1rem;
+  --zoom: 1;
 }
 
 .preview-elements {


### PR DESCRIPTION
Fixes the following bug: when the page is zoomed, the neumes in the preview container of the page setup dialog are zoomed too.