### PR TITLE
Don't show unsaved changes for non-user initiated text box height changes

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -5511,7 +5511,7 @@ export default class Editor extends Vue {
       this.refreshStaffLyrics();
     }
 
-    this.save();
+    this.save(!noHistory);
   }
 
   updateRichTextBoxHeight(element: RichTextBoxElement, height: number) {
@@ -5519,7 +5519,7 @@ export default class Editor extends Vue {
     // (e.g. if PageSetup changes) so we debounce the save.
     element.height = height;
     this.richTextBoxCalculationCount++;
-    this.saveDebounced();
+    this.saveDebounced(false);
   }
 
   updateRichTextBoxMarginTop(element: RichTextBoxElement, marginTop: number) {
@@ -5545,7 +5545,7 @@ export default class Editor extends Vue {
       noHistory,
     );
 
-    this.save();
+    this.save(!noHistory);
   }
 
   updateTextBoxHeight(element: TextBoxElement, height: number) {
@@ -5553,7 +5553,7 @@ export default class Editor extends Vue {
     // (e.g. if PageSetup changes) so we debounce the save.
     element.height = height;
     this.textBoxCalculationCount++;
-    this.saveDebounced();
+    this.saveDebounced(false);
   }
 
   updateTextBoxUseDefaultStyle(
@@ -6557,7 +6557,7 @@ export default class Editor extends Vue {
       await new Promise(poll);
 
       this.richTextBoxCalculation = false;
-      this.saveDebounced();
+      this.saveDebounced(false);
     });
   }
 
@@ -6593,7 +6593,7 @@ export default class Editor extends Vue {
       await new Promise(poll);
 
       this.textBoxCalculation = false;
-      this.saveDebounced();
+      this.saveDebounced(false);
     });
   }
 


### PR DESCRIPTION
If Neanes re-calculates the height of a text box, but the user did not also make changes to the text box (e.g. changing the text box content, or the font size, etc.), then Neanes should not indicate that there are unsaved changes.

There should be no harm if the user exits the application without saving these changes since, at worst, the text box height will just be re-calculated next time the user opens the score.

