### PR TITLE
Remove space after right-aligned martyria

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1507,7 +1507,9 @@ export class LayoutService {
 
     // Add in padding to give some extra space between
     // the martyria and the next neume
-    const padding = pageSetup.neumeDefaultFontSize * 0.148;
+    const padding = martyriaElement.alignRight
+      ? 0
+      : pageSetup.neumeDefaultFontSize * 0.148;
 
     martyriaElement.neumeWidth = this.getNeumeWidthFromCache(
       neumeWidthCache,


### PR DESCRIPTION
Right aligned martyria mistakenly had padding that was intended to provide spacing before the following neume.