### PR TITLE
Update Neume Select Buttons

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1283,11 +1283,11 @@ import { Header } from '@/models/Header';
 import { modeKeyTemplates } from '@/models/ModeKeys';
 import {
   areVocalExpressionsEquivalent,
+  getSecondaryNeume,
   measureBarAboveToLeft,
   onlyTakesBottomKlasma,
   onlyTakesTopGorgon,
   onlyTakesTopKlasma,
-  takesSecondaryNeumes,
 } from '@/models/NeumeReplacements';
 import {
   Accidental,
@@ -2575,7 +2575,7 @@ export default class Editor extends Vue {
 
     element.quantitativeNeume = quantitativeNeume;
     // Special case for neumes with secondary gorgon
-    if (takesSecondaryNeumes(quantitativeNeume)) {
+    if (getSecondaryNeume(quantitativeNeume) != null) {
       element.secondaryGorgonNeume = secondaryGorgonNeume;
     }
 

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -1422,6 +1422,14 @@ label.right-space {
   height: 16px;
 }
 
+.btnNeumeSelect {
+  font-size: 24px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .btnNeumeSelect.selected {
   background-color: var(--btn-color-selected);
 }

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -1226,12 +1226,29 @@ export default class ToolbarNeume extends Vue {
   }
 
   updateAccidental(args: string) {
+    // There is some admittedly confusing logic here regarding the hyporoe.
+    // Compare to handleHyporoe in the Analysis Service.
+
     if (this.innerNeume === 'Secondary') {
-      this.$emit('update:secondaryAccidental', args + this.innerNeume);
+      if (
+        this.element.quantitativeNeume == QuantitativeNeume.Hyporoe &&
+        args.startsWith('Flat')
+      ) {
+        this.$emit('update:accidental', args);
+      } else {
+        this.$emit('update:secondaryAccidental', args + this.innerNeume);
+      }
     } else if (this.innerNeume === 'Tertiary') {
       this.$emit('update:tertiaryAccidental', args + this.innerNeume);
     } else {
-      this.$emit('update:accidental', args);
+      if (
+        this.element.quantitativeNeume == QuantitativeNeume.Hyporoe &&
+        args.startsWith('Flat')
+      ) {
+        this.$emit('update:secondaryAccidental', args + 'Secondary');
+      } else {
+        this.$emit('update:accidental', args);
+      }
     }
   }
 

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -1,29 +1,38 @@
 <template>
   <div class="neume-toolbar">
-    <div class="row" v-if="isMultiNeume">
+    <div class="row" v-if="secondaryNeume">
       <span>{{ $t('toolbar:neume.neumeSelect') }}</span>
       <span class="space"></span>
       <button
-        v-if="hasTertiaryNeume"
+        v-if="tertiaryNeume"
         class="btnNeumeSelect"
         @click="$emit('update:innerNeume', 'Tertiary')"
         :class="{ selected: innerNeume === 'Tertiary' }"
       >
-        1
+        <Neume
+          :neume="tertiaryNeume"
+          :fontFamily="pageSetup.neumeDefaultFontFamily"
+        />
       </button>
       <button
         @click="$emit('update:innerNeume', 'Secondary')"
         class="btnNeumeSelect"
         :class="{ selected: innerNeume === 'Secondary' }"
       >
-        {{ hasTertiaryNeume ? '2' : '1' }}
+        <Neume
+          :neume="secondaryNeume"
+          :fontFamily="pageSetup.neumeDefaultFontFamily"
+        />
       </button>
       <button
         @click="$emit('update:innerNeume', 'Primary')"
         class="btnNeumeSelect"
         :class="{ selected: innerNeume === 'Primary' }"
       >
-        {{ hasTertiaryNeume ? '3' : '2' }}
+        <Neume
+          :neume="primaryNeume"
+          :fontFamily="pageSetup.neumeDefaultFontFamily"
+        />
       </button>
     </div>
     <div class="row">
@@ -510,9 +519,10 @@ import ButtonWithMenu, {
 import InputUnit from '@/components/InputUnit.vue';
 import { AcceptsLyricsOption, NoteElement } from '@/models/Element';
 import {
+  getPrimaryNeume,
+  getSecondaryNeume,
+  getTertiaryNeume,
   kentemataNeumes,
-  takesSecondaryNeumes,
-  takesTertiaryNeumes,
 } from '@/models/NeumeReplacements';
 import {
   Accidental,
@@ -534,8 +544,10 @@ import { ScaleNote } from '@/models/Scales';
 import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 import { Unit } from '@/utils/Unit';
 
+import NeumeVue from './Neume.vue';
+
 @Component({
-  components: { InputUnit, ButtonWithMenu },
+  components: { InputUnit, ButtonWithMenu, Neume: NeumeVue },
   emits: [
     'open-syllable-positioning-dialog',
     'update:accidental',
@@ -896,12 +908,16 @@ export default class ToolbarNeume extends Vue {
     },
   ];
 
-  get isMultiNeume() {
-    return takesSecondaryNeumes(this.element.quantitativeNeume);
+  get primaryNeume() {
+    return getPrimaryNeume(this.element.quantitativeNeume);
   }
 
-  get hasTertiaryNeume() {
-    return takesTertiaryNeumes(this.element.quantitativeNeume);
+  get secondaryNeume() {
+    return getSecondaryNeume(this.element.quantitativeNeume);
+  }
+
+  get tertiaryNeume() {
+    return getTertiaryNeume(this.element.quantitativeNeume);
   }
 
   get notes() {

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -22,13 +22,13 @@ import {
   getFthoraReplacements,
   getGorgonReplacements,
   getQuantitativeReplacements,
+  getSecondaryNeume,
+  getTertiaryNeume,
   getTimeReplacements,
   getVocalExpressionReplacements,
   isMeasureBarAbove,
   measureBarAboveToLeft,
   measureBarLeftToAbove,
-  takesSecondaryNeumes,
-  takesTertiaryNeumes,
 } from './NeumeReplacements';
 import { Scale, ScaleNote } from './Scales';
 
@@ -272,13 +272,13 @@ export class NoteElement extends ScoreElement {
     this._quantitativeNeume = neume;
     this.replaceNeumes();
 
-    if (!takesSecondaryNeumes(this.quantitativeNeume)) {
+    if (getSecondaryNeume(this.quantitativeNeume) == null) {
       this._secondaryGorgonNeume = null;
       this._secondaryFthora = null;
       this._secondaryAccidental = null;
     }
 
-    if (!takesTertiaryNeumes(this.quantitativeNeume)) {
+    if (getTertiaryNeume(this.quantitativeNeume) == null) {
       this._tertiaryFthora = null;
       this._tertiaryAccidental = null;
     }

--- a/src/models/NeumeReplacements.ts
+++ b/src/models/NeumeReplacements.ts
@@ -112,24 +112,84 @@ const rests: Neume[] = [
   QuantitativeNeume.Cross,
 ];
 
-const secondaryNeumesAllowedNeumes: Neume[] = [
-  QuantitativeNeume.OligonPlusIsonPlusKentemata,
-  QuantitativeNeume.OligonPlusApostrophosPlusKentemata,
-  QuantitativeNeume.OligonPlusElaphronPlusKentemata,
-  QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata,
-  QuantitativeNeume.OligonPlusHamiliPlusKentemata,
-  QuantitativeNeume.OligonPlusHyporoePlusKentemata,
-  QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
-  QuantitativeNeume.OligonPlusKentemata,
-  QuantitativeNeume.RunningElaphron,
-  QuantitativeNeume.PetastiPlusRunningElaphron,
-  QuantitativeNeume.KentemataPlusOligon,
-  QuantitativeNeume.Hyporoe,
-];
+const secondaryNeumeMap: Map<QuantitativeNeume, QuantitativeNeume> = new Map<
+  QuantitativeNeume,
+  QuantitativeNeume
+>([
+  [QuantitativeNeume.OligonPlusIsonPlusKentemata, QuantitativeNeume.Ison],
+  [
+    QuantitativeNeume.OligonPlusApostrophosPlusKentemata,
+    QuantitativeNeume.Apostrophos,
+  ],
+  [
+    QuantitativeNeume.OligonPlusElaphronPlusKentemata,
+    QuantitativeNeume.Elaphron,
+  ],
+  [
+    QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata,
+    QuantitativeNeume.ElaphronPlusApostrophos,
+  ],
+  [QuantitativeNeume.OligonPlusHamiliPlusKentemata, QuantitativeNeume.Hamili],
+  [QuantitativeNeume.OligonPlusHyporoePlusKentemata, QuantitativeNeume.Hyporoe],
+  [
+    QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
+    QuantitativeNeume.Elaphron,
+  ],
+  [QuantitativeNeume.OligonPlusKentemata, QuantitativeNeume.Oligon],
+  [QuantitativeNeume.RunningElaphron, QuantitativeNeume.Apostrophos],
+  [QuantitativeNeume.PetastiPlusRunningElaphron, QuantitativeNeume.Apostrophos],
+  [QuantitativeNeume.KentemataPlusOligon, QuantitativeNeume.Kentemata],
+  [QuantitativeNeume.Hyporoe, QuantitativeNeume.Apostrophos],
+]);
 
-const tertiaryNeumesAllowedNeumes: Neume[] = [
-  QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
-];
+const tertiaryNeumeMap: Map<QuantitativeNeume, QuantitativeNeume> = new Map<
+  QuantitativeNeume,
+  QuantitativeNeume
+>([
+  [
+    QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
+    QuantitativeNeume.Apostrophos,
+  ],
+]);
+
+const primaryNeumeMap: Map<QuantitativeNeume, QuantitativeNeume> = new Map<
+  QuantitativeNeume,
+  QuantitativeNeume
+>([
+  [QuantitativeNeume.OligonPlusIsonPlusKentemata, QuantitativeNeume.Kentemata],
+  [
+    QuantitativeNeume.OligonPlusApostrophosPlusKentemata,
+    QuantitativeNeume.Kentemata,
+  ],
+  [
+    QuantitativeNeume.OligonPlusElaphronPlusKentemata,
+    QuantitativeNeume.Kentemata,
+  ],
+  [
+    QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata,
+    QuantitativeNeume.Kentemata,
+  ],
+  [
+    QuantitativeNeume.OligonPlusHamiliPlusKentemata,
+    QuantitativeNeume.Kentemata,
+  ],
+  [
+    QuantitativeNeume.OligonPlusHyporoePlusKentemata,
+    QuantitativeNeume.Kentemata,
+  ],
+  [
+    QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
+    QuantitativeNeume.Kentemata,
+  ],
+  [QuantitativeNeume.OligonPlusKentemata, QuantitativeNeume.Kentemata],
+  [QuantitativeNeume.RunningElaphron, QuantitativeNeume.Elaphron],
+  [
+    QuantitativeNeume.PetastiPlusRunningElaphron,
+    QuantitativeNeume.PetastiPlusElaphron,
+  ],
+  [QuantitativeNeume.KentemataPlusOligon, QuantitativeNeume.Oligon],
+  [QuantitativeNeume.Hyporoe, QuantitativeNeume.Apostrophos],
+]);
 
 const measureBarAboveNeumes: Neume[] = [
   QuantitativeNeume.Hyporoe,
@@ -590,11 +650,14 @@ export const onlyTakesBottomKlasma = (neume: QuantitativeNeume) =>
 export const onlyTakesTopGorgon = (neume: QuantitativeNeume) =>
   !bottomAllowedGorgonNeumes.includes(neume);
 
-export const takesSecondaryNeumes = (neume: QuantitativeNeume) =>
-  secondaryNeumesAllowedNeumes.includes(neume);
+export const getPrimaryNeume = (neume: QuantitativeNeume) =>
+  primaryNeumeMap.get(neume) ?? null;
 
-export const takesTertiaryNeumes = (neume: QuantitativeNeume) =>
-  tertiaryNeumesAllowedNeumes.includes(neume);
+export const getSecondaryNeume = (neume: QuantitativeNeume) =>
+  secondaryNeumeMap.get(neume) ?? null;
+
+export const getTertiaryNeume = (neume: QuantitativeNeume) =>
+  tertiaryNeumeMap.get(neume) ?? null;
 
 export const isMeasureBarAbove = (neume: QuantitativeNeume) =>
   measureBarAboveNeumes.includes(neume);


### PR DESCRIPTION
This PR updates the neume selection buttons in the neume toolbar in order to clarify the meaning of the buttons. Instead of numbers, a button for each neume is displayed. The selected neume is (usually) the one that will receive the gorgon/accidental/etc.

<img width="41" alt="image" src="https://github.com/user-attachments/assets/7e24d044-ec1b-4634-922f-3790d99f645c" />
<img width="142" alt="image" src="https://github.com/user-attachments/assets/1e51a21f-9a6a-49f8-9630-60c95b85f43c" />

This PR does not attempt to fix any reported issues related to the behavior of secondary or tertiary neumes.

The behavior for adding flats to the yporroi was altered because the analysis service interprets the primary flat accidental as being belonging to the first note. So now, instead of selecting the "primary" button, users must select the "secondary" button to place a flat on the first note of the yporroi.

In RTL, the buttons remain unreversed since I'm not sure what would be most natural to RTL users since I am not one myself. If anyone opens an issue, I will reverse the buttons.