### PR TITLE
Fix height of text boxes when zoomed

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -456,6 +456,7 @@
                       :editMode="true"
                       :metadata="getTokenMetadata(pageIndex)"
                       :pageSetup="score.pageSetup"
+                      :zoom="zoom"
                       :selected="isSelected(element)"
                       @select-single="selectedElement = element"
                       @update="updateTextBox(element as TextBoxElement, $event)"
@@ -482,6 +483,7 @@
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element"
                       :pageSetup="score.pageSetup"
+                      :zoom="zoom"
                       :fonts="fonts"
                       :selected="isSelected(element)"
                       @select-single="selectedElement = element"
@@ -605,6 +607,7 @@
                     "
                     :metadata="getTokenMetadata(pageIndex)"
                     :pageSetup="score.pageSetup"
+                    :zoom="zoom"
                     :fonts="fonts"
                     :selected="
                       getFooterForPageIndex(pageIndex) ==
@@ -646,6 +649,7 @@
                     "
                     :metadata="getTokenMetadata(pageIndex)"
                     :pageSetup="score.pageSetup"
+                    :zoom="zoom"
                     :class="[
                       {
                         selectedTextbox:
@@ -1210,6 +1214,7 @@
         :key="element.id"
         :element="element"
         :pageSetup="score.pageSetup"
+        :zoom="zoom"
         :fonts="fonts"
         @update:height="
           updateRichTextBoxHeight(element as RichTextBoxElement, $event)
@@ -1223,6 +1228,7 @@
         :key="element.id"
         :element="element"
         :pageSetup="score.pageSetup"
+        :zoom="zoom"
         :fonts="fonts"
         @update:height="updateTextBoxHeight(element as TextBoxElement, $event)"
       />

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -89,6 +89,7 @@ export default class TextBox extends Vue {
   @Prop({ default: true }) editMode!: boolean;
   @Prop() selected!: boolean;
   @Prop() metadata!: TokenMetadata;
+  @Prop({ default: 1 }) zoom!: number;
 
   resizeObserver: ResizeObserver | null = null;
   unmounting = false;
@@ -260,14 +261,18 @@ export default class TextBox extends Vue {
 
   getHeight() {
     if (this.element.multipanel) {
-      return Math.max(
-        this.textElementLeft.htmlElement.getBoundingClientRect().height,
-        this.textElementCenter.htmlElement.getBoundingClientRect().height,
-        this.textElementRight.htmlElement.getBoundingClientRect().height,
+      return (
+        Math.max(
+          this.textElementLeft.htmlElement.getBoundingClientRect().height,
+          this.textElementCenter.htmlElement.getBoundingClientRect().height,
+          this.textElementRight.htmlElement.getBoundingClientRect().height,
+        ) / this.zoom
       );
     }
 
-    return this.textElement.htmlElement.getBoundingClientRect().height;
+    return (
+      this.textElement.htmlElement.getBoundingClientRect().height / this.zoom
+    );
   }
 
   onBlur() {

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -505,15 +505,23 @@ export default class TextBoxRich extends Vue {
   }
 
   getHeightBottom() {
-    return (this.$el as HTMLElement)
-      .querySelector('.ck-content.inline-bottom')
-      ?.getBoundingClientRect().height;
+    const element = (this.$el as HTMLElement).querySelector(
+      '.ck-content.inline-bottom',
+    );
+
+    return element != null
+      ? element.getBoundingClientRect().height / this.zoom
+      : null;
   }
 
   getHeightTop() {
-    return (this.$el as HTMLElement)
-      .querySelector('.ck-content.inline-top')
-      ?.getBoundingClientRect().height;
+    const element = (this.$el as HTMLElement).querySelector(
+      '.ck-content.inline-top',
+    );
+
+    return element != null
+      ? element.getBoundingClientRect().height / this.zoom
+      : null;
   }
 
   setPadding(editor: Editor | undefined) {

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -498,7 +498,6 @@ export default class TextBoxRich extends Vue {
   }
 
   getHeight() {
-    console.log(this.zoom);
     const element = (this.$el as HTMLElement).querySelector('.ck-content');
     return element != null
       ? element.getBoundingClientRect().height / this.zoom

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -111,6 +111,7 @@ export default class TextBoxRich extends Vue {
   @Prop({ default: true }) editMode!: boolean;
   @Prop() selected!: boolean;
   @Prop() metadata!: TokenMetadata;
+  @Prop({ default: 1 }) zoom!: number;
 
   editor = InlineEditor;
   editorData = '';
@@ -281,7 +282,7 @@ export default class TextBoxRich extends Vue {
           (this.heightTop - this.element.defaultLyricsFontHeight) +
           this.element.offsetYTop,
       ),
-      lineHeight: `${this.element.defaultLyricsFontHeight}px`,
+      lineHeight: withZoom(this.element.defaultLyricsFontHeight),
     };
 
     return style;
@@ -316,10 +317,10 @@ export default class TextBoxRich extends Vue {
     const style: any = {
       top: withZoom(
         this.pageSetup.lyricsVerticalOffset -
-          (this.heightBottom - this.element.defaultLyricsFontHeight) +
+          (this.heightBottom / 2 - this.element.defaultLyricsFontHeight) +
           this.element.offsetYBottom,
       ),
-      lineHeight: `${this.element.defaultLyricsFontHeight}px`,
+      lineHeight: withZoom(this.element.defaultLyricsFontHeight),
     };
 
     return style;
@@ -497,9 +498,11 @@ export default class TextBoxRich extends Vue {
   }
 
   getHeight() {
-    return (this.$el as HTMLElement)
-      .querySelector('.ck-content')
-      ?.getBoundingClientRect().height;
+    console.log(this.zoom);
+    const element = (this.$el as HTMLElement).querySelector('.ck-content');
+    return element != null
+      ? element.getBoundingClientRect().height / this.zoom
+      : null;
   }
 
   getHeightBottom() {


### PR DESCRIPTION
There is still a bug with the alignment of inline rich text boxes, but this fixes the height calculation issue.