### PR TITLE
Add macOS ARM64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
 
@@ -41,3 +41,10 @@ jobs:
       - run: npm run build
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: Neanes-${{ matrix.os }}
+          path: dist/Neanes-*
+          retention-days: 3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/components/Downloads.vue
+++ b/docs/components/Downloads.vue
@@ -72,13 +72,16 @@ export default {
       const macAsset = this.latestRelease.assets.find(
         (x) => x.name.endsWith('.dmg') && !x.name.endsWith('arm64.dmg'),
       );
-
+      const macArm64Asset = this.latestRelease.assets.find((x) =>
+        x.name.endsWith('arm64.dmg'),
+      );
       const windowsAsset = this.latestRelease.assets.find((x) =>
         x.name.endsWith('.exe'),
       );
 
       this.rows.push({ asset: linuxAsset, os: 'Linux' });
       this.rows.push({ asset: macAsset, os: 'macOS' });
+      this.rows.push({ asset: macArm64Asset, os: 'macOS-arm64' });
       this.rows.push({ asset: windowsAsset, os: 'Windows' });
     } catch (e) {
       console.error(e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.5.0",
         "electron": "^35.1.5",
-        "electron-builder": "^26.0.12",
+        "electron-builder": "^26.0.13",
         "electron-updater": "^6.6.2",
         "eslint": "^9.24.0",
         "eslint-plugin-prettier": "^5.2.6",
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.0.tgz",
-      "integrity": "sha512-VW++CNSlZwMYP7MyXEbrKjpzEwhB5kDNbzGtiPEjwYysqyTCF+YbNJ210Dj3AjWsGSV4iEEwNkmJN9yGZmVvmw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
+      "integrity": "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6547,9 +6547,9 @@
       "license": "MIT"
     },
     "node_modules/app-builder-lib": {
-      "version": "26.0.12",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.0.12.tgz",
-      "integrity": "sha512-+/CEPH1fVKf6HowBUs6LcAIoRcjeqgvAeoSE+cl7Y7LndyQ9ViGPYibNk7wmhMHzNgHIuIbw4nWADPO+4mjgWw==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.0.13.tgz",
+      "integrity": "sha512-Iov4wX9dHRiI1rxRFk7k3X4QtltsTXN+8Kge7B5DO+pTjKxSNhJ1S+wjJAQM5VatxGxwX7HnxmHLt5PRI5AYSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6558,20 +6558,20 @@
         "@electron/fuses": "^1.8.0",
         "@electron/notarize": "2.5.0",
         "@electron/osx-sign": "1.3.1",
-        "@electron/rebuild": "3.7.0",
+        "@electron/rebuild": "3.7.2",
         "@electron/universal": "2.0.1",
         "@malept/flatpak-bundler": "^0.4.0",
         "@types/fs-extra": "9.0.13",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.0.11",
-        "builder-util-runtime": "9.3.1",
+        "builder-util": "26.0.13",
+        "builder-util-runtime": "9.3.2",
         "chromium-pickle-js": "^0.2.0",
         "config-file-ts": "0.2.8-rc1",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.0.11",
+        "electron-publish": "26.0.13",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "is-ci": "^3.0.0",
@@ -6591,8 +6591,22 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.0.12",
-        "electron-builder-squirrel-windows": "26.0.12"
+        "dmg-builder": "26.0.13",
+        "electron-builder-squirrel-windows": "26.0.13"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.2.tgz",
+      "integrity": "sha512-7QDXJ1FwT6d9ZhG4kuObUUPY8/ENBS/Ky26O4hR5vbeoRGavgekS2Jxv+8sCn/v23aPGU2DXRWEeJuijN2ooYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/fs-extra": {
@@ -7026,16 +7040,16 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.0.11",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.0.11.tgz",
-      "integrity": "sha512-xNjXfsldUEe153h1DraD0XvDOpqGR0L5eKFkdReB7eFW5HqysDZFfly4rckda6y9dF39N3pkPlOblcfHKGw+uA==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.0.13.tgz",
+      "integrity": "sha512-6b64uHzywaL2KAG+rVcqk/Prta1m3I2Jo1d4d2CrApb6EeSk2V384tmSL0EniH+P8jaNbMp6qhg7cIALw32zRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "7zip-bin": "~5.2.0",
         "app-builder-bin": "5.0.0-alpha.12",
-        "builder-util-runtime": "9.3.1",
+        "builder-util-runtime": "9.3.2",
         "chalk": "^4.1.2",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.4",
@@ -7055,6 +7069,20 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
       "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/builder-util-runtime": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.2.tgz",
+      "integrity": "sha512-7QDXJ1FwT6d9ZhG4kuObUUPY8/ENBS/Ky26O4hR5vbeoRGavgekS2Jxv+8sCn/v23aPGU2DXRWEeJuijN2ooYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8176,21 +8204,35 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.0.12",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.12.tgz",
-      "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.13.tgz",
+      "integrity": "sha512-OBa6xbQwFAm6gbbClkuGrxnOLbrPauv3yaugnGtIHsn7BvFSmMhZzhmcJQMrAGzDW2M3n/RmG/5mgOYUagqoeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.0.12",
-        "builder-util": "26.0.11",
-        "builder-util-runtime": "9.3.1",
+        "app-builder-lib": "26.0.13",
+        "builder-util": "26.0.13",
+        "builder-util-runtime": "9.3.2",
         "fs-extra": "^10.1.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
       },
       "optionalDependencies": {
         "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/builder-util-runtime": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.2.tgz",
+      "integrity": "sha512-7QDXJ1FwT6d9ZhG4kuObUUPY8/ENBS/Ky26O4hR5vbeoRGavgekS2Jxv+8sCn/v23aPGU2DXRWEeJuijN2ooYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/dmg-builder/node_modules/fs-extra": {
@@ -8259,9 +8301,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -8355,17 +8397,17 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.0.12",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.0.12.tgz",
-      "integrity": "sha512-cD1kz5g2sgPTMFHjLxfMjUK5JABq3//J4jPswi93tOPFz6btzXYtK5NrDt717NRbukCUDOrrvmYVOWERlqoiXA==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.0.13.tgz",
+      "integrity": "sha512-DbTHV16W03TcGImDXeFulmCGIaFIh4nyXTLm5CE3ml47R54AaAlEWI+Jj1/kMsK2rproHw3eoR4l/3P7hlJ0fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.0.12",
-        "builder-util": "26.0.11",
-        "builder-util-runtime": "9.3.1",
+        "app-builder-lib": "26.0.13",
+        "builder-util": "26.0.13",
+        "builder-util-runtime": "9.3.2",
         "chalk": "^4.1.2",
-        "dmg-builder": "26.0.12",
+        "dmg-builder": "26.0.13",
         "fs-extra": "^10.1.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -8381,16 +8423,30 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.0.12",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz",
-      "integrity": "sha512-kpwXM7c/ayRUbYVErQbsZ0nQZX4aLHQrPEG9C4h9vuJCXylwFH8a7Jgi2VpKIObzCXO7LKHiCw4KdioFLFOgqA==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.13.tgz",
+      "integrity": "sha512-MNYTB46mSoj5FetmSw0KFt8JRBtFPEArhaNDLAKXB1/6GMSktrpuRqwK2iyOQxbaYT5Oo7Z4O2KOIW+UmH8iDw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.0.12",
-        "builder-util": "26.0.11",
+        "app-builder-lib": "26.0.13",
+        "builder-util": "26.0.13",
         "electron-winstaller": "5.4.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/builder-util-runtime": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.2.tgz",
+      "integrity": "sha512-7QDXJ1FwT6d9ZhG4kuObUUPY8/ENBS/Ky26O4hR5vbeoRGavgekS2Jxv+8sCn/v23aPGU2DXRWEeJuijN2ooYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-builder/node_modules/fs-extra": {
@@ -8432,20 +8488,34 @@
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.0.11",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.0.11.tgz",
-      "integrity": "sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.0.13.tgz",
+      "integrity": "sha512-O5hfHSwli5cegQ4JS3Dp0dZcheex6UCRE/qYyRQvhB6DhSwojiwTnAGEuQCJXc8K8Zxz2lku5Du3VwYHf8d5Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "26.0.11",
-        "builder-util-runtime": "9.3.1",
+        "builder-util": "26.0.13",
+        "builder-util-runtime": "9.3.2",
         "chalk": "^4.1.2",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/builder-util-runtime": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.2.tgz",
+      "integrity": "sha512-7QDXJ1FwT6d9ZhG4kuObUUPY8/ENBS/Ky26O4hR5vbeoRGavgekS2Jxv+8sCn/v23aPGU2DXRWEeJuijN2ooYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-publish/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.5.0",
     "electron": "^35.1.5",
-    "electron-builder": "^26.0.12",
+    "electron-builder": "^26.0.13",
     "electron-updater": "^6.6.2",
     "eslint": "^9.24.0",
     "eslint-plugin-prettier": "^5.2.6",


### PR DESCRIPTION
Reverts neanes/neanes@cea1b32745e38b13496ab45f5b39c05c256d2a2f. Fixes #1371.

### Testing done

With `CSC_FOR_PULL_REQUEST` temporarily set to `true`, observed the expected

```
  • falling back to ad-hoc signature for macOS application code signing
  • signing         file=dist/mac-arm64/Neanes.app platform=darwin type=distribution identityName=- identityHash=none provisioningProfile=none
  • skipped macOS notarization  reason=`notarize` options were unable to be generated
```

from https://github.com/electron-userland/electron-builder/pull/9007. Downloaded the resulting `.dmg` file and installed to `/Applications`. Right-clicked and selected **Open,** saw "Neanes Not Opened: Apple could not verify Neanes is free of malware that may harm your Mac or compromise your privacy." (This is expected, and is better than the previous result of "damaged.") Went to **Settings, Privacy & Security,** saw "Neanes was blocked to protect your Mac," and clicked **Open Anyway.** Neanes launched and playback was fine.