### PR TITLE
Right align the last martyria on a line

### DIFF
--- a/src/models/PageSetup.ts
+++ b/src/models/PageSetup.ts
@@ -118,10 +118,10 @@ export class PageSetup {
   public lyricsMinimumSpacing = Unit.fromInch(0.05);
   public lyricsMelismaCutoffWidth = Unit.fromPt(5);
 
-  // These two melisma properties are currently not exposed in the UI or saved
-  // as part of the byzx format.
+  // These properties are currently not exposed in the UI or saved as part of the byzx format.
   public lyricsMelismaSpacing = Unit.fromInch(0.025);
   public lyricsMelismaThickness = 1;
+  public spaceAfterMartyriaFactor = 0.148;
 
   public get lyricsFont() {
     return `${this.lyricsDefaultFontStyle} normal ${this.lyricsDefaultFontWeight} ${this.lyricsDefaultFontSize}px "${this.lyricsDefaultFontFamily}"`;

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1514,7 +1514,7 @@ export class LayoutService {
     // the martyria and the next neume
     const padding = martyriaElement.alignRight
       ? 0
-      : pageSetup.neumeDefaultFontSize * 0.148;
+      : pageSetup.neumeDefaultFontSize * pageSetup.spaceAfterMartyriaFactor;
 
     martyriaElement.neumeWidth = this.getNeumeWidthFromCache(
       neumeWidthCache,
@@ -1668,6 +1668,21 @@ export class LayoutService {
           (x) =>
             x.lineBreak == true && x.lineBreakType === LineBreakType.Center,
         );
+
+        // If the last element is a martyria, we remove any unnecessary padding
+        // to the right of the martyria, so that it does not affect the justification
+        // of the line. This causes the martyria to be aligned flush to the right side of the page.
+        const lastElementOnLine = line.elements[line.elements.length - 1];
+
+        if (lastElementOnLine.elementType === ElementType.Martyria) {
+          const martyriaElement = lastElementOnLine as MartyriaElement;
+
+          if (!martyriaElement.alignRight) {
+            martyriaElement.width -=
+              pageSetup.neumeDefaultFontSize *
+              pageSetup.spaceAfterMartyriaFactor;
+          }
+        }
 
         const currentWidthPx = line.elements
           .map((x) => x.width)


### PR DESCRIPTION
If the last element of a line is a non-right aligned martyria, the martyria is right aligned for visual consistency.

Before
<img width="735" alt="image" src="https://github.com/user-attachments/assets/cac384b8-f195-496b-83d9-8a1f438c9d76" />

After
<img width="677" alt="image" src="https://github.com/user-attachments/assets/199eab75-cf60-4b7e-bc7e-e7bfd998395a" />
