### PR TITLE
Revert "chore: bump vite-plugin-electron from 0.28.8 to 0.29.0 (#1111)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "prettier": "^3.6.2",
         "typescript": "^5.8.3",
         "vite": "^7.0.2",
-        "vite-plugin-electron": "^0.29.0",
+        "vite-plugin-electron": "^0.28.8",
         "vite-plugin-electron-renderer": "^0.14.6",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-pwa": "^1.0.1",
@@ -15514,9 +15514,9 @@
       }
     },
     "node_modules/vite-plugin-electron": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.29.0.tgz",
-      "integrity": "sha512-HP0DI9Shg41hzt55IKYVnbrChWXHX95QtsEQfM+szQBpWjVhVGMlqRjVco6ebfQjWNr+Ga+PeoBjMIl8zMaufw==",
+      "version": "0.28.8",
+      "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.28.8.tgz",
+      "integrity": "sha512-ir+B21oSGK9j23OEvt4EXyco9xDCaF6OGFe0V/8Zc0yL2+HMyQ6mmNQEIhXsEsZCSfIowBpwQBeHH4wVsfraeg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^7.0.2",
-    "vite-plugin-electron": "^0.29.0",
+    "vite-plugin-electron": "^0.28.8",
     "vite-plugin-electron-renderer": "^0.14.6",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-pwa": "^1.0.1",


### PR DESCRIPTION
This reverts commit 8a75001ed9696c7cc872862ffee3a4c40b992528 because it breaks the "Toggle Developer Tools" feature when running `npm run dev`.