### PR TITLE
Fix document title bug when changing tabs

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -2064,8 +2064,8 @@ export default class Editor extends Vue {
     document.documentElement.style.setProperty('--zoom', this.zoom.toString());
   }
 
-  @Watch('currentFilePath')
-  onFilePathUpdated() {
+  @Watch('selectedWorkspaceId')
+  onCurrentWorkspaceId() {
     window.document.title = this.windowTitle;
   }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -2065,7 +2065,7 @@ export default class Editor extends Vue {
   }
 
   @Watch('selectedWorkspaceId')
-  onCurrentWorkspaceId() {
+  onCurrentWorkspaceIdUpdated() {
     window.document.title = this.windowTitle;
   }
 


### PR DESCRIPTION
This fixes a bug where the window title doesn't change when switching tabs unless the workspace has been saved at least once.