### PR TITLE
Fix specific case of spathi playback

### DIFF
--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -783,7 +783,7 @@ export class PlaybackService {
       }
 
       // Scale change
-      workspace.scale = this.getPlaybackScale(fthoraNode.scale, workspace);
+      workspace.scale = newScale;
 
       // Compute distance from Di to virtual note in the new scale
       const moria2 = this.moriaBetweenNotes(


### PR DESCRIPTION
This PR updates the playback service to remember the last pivot used. If the current or previous scale is Spathi on KE, for example, the pivot is KE.

Without this PR, KE is only used as the pivot when switching **to** spathi, but not when switching **away** from spathi.

This fixes the spathi example in #430.