### PR TITLE
Make font family and size dropdown buttons display their current value

### DIFF
--- a/src/ckeditor-plugins/fontfamilydropdown/fontfamilydropdown.ts
+++ b/src/ckeditor-plugins/fontfamilydropdown/fontfamilydropdown.ts
@@ -1,0 +1,45 @@
+import { Command, DropdownView, Editor, FontFamily, Plugin } from 'ckeditor5';
+
+// Work around https://github.com/ckeditor/ckeditor5/issues/2282
+export default class FontFamilyDropdown extends Plugin {
+  static get pluginName() {
+    return 'FontFamilyDropdown';
+  }
+
+  static get requires() {
+    return [FontFamily];
+  }
+
+  init() {
+    this.editor.ui.componentFactory.add('fontFamilyDropdown', () => {
+      const editor: Editor = this.editor;
+      const command: Command = editor.commands.get('fontFamily')!;
+
+      // Use the original font family dropdown and modify its behavior.
+      const dropdownView: DropdownView = editor.ui.componentFactory.create(
+        'fontFamily',
+      ) as DropdownView;
+
+      // Show the label on the dropdown's button.
+      dropdownView.buttonView.set('withText', true);
+
+      // Bind the dropdown's button label to the font family command value.
+      dropdownView.buttonView
+        .bind('label')
+        .to(command, 'value', (value: unknown): string => {
+          const fontFamily = typeof value === 'string' ? value : undefined;
+          if (fontFamily) {
+            return fontFamily
+              .split(',')[0]
+              .trim()
+              .replace(/^'(.*)'$/, '$1');
+          }
+          // If no value is set on the command, show the default text. Use the
+          // t() method to make this string translatable.
+          return editor.t('Default');
+        });
+
+      return dropdownView;
+    });
+  }
+}

--- a/src/ckeditor-plugins/fontsizedropdown/fontsizedropdown.css
+++ b/src/ckeditor-plugins/fontsizedropdown/fontsizedropdown.css
@@ -1,0 +1,3 @@
+.ck.ck-dropdown.ck-font-size-dropdown .ck-button.ck-dropdown__button .ck-button__label {
+  width: auto;
+}

--- a/src/ckeditor-plugins/fontsizedropdown/fontsizedropdown.ts
+++ b/src/ckeditor-plugins/fontsizedropdown/fontsizedropdown.ts
@@ -1,0 +1,44 @@
+import './fontsizedropdown.css';
+
+import { Command, DropdownView, Editor, FontSize, Plugin } from 'ckeditor5';
+
+// Work around https://github.com/ckeditor/ckeditor5/issues/2282
+export default class FontSizeDropdown extends Plugin {
+  static get pluginName() {
+    return 'FontSizeDropdown';
+  }
+
+  static get requires() {
+    return [FontSize];
+  }
+
+  init() {
+    this.editor.ui.componentFactory.add('fontSizeDropdown', () => {
+      const editor: Editor = this.editor;
+      const command: Command = editor.commands.get('fontSize')!;
+
+      // Use the original font size dropdown and modify its behavior.
+      const dropdownView: DropdownView = editor.ui.componentFactory.create(
+        'fontSize',
+      ) as DropdownView;
+
+      // Show the label on the dropdown's button.
+      dropdownView.buttonView.set('withText', true);
+
+      // Bind the dropdown's button label to the font size command value.
+      dropdownView.buttonView
+        .bind('label')
+        .to(command, 'value', (value: unknown): string => {
+          const fontSize = typeof value === 'string' ? value : undefined;
+          if (fontSize) {
+            return fontSize.replace(/pt$/, '');
+          }
+          // If no value is set on the command, show the default text. Use the
+          // t() method to make this string translatable.
+          return editor.t('Default');
+        });
+
+      return dropdownView;
+    });
+  }
+}

--- a/src/customEditor.ts
+++ b/src/customEditor.ts
@@ -41,6 +41,8 @@ import {
   Undo,
 } from 'ckeditor5';
 
+import FontFamilyDropdown from './ckeditor-plugins/fontfamilydropdown/fontfamilydropdown';
+import FontSizeDropdown from './ckeditor-plugins/fontsizedropdown/fontsizedropdown';
 import InsertNeume from './ckeditor-plugins/insertneume/insertneume';
 
 export default class InlineEditor extends InlineEditorBase {}
@@ -55,7 +57,9 @@ InlineEditor.builtinPlugins = [
   FindAndReplace,
   FontColor,
   FontFamily,
+  FontFamilyDropdown,
   FontSize,
+  FontSizeDropdown,
   GeneralHtmlSupport,
   Image,
   ImageCaption,
@@ -89,8 +93,8 @@ InlineEditor.builtinPlugins = [
 InlineEditor.defaultConfig = {
   toolbar: {
     items: [
-      'fontFamily',
-      'fontSize',
+      'fontFamilyDropdown',
+      'fontSizeDropdown',
       '|',
       'bold',
       'italic',


### PR DESCRIPTION
Work around https://github.com/ckeditor/ckeditor5/issues/2282

![image](https://github.com/user-attachments/assets/924bb90d-8de8-4292-a8ed-e57812bc6195)
