### PR TITLE
Add back missing handle for text boxes

### DIFF
--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -487,6 +487,10 @@ export default class TextBox extends Vue {
   display: none;
 }
 
+.text-box-container.selected .handle {
+  display: inline;
+}
+
 .inline-container {
   display: flex;
   flex-direction: column;

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -624,6 +624,10 @@ export default class TextBoxRich extends Vue {
   display: none;
 }
 
+.rich-text-box-container.selected .handle {
+  display: inline;
+}
+
 .rich-text-box-multipanel-container {
   display: flex;
 }


### PR DESCRIPTION
Handles for text boxes were broken when the method of selecting text boxes changed.