### PR TITLE
Add annotations and alternate lines

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1445,6 +1445,12 @@ function createMenu() {
       label: i18next.t('menu:insert.root'),
       submenu: [
         {
+          label: i18next.t('menu:insert.annotation'),
+          click() {
+            win?.webContents.send(IpcMainChannels.FileMenuInsertAnnotation);
+          },
+        },
+        {
           label: i18next.t('menu:insert.dropCapBefore'),
           accelerator: 'CmdOrCtrl+D',
           click() {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1445,6 +1445,12 @@ function createMenu() {
       label: i18next.t('menu:insert.root'),
       submenu: [
         {
+          label: i18next.t('menu:insert.alternateLine'),
+          click() {
+            win?.webContents.send(IpcMainChannels.FileMenuInsertAlternateLine);
+          },
+        },
+        {
           label: i18next.t('menu:insert.annotation'),
           click() {
             win?.webContents.send(IpcMainChannels.FileMenuInsertAnnotation);

--- a/src/components/AlternateLine.vue
+++ b/src/components/AlternateLine.vue
@@ -1,0 +1,101 @@
+<template>
+  <div
+    class="alternate-line-container"
+    :style="style"
+    @mousedown="handleMouseDown"
+    @dblclick="handleDoubleClick"
+  >
+    <template v-for="(element, index) in element.elements" :key="index">
+      <NeumeBoxSyllable
+        v-if="element.elementType === ElementType.Note"
+        class="syllable-box"
+        :note="element"
+        :pageSetup="pageSetup"
+        :alternateLine="true"
+      />
+      <NeumeBoxEmpty
+        v-else-if="element.elementType === ElementType.Empty"
+        class="empty-neume-box"
+      />
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-facing-decorator';
+
+import { AlternateLineElement, ElementType } from '@/models/Element';
+import { PageSetup } from '@/models/PageSetup';
+import { withZoom } from '@/utils/withZoom';
+
+import NeumeBoxEmpty from './NeumeBoxEmpty.vue';
+import NeumeBoxSyllable from './NeumeBoxSyllable.vue';
+
+@Component({
+  components: {
+    NeumeBoxEmpty,
+    NeumeBoxSyllable,
+  },
+  emits: ['update'],
+})
+export default class Annotation extends Vue {
+  @Prop({ required: true }) element!: AlternateLineElement;
+  @Prop({ required: true }) pageSetup!: PageSetup;
+
+  ElementType = ElementType;
+
+  startX: number = 0;
+  startY: number = 0;
+
+  get style() {
+    return {
+      left: withZoom(this.element.x),
+      top: withZoom(this.element.y),
+    };
+  }
+
+  beforeDestroy() {
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('mousemove', this.handleMouseMove);
+  }
+
+  async handleDoubleClick() {
+    // TODO
+  }
+
+  handleMouseDown(e: MouseEvent) {
+    this.startX = e.clientX - this.element.x;
+    this.startY = e.clientY - this.element.y;
+
+    document.addEventListener('mouseup', this.handleMouseUp);
+    document.addEventListener('mousemove', this.handleMouseMove);
+  }
+
+  handleMouseMove(e: MouseEvent) {
+    e.preventDefault();
+
+    this.element.x = e.clientX - this.startX;
+    this.element.y = e.clientY - this.startY;
+  }
+
+  handleMouseUp() {
+    const { x, y } = this.element;
+    this.$emit('update', { x, y });
+
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('mousemove', this.handleMouseMove);
+  }
+}
+</script>
+
+<style scoped>
+.alternate-line-container {
+  position: absolute;
+  white-space: nowrap;
+  z-index: 1000;
+  cursor: default;
+  min-width: 10px;
+  min-height: 10px;
+  display: flex;
+}
+</style>

--- a/src/components/AlternateLine.vue
+++ b/src/components/AlternateLine.vue
@@ -39,8 +39,8 @@ export default class Annotation extends Vue {
 
   ElementType = ElementType;
 
-  startX: number = 0;
-  startY: number = 0;
+  offsetX: number = 0;
+  offsetY: number = 0;
 
   zoom: number = 1;
 
@@ -62,8 +62,12 @@ export default class Annotation extends Vue {
     // to avoid recalculating it on every mouse move
     this.zoom = Number(getComputedStyle(this.$el).getPropertyValue('--zoom'));
 
-    this.startX = e.clientX / this.zoom - this.element.x;
-    this.startY = e.clientY / this.zoom - this.element.y;
+    const draggedEl = this.$el as HTMLElement;
+    const rect = draggedEl.getBoundingClientRect();
+
+    // Calculate the offset of the mouse click relative to the element
+    this.offsetX = e.clientX - rect.left;
+    this.offsetY = e.clientY - rect.top;
 
     document.addEventListener('mouseup', this.handleMouseUp);
     document.addEventListener('mousemove', this.handleMouseMove);
@@ -72,8 +76,42 @@ export default class Annotation extends Vue {
   handleMouseMove(e: MouseEvent) {
     e.preventDefault();
 
-    this.element.x = e.clientX / this.zoom - this.startX;
-    this.element.y = e.clientY / this.zoom - this.startY;
+    const draggedEl = this.$el as HTMLElement;
+    const pageEl = draggedEl.closest('.page') as HTMLElement;
+    if (!draggedEl || !pageEl) {
+      console.warn('Could not find dragged element or page element');
+      return;
+    }
+
+    const elRect = draggedEl.getBoundingClientRect();
+    const pageRect = pageEl.getBoundingClientRect();
+
+    const elWidth = elRect.width;
+    const elHeight = elRect.height;
+
+    // Compute desired top-left corner of element in viewport space
+    const desiredLeft = e.clientX - this.offsetX;
+    const desiredTop = e.clientY - this.offsetY;
+
+    // Clamp those values to page bounds
+    const clampedLeft = Math.max(
+      pageRect.left,
+      Math.min(desiredLeft, pageRect.right - elWidth),
+    );
+    const clampedTop = Math.max(
+      pageRect.top,
+      Math.min(desiredTop, pageRect.bottom - elHeight),
+    );
+
+    // Convert clamped screen coords into coordinates relative to the element's offsetParent
+    const offsetParent = draggedEl.offsetParent as HTMLElement;
+    const parentRect = offsetParent.getBoundingClientRect();
+
+    const newX = clampedLeft - parentRect.left;
+    const newY = clampedTop - parentRect.top;
+
+    this.element.x = newX / this.zoom;
+    this.element.y = newY / this.zoom;
   }
 
   handleMouseUp() {

--- a/src/components/Annotation.vue
+++ b/src/components/Annotation.vue
@@ -1,0 +1,196 @@
+<template>
+  <div
+    class="annotation-container"
+    :style="style"
+    @mousedown="handleMouseDown"
+    @dblclick="handleDoubleClick"
+  >
+    <ckeditor
+      ref="editor"
+      class="rich-text-editor"
+      :editor="editor"
+      :model-value="element.text"
+      :config="editorConfig"
+      @ready="onEditorReady"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
+import { EditorConfig, FontSizeOption } from 'ckeditor5';
+import { ComponentExposed } from 'vue-component-type-helpers';
+import { Component, Prop, Vue } from 'vue-facing-decorator';
+
+import ContentEditable from '@/components/ContentEditable.vue';
+import InlineEditor from '@/customEditor';
+import { AnnotationElement } from '@/models/Element';
+import { PageSetup } from '@/models/PageSetup';
+import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
+import { withZoom } from '@/utils/withZoom';
+
+const STAFF_TEXT_LOCK_ID = 'staff-text-ro-lock';
+
+@Component({
+  components: {
+    Ckeditor,
+    ContentEditable,
+  },
+  emits: ['update', 'delete'],
+})
+export default class Annotation extends Vue {
+  @Prop({ required: true }) element!: AnnotationElement;
+  @Prop({ required: true }) pageSetup!: PageSetup;
+  @Prop({ required: true }) fonts!: string[];
+
+  editable: boolean = false;
+
+  startX: number = 0;
+  startY: number = 0;
+
+  editor = InlineEditor;
+
+  get textElement() {
+    return this.$refs.text as ContentEditable;
+  }
+
+  get style() {
+    return {
+      left: withZoom(this.element.x),
+      top: withZoom(this.element.y),
+      '--ck-content-font-family': getFontFamilyWithFallback(
+        this.pageSetup.textBoxDefaultFontFamily,
+        this.pageSetup.neumeDefaultFontFamily,
+      ),
+      '--ck-content-font-size': `${this.pageSetup.lyricsDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
+      '--ck-content-line-height': 'normal',
+    };
+  }
+
+  get editorConfig(): EditorConfig {
+    const fontSizeOptions: FontSizeOption[] = [];
+
+    for (let i = 8; i <= 72; i++) {
+      fontSizeOptions.push({
+        title: `${i}`,
+        model: `${i}pt`,
+      });
+    }
+
+    // Add a fall back font to each font so that neumes "just work"
+    const fonts = this.fonts.map(
+      (x) => x + ',' + this.pageSetup.neumeDefaultFontFamily,
+    );
+
+    return {
+      fontFamily: {
+        options: [
+          'default',
+          'Source Serif' + ',' + this.pageSetup.neumeDefaultFontFamily,
+          'GFS Didot' + ',' + this.pageSetup.neumeDefaultFontFamily,
+          'Noto Naskh Arabic' + ',' + this.pageSetup.neumeDefaultFontFamily,
+          'Old Standard' + ',' + this.pageSetup.neumeDefaultFontFamily,
+          'Omega' + ',' + this.pageSetup.neumeDefaultFontFamily,
+          'Neanes',
+          'NeanesStathisSeries',
+          ...fonts,
+        ],
+      },
+      fontSize: {
+        supportAllValues: true,
+        options: ['default', ...fontSizeOptions],
+      },
+      // TODO support rtl
+      // language: {
+      //   content: this.element.rtl ? 'ar' : 'en',
+      // },
+      licenseKey: 'GPL',
+      insertNeume: {
+        neumeDefaultFontFamily: this.pageSetup.neumeDefaultFontFamily,
+        defaultFontSize: this.pageSetup.lyricsDefaultFontSize,
+        defaultFontFamily: this.pageSetup.lyricsDefaultFontFamily,
+        fthoraDefaultColor: this.pageSetup.fthoraDefaultColor,
+      },
+    };
+  }
+
+  beforeDestroy() {
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('mousemove', this.handleMouseMove);
+  }
+
+  getEditorInstance() {
+    return (this.$refs.editor as ComponentExposed<typeof Ckeditor>)?.instance;
+  }
+
+  onEditorReady(editor: InlineEditor) {
+    editor.enableReadOnlyMode(STAFF_TEXT_LOCK_ID);
+
+    editor.ui.focusTracker.on('change:isFocused', (evt, name, isFocused) => {
+      if (!isFocused) {
+        editor.enableReadOnlyMode(STAFF_TEXT_LOCK_ID);
+
+        const text = editor.getData();
+
+        if (this.element.text !== text) {
+          if (text === '') {
+            this.$emit('delete');
+          } else {
+            this.element.text = text;
+          }
+
+          this.$emit('update', { text });
+        }
+      }
+    });
+  }
+
+  async handleDoubleClick() {
+    const editor = this.getEditorInstance();
+
+    if (editor == null) {
+      return;
+    }
+
+    if (editor.isReadOnly) {
+      editor.disableReadOnlyMode(STAFF_TEXT_LOCK_ID);
+      editor.editing.view.focus();
+    }
+  }
+
+  handleMouseDown(e: MouseEvent) {
+    if (this.getEditorInstance()?.isReadOnly === false) {
+      return;
+    }
+
+    this.startX = e.clientX - this.element.x;
+    this.startY = e.clientY - this.element.y;
+
+    document.addEventListener('mouseup', this.handleMouseUp);
+    document.addEventListener('mousemove', this.handleMouseMove);
+  }
+
+  handleMouseMove(e: MouseEvent) {
+    e.preventDefault();
+
+    this.element.x = e.clientX - this.startX;
+    this.element.y = e.clientY - this.startY;
+  }
+
+  handleMouseUp() {
+    const { x, y } = this.element;
+    this.$emit('update', { x, y });
+
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('mousemove', this.handleMouseMove);
+  }
+}
+</script>
+
+<style scoped>
+.annotation-container {
+  position: absolute;
+  white-space: nowrap;
+  z-index: 1000;
+}
+</style>

--- a/src/components/Annotation.vue
+++ b/src/components/Annotation.vue
@@ -44,6 +44,8 @@ export default class Annotation extends Vue {
   startX: number = 0;
   startY: number = 0;
 
+  zoom: number = 1;
+
   editor = InlineEditor;
 
   get style() {
@@ -184,8 +186,12 @@ export default class Annotation extends Vue {
       return;
     }
 
-    this.startX = e.clientX - this.element.x;
-    this.startY = e.clientY - this.element.y;
+    // We only calculate zoom once when the mouse is pressed down
+    // to avoid recalculating it on every mouse move
+    this.zoom = Number(getComputedStyle(this.$el).getPropertyValue('--zoom'));
+
+    this.startX = e.clientX / this.zoom - this.element.x;
+    this.startY = e.clientY / this.zoom - this.element.y;
 
     document.addEventListener('mouseup', this.handleMouseUp);
     document.addEventListener('mousemove', this.handleMouseMove);
@@ -194,8 +200,8 @@ export default class Annotation extends Vue {
   handleMouseMove(e: MouseEvent) {
     e.preventDefault();
 
-    this.element.x = e.clientX - this.startX;
-    this.element.y = e.clientY - this.startY;
+    this.element.x = e.clientX / this.zoom - this.startX;
+    this.element.y = e.clientY / this.zoom - this.startY;
   }
 
   handleMouseUp() {

--- a/src/components/Annotation.vue
+++ b/src/components/Annotation.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="annotation-container"
+    :class="{ selectedAnnotation: selected }"
     :style="style"
     @mousedown="handleMouseDown"
     @dblclick="handleDoubleClick"
@@ -40,6 +41,7 @@ export default class Annotation extends Vue {
   @Prop({ required: true }) element!: AnnotationElement;
   @Prop({ required: true }) pageSetup!: PageSetup;
   @Prop({ required: true }) fonts!: string[];
+  @Prop({ default: false }) selected!: boolean;
 
   offsetX: number = 0;
   offsetY: number = 0;
@@ -259,14 +261,19 @@ export default class Annotation extends Vue {
   z-index: 1000;
   cursor: default;
   padding: 0 10px;
+  transform-origin: 0 0;
+  transform: scale(var(--zoom, 1));
+}
+
+.selectedAnnotation {
+  outline: 1px solid goldenrod;
 }
 
 .rich-text-editor {
   padding: 0;
   box-sizing: border-box;
   overflow: visible;
-  transform-origin: 0 0;
-  transform: scale(var(--zoom, 1));
+
   border: none !important;
 }
 

--- a/src/components/Annotation.vue
+++ b/src/components/Annotation.vue
@@ -22,7 +22,6 @@ import { EditorConfig, FontSizeOption } from 'ckeditor5';
 import { ComponentExposed } from 'vue-component-type-helpers';
 import { Component, Prop, Vue } from 'vue-facing-decorator';
 
-import ContentEditable from '@/components/ContentEditable.vue';
 import InlineEditor from '@/customEditor';
 import { AnnotationElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
@@ -34,7 +33,6 @@ const ANNOTATION_LOCK_ID = 'ANNOTATION_LOCK_ID';
 @Component({
   components: {
     Ckeditor,
-    ContentEditable,
   },
   emits: ['update', 'delete'],
 })
@@ -43,16 +41,10 @@ export default class Annotation extends Vue {
   @Prop({ required: true }) pageSetup!: PageSetup;
   @Prop({ required: true }) fonts!: string[];
 
-  editable: boolean = false;
-
   startX: number = 0;
   startY: number = 0;
 
   editor = InlineEditor;
-
-  get textElement() {
-    return this.$refs.text as ContentEditable;
-  }
 
   get style() {
     return {

--- a/src/components/Annotation.vue
+++ b/src/components/Annotation.vue
@@ -111,6 +111,27 @@ export default class Annotation extends Vue {
         defaultFontFamily: this.pageSetup.lyricsDefaultFontFamily,
         fthoraDefaultColor: this.pageSetup.fthoraDefaultColor,
       },
+      toolbar: {
+        items: [
+          'fontFamily',
+          'fontSize',
+          '|',
+          'bold',
+          'italic',
+          'underline',
+          '|',
+          'fontColor',
+          '|',
+          'link',
+          '|',
+          'removeFormat',
+          '|',
+          'insertNeume',
+          'insertMartyria',
+          'insertPlagal',
+        ],
+        shouldNotGroupWhenFull: true,
+      },
     };
   }
 
@@ -132,17 +153,18 @@ export default class Annotation extends Vue {
 
         const text = editor.getData();
 
-        if (this.element.text !== text) {
-          if (text === '') {
-            this.$emit('delete');
-          } else {
-            this.element.text = text;
-          }
-
+        if (text.trim() === '') {
+          this.$emit('delete');
+        } else if (this.element.text !== text) {
           this.$emit('update', { text });
         }
       }
     });
+
+    const toolbarEl = editor.ui.view.toolbar.element;
+    if (toolbarEl) {
+      toolbarEl.style.maxWidth = '400px';
+    }
   }
 
   async handleDoubleClick() {
@@ -192,5 +214,27 @@ export default class Annotation extends Vue {
   position: absolute;
   white-space: nowrap;
   z-index: 1000;
+  cursor: default;
+}
+
+.rich-text-editor {
+  padding: 0;
+  box-sizing: border-box;
+  overflow: visible;
+  transform-origin: 0 0;
+  transform: scale(var(--zoom, 1));
+  border: none !important;
+}
+
+:deep(p) {
+  margin: 0;
+}
+
+.ck.ck-editor__editable_inline > *:first-child {
+  margin-top: 0;
+}
+
+.ck.ck-editor__editable_inline > *:last-child {
+  margin-bottom: 0;
 }
 </style>

--- a/src/components/Annotation.vue
+++ b/src/components/Annotation.vue
@@ -29,7 +29,7 @@ import { PageSetup } from '@/models/PageSetup';
 import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
 import { withZoom } from '@/utils/withZoom';
 
-const STAFF_TEXT_LOCK_ID = 'staff-text-ro-lock';
+const ANNOTATION_LOCK_ID = 'ANNOTATION_LOCK_ID';
 
 @Component({
   components: {
@@ -145,11 +145,18 @@ export default class Annotation extends Vue {
   }
 
   onEditorReady(editor: InlineEditor) {
-    editor.enableReadOnlyMode(STAFF_TEXT_LOCK_ID);
+    // If the text is empty, we want to focus the editor
+    // because this is a new annotation
+    if (this.element.text.trim() === '') {
+      editor.editing.view.focus();
+    } else {
+      // Otherwise, we want to enable read-only mode
+      editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
+    }
 
     editor.ui.focusTracker.on('change:isFocused', (evt, name, isFocused) => {
       if (!isFocused) {
-        editor.enableReadOnlyMode(STAFF_TEXT_LOCK_ID);
+        editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
 
         const text = editor.getData();
 
@@ -175,7 +182,7 @@ export default class Annotation extends Vue {
     }
 
     if (editor.isReadOnly) {
-      editor.disableReadOnlyMode(STAFF_TEXT_LOCK_ID);
+      editor.disableReadOnlyMode(ANNOTATION_LOCK_ID);
       editor.editing.view.focus();
     }
   }
@@ -215,6 +222,7 @@ export default class Annotation extends Vue {
   white-space: nowrap;
   z-index: 1000;
   cursor: default;
+  padding: 0 10px;
 }
 
 .rich-text-editor {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1491,20 +1491,6 @@ export default class Editor extends Vue {
   workspaces: Workspace[] = [];
   selectedWorkspaceValue: Workspace = new Workspace();
 
-  // TODO remove
-  DEBUG_add_staff_text() {
-    if (this.selectedElement?.elementType === ElementType.Note) {
-      const el = new AnnotationElement();
-      const fontHeight = TextMeasurementService.getFontHeight(
-        this.score.pageSetup.lyricsFont,
-      );
-      el.x = 0;
-      el.y = -fontHeight;
-      (this.selectedElement as NoteElement).annotations.push(el);
-      this.save();
-    }
-  }
-
   get selectedWorkspaceId() {
     return this.selectedWorkspace.id;
   }
@@ -2431,6 +2417,10 @@ export default class Editor extends Vue {
       this.onFileMenuPreferences,
     );
     EventBus.$on(
+      IpcMainChannels.FileMenuInsertAnnotation,
+      this.onFileMenuInsertAnnotation,
+    );
+    EventBus.$on(
       IpcMainChannels.FileMenuInsertTextBox,
       this.onFileMenuInsertTextBox,
     );
@@ -2542,6 +2532,10 @@ export default class Editor extends Vue {
     EventBus.$off(
       IpcMainChannels.FileMenuPreferences,
       this.onFileMenuPreferences,
+    );
+    EventBus.$off(
+      IpcMainChannels.FileMenuInsertAnnotation,
+      this.onFileMenuInsertAnnotation,
     );
     EventBus.$off(
       IpcMainChannels.FileMenuInsertTextBox,
@@ -6961,6 +6955,19 @@ export default class Editor extends Vue {
     }
   }
 
+  onFileMenuInsertAnnotation() {
+    if (this.selectedElement?.elementType === ElementType.Note) {
+      const el = new AnnotationElement();
+      const fontHeight = TextMeasurementService.getFontHeight(
+        this.score.pageSetup.lyricsFont,
+      );
+      el.x = 0;
+      el.y = -fontHeight;
+      (this.selectedElement as NoteElement).annotations.push(el);
+      this.save();
+    }
+  }
+
   onFileMenuInsertTextBox(args?: FileMenuInsertTextboxArgs) {
     const element = new TextBoxElement();
     element.inline = args?.inline ?? false;
@@ -7915,6 +7922,7 @@ export default class Editor extends Vue {
 .page.print .drop-cap-container,
 .page.print .mode-key-container,
 .page.print .image-box-container,
+.page.print .selectedAnnotation,
 .page.print :deep(.text-box),
 .page.print :deep(.rich-text-editor),
 .page.print :deep(.inline-container),

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -252,12 +252,6 @@
                               .selectedAlternateLineElement === alternateLine,
                         }"
                         @update="updateAlternateLine(alternateLine, $event)"
-                        @delete="
-                          removeAlternateLine(
-                            element as NoteElement,
-                            alternateLine,
-                          )
-                        "
                         @mousedown="
                           setSelectedAlternateLine(element, alternateLine)
                         "
@@ -2904,10 +2898,11 @@ export default class Editor extends Vue {
     // and return immediately. Alternate lines do not support
     // different entry modes.
     if (this.selectedWorkspace.selectedAlternateLineElement != null) {
-      this.selectedWorkspace.selectedAlternateLineElement.elements.push(
+      this.addScoreElement(
         element,
+        this.selectedWorkspace.selectedAlternateLineElement.elements.length,
+        this.selectedWorkspace.selectedAlternateLineElement.elements,
       );
-
       this.save();
       return;
     }
@@ -5214,10 +5209,8 @@ export default class Editor extends Vue {
   addScoreElement(
     element: ScoreElement,
     insertAtIndex?: number,
-    collection?: ScoreElement[],
+    collection: ScoreElement[] = this.elements,
   ) {
-    collection = collection ?? this.elements;
-
     this.commandService.execute(
       this.scoreElementCommandFactory.create('add-to-collection', {
         elements: [element],
@@ -7359,8 +7352,11 @@ export default class Editor extends Vue {
 
     if (currentIndex > -1) {
       // If the selected element was removed during the undo process, choose a new one
-      this.selectedElement =
-        this.elements[Math.min(currentIndex, this.elements.length - 1)];
+      const clampedIndex = Math.min(currentIndex, this.elements.length - 1);
+
+      if (this.selectedElement !== this.elements[clampedIndex]) {
+        this.selectedElement = this.elements[clampedIndex];
+      }
 
       // Undo/redo could affect the note display in the neume toolbar (among other things),
       // so we force a refresh here
@@ -7396,8 +7392,11 @@ export default class Editor extends Vue {
 
     if (currentIndex > -1) {
       // If the selected element was removed during the redo process, choose a new one
-      this.selectedElement =
-        this.elements[Math.min(currentIndex, this.elements.length - 1)];
+      const clampedIndex = Math.min(currentIndex, this.elements.length - 1);
+
+      if (this.selectedElement !== this.elements[clampedIndex]) {
+        this.selectedElement = this.elements[clampedIndex];
+      }
 
       // Undo/redo could affect the note display in the neume toolbar (among other things),
       // so we force a refresh here

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -247,7 +247,7 @@
                         :element="alternateLine"
                         :pageSetup="score.pageSetup"
                         :class="{
-                          selectedAnnotation:
+                          selectedAlternateLine:
                             this.selectedWorkspace
                               .selectedAlternateLineElement === alternateLine,
                         }"
@@ -263,11 +263,10 @@
                         :element="annotation"
                         :pageSetup="score.pageSetup"
                         :fonts="fonts"
-                        :class="{
-                          selectedAnnotation:
-                            this.selectedWorkspace.selectedAnnotationElement ===
-                            annotation,
-                        }"
+                        :selected="
+                          this.selectedWorkspace.selectedAnnotationElement ===
+                          annotation
+                        "
                         @update="updateAnnotation(annotation, $event)"
                         @delete="
                           removeAnnotation(
@@ -7860,7 +7859,7 @@ export default class Editor extends Vue {
   border: 1px solid goldenrod;
 }
 
-.selectedAnnotation {
+.selectedAlternateLine {
   outline: 1px solid goldenrod;
 }
 
@@ -7981,7 +7980,7 @@ export default class Editor extends Vue {
   margin-right: auto;
 
   background-color: white;
-  overflow: hidden;
+  overflow: clip;
 
   position: relative;
 }
@@ -8156,6 +8155,7 @@ export default class Editor extends Vue {
 .page.print .mode-key-container,
 .page.print .image-box-container,
 .page.print .selectedAnnotation,
+.page.print .selectedAlternateLine,
 .page.print :deep(.text-box),
 .page.print :deep(.rich-text-editor),
 .page.print :deep(.inline-container),

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -6964,6 +6964,7 @@ export default class Editor extends Vue {
       el.x = 0;
       el.y = -fontHeight;
       (this.selectedElement as NoteElement).annotations.push(el);
+      this.selectedWorkspace.selectedAnnotationElement = el;
       this.save();
     }
   }

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -239,6 +239,29 @@
                           v-else
                           src="@/assets/icons/line-break.svg"
                       /></span>
+                      <AlternateLine
+                        v-for="(alternateLine, index) in (
+                          element as NoteElement
+                        ).alternateLines"
+                        :key="index"
+                        :element="alternateLine"
+                        :pageSetup="score.pageSetup"
+                        :class="{
+                          selectedAnnotation:
+                            this.selectedWorkspace
+                              .selectedAlternateLineElement === alternateLine,
+                        }"
+                        @update="updateAlternateLine(alternateLine, $event)"
+                        @delete="
+                          removeAlternateLine(
+                            element as NoteElement,
+                            alternateLine,
+                          )
+                        "
+                        @mousedown="
+                          setSelectedAlternateLine(element, alternateLine)
+                        "
+                      />
                       <Annotation
                         v-for="(annotation, index) in (element as NoteElement)
                           .annotations"
@@ -253,7 +276,11 @@
                         }"
                         @update="updateAnnotation(annotation, $event)"
                         @delete="
-                          removeAnnotation(element as NoteElement, annotation)
+                          removeAnnotation(
+                            element as NoteElement,
+                            annotation,
+                            true,
+                          )
                         "
                         @mousedown="setSelectedAnnotation(element, annotation)"
                       />
@@ -1013,86 +1040,153 @@
       />
     </template>
     <template
-      v-if="selectedElement != null && isSyllableElement(selectedElement)"
+      v-if="
+        selectedElement != null &&
+        selectedElementForNeumeToolbar != null &&
+        isSyllableElement(selectedElementForNeumeToolbar)
+      "
     >
       <ToolbarNeume
-        :element="selectedElement"
+        :element="selectedElementForNeumeToolbar"
         :pageSetup="score.pageSetup"
         :neumeKeyboard="neumeKeyboard"
         :key="`toolbar-neume-${this.selectedWorkspaceId}-${selectedElement.id}-${selectedElement.keyHelper}`"
         :innerNeume="toolbarInnerNeume"
         @update:innerNeume="toolbarInnerNeume = $event"
         @update:accidental="
-          setAccidental(selectedElement as NoteElement, $event)
+          setAccidental(selectedElementForNeumeToolbar as NoteElement, $event)
         "
         @update:secondaryAccidental="
-          setSecondaryAccidental(selectedElement as NoteElement, $event)
+          setSecondaryAccidental(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:tertiaryAccidental="
-          setTertiaryAccidental(selectedElement as NoteElement, $event)
+          setTertiaryAccidental(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
-        @update:fthora="setFthoraNote(selectedElement as NoteElement, $event)"
+        @update:fthora="
+          setFthoraNote(selectedElementForNeumeToolbar as NoteElement, $event)
+        "
         @update:secondaryFthora="
-          setSecondaryFthora(selectedElement as NoteElement, $event)
+          setSecondaryFthora(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:tertiaryFthora="
-          setTertiaryFthora(selectedElement as NoteElement, $event)
+          setTertiaryFthora(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:chromaticFthoraNote="
-          updateNoteChromaticFthoraNote(selectedElement as NoteElement, $event)
+          updateNoteChromaticFthoraNote(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:secondaryChromaticFthoraNote="
           updateNoteSecondaryChromaticFthoraNote(
-            selectedElement as NoteElement,
+            selectedElementForNeumeToolbar as NoteElement,
             $event,
           )
         "
         @update:tertiaryChromaticFthoraNote="
           updateNoteTertiaryChromaticFthoraNote(
-            selectedElement as NoteElement,
+            selectedElementForNeumeToolbar as NoteElement,
             $event,
           )
         "
-        @update:gorgon="setGorgon(selectedElement as NoteElement, $event)"
-        @update:secondaryGorgon="
-          setSecondaryGorgon(selectedElement as NoteElement, $event)
+        @update:gorgon="
+          setGorgon(selectedElementForNeumeToolbar as NoteElement, $event)
         "
-        @update:klasma="setKlasma(selectedElement as NoteElement)"
-        @update:time="setTimeNeume(selectedElement as NoteElement, $event)"
+        @update:secondaryGorgon="
+          setSecondaryGorgon(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
+        "
+        @update:klasma="
+          setKlasma(selectedElementForNeumeToolbar as NoteElement)
+        "
+        @update:time="
+          setTimeNeume(selectedElementForNeumeToolbar as NoteElement, $event)
+        "
         @update:expression="
-          setVocalExpression(selectedElement as NoteElement, $event)
+          setVocalExpression(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:measureBar="
-          setMeasureBarNote(selectedElement as NoteElement, $event)
+          setMeasureBarNote(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:measureNumber="
-          setMeasureNumber(selectedElement as NoteElement, $event)
+          setMeasureNumber(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:noteIndicator="
-          updateNoteNoteIndicator(selectedElement as NoteElement, $event)
+          updateNoteNoteIndicator(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
-        @update:ison="setIson(selectedElement as NoteElement, $event)"
+        @update:ison="
+          setIson(selectedElementForNeumeToolbar as NoteElement, $event)
+        "
         @update:koronis="
-          updateNoteKoronis(selectedElement as NoteElement, $event)
+          updateNoteKoronis(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:stavros="
-          updateNoteStavros(selectedElement as NoteElement, $event)
+          updateNoteStavros(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:vareia="
-          updateNoteVareia(selectedElement as NoteElement, $event)
+          updateNoteVareia(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
-        @update:tie="setTie(selectedElement as NoteElement, $event)"
+        @update:tie="
+          setTie(selectedElementForNeumeToolbar as NoteElement, $event)
+        "
         @update:spaceAfter="
-          updateNoteSpaceAfter(selectedElement as NoteElement, $event)
+          updateNoteSpaceAfter(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:ignoreAttractions="
-          updateNoteIgnoreAttractions(selectedElement as NoteElement, $event)
+          updateNoteIgnoreAttractions(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:acceptsLyrics="
-          updateNoteAcceptsLyrics(selectedElement as NoteElement, $event)
+          updateNoteAcceptsLyrics(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @update:sectionName="
-          updateScoreElementSectionName(selectedElement as NoteElement, $event)
+          updateScoreElementSectionName(
+            selectedElementForNeumeToolbar as NoteElement,
+            $event,
+          )
         "
         @open-syllable-positioning-dialog="openSyllablePositioningDialog"
       />
@@ -1282,6 +1376,7 @@ import { nextTick, StyleValue, toRaw } from 'vue';
 import { Component, Inject, Prop, Vue, Watch } from 'vue-facing-decorator';
 import Vue3TabsChrome, { Tab } from 'vue3-tabs-chrome';
 
+import AlternateLine from '@/components/AlternateLine.vue';
 import Annotation from '@/components/Annotation.vue';
 import ContentEditable from '@/components/ContentEditable.vue';
 import DropCap from '@/components/DropCap.vue';
@@ -1334,6 +1429,7 @@ import {
 import { EditorPreferences } from '@/models/EditorPreferences';
 import {
   AcceptsLyricsOption,
+  AlternateLineElement,
   AnnotationElement,
   DropCapElement,
   ElementType,
@@ -1426,6 +1522,7 @@ interface Vue3TabsChromeComponent {
 
 @Component({
   components: {
+    AlternateLine,
     Annotation,
     SyllableNeumeBox,
     MartyriaNeumeBox,
@@ -1593,6 +1690,9 @@ export default class Editor extends Vue {
 
   annotationCommandFactory: CommandFactory<AnnotationElement> =
     new CommandFactory<AnnotationElement>();
+
+  alternateLineCommandFactory: CommandFactory<AlternateLineElement> =
+    new CommandFactory<AlternateLineElement>();
 
   textBoxCommandFactory: CommandFactory<TextBoxElement> =
     new CommandFactory<TextBoxElement>();
@@ -1904,8 +2004,32 @@ export default class Editor extends Vue {
       }
     }
 
+    if (
+      this.selectedWorkspace.selectedAlternateLineElement != null &&
+      this.selectedWorkspace.selectedAlternateLineElement.elements.length === 0
+    ) {
+      this.removeAlternateLine(
+        this.selectedElement as NoteElement,
+        this.selectedWorkspace.selectedAlternateLineElement,
+        true,
+      );
+    }
+
     this.selectedWorkspace.selectedElement = element;
     this.selectedWorkspace.selectedAnnotationElement = null;
+    this.selectedWorkspace.selectedAlternateLineElement = null;
+  }
+
+  get selectedElementForNeumeToolbar() {
+    if (
+      this.selectedWorkspace.selectedAlternateLineElement != null &&
+      this.selectedWorkspace.selectedAlternateLineElement.elements.length > 0
+    ) {
+      return this.selectedWorkspace.selectedAlternateLineElement.elements[
+        this.selectedWorkspace.selectedAlternateLineElement.elements.length - 1
+      ];
+    }
+    return this.selectedWorkspace.selectedElement;
   }
 
   get previousElementOnLine() {
@@ -2421,6 +2545,10 @@ export default class Editor extends Vue {
       this.onFileMenuInsertAnnotation,
     );
     EventBus.$on(
+      IpcMainChannels.FileMenuInsertAlternateLine,
+      this.onFileMenuInsertAlternateLine,
+    );
+    EventBus.$on(
       IpcMainChannels.FileMenuInsertTextBox,
       this.onFileMenuInsertTextBox,
     );
@@ -2538,6 +2666,10 @@ export default class Editor extends Vue {
       this.onFileMenuInsertAnnotation,
     );
     EventBus.$off(
+      IpcMainChannels.FileMenuInsertAlternateLine,
+      this.onFileMenuInsertAlternateLine,
+    );
+    EventBus.$off(
       IpcMainChannels.FileMenuInsertTextBox,
       this.onFileMenuInsertTextBox,
     );
@@ -2649,6 +2781,14 @@ export default class Editor extends Vue {
     this.selectedWorkspace.selectedAnnotationElement = annotation;
   }
 
+  setSelectedAlternateLine(
+    parent: ScoreElement | null,
+    alternateLine: AlternateLineElement,
+  ) {
+    this.selectedElement = parent;
+    this.selectedWorkspace.selectedAlternateLineElement = alternateLine;
+  }
+
   isAudioSelected(element: ScoreElement) {
     return this.audioElement === element;
   }
@@ -2757,6 +2897,19 @@ export default class Editor extends Vue {
     // Special case for neumes with secondary gorgon
     if (getSecondaryNeume(quantitativeNeume) != null) {
       element.secondaryGorgonNeume = secondaryGorgonNeume;
+    }
+
+    // If the selected element is an alternate line element,
+    // add the new element to the alternate line's elements
+    // and return immediately. Alternate lines do not support
+    // different entry modes.
+    if (this.selectedWorkspace.selectedAlternateLineElement != null) {
+      this.selectedWorkspace.selectedAlternateLineElement.elements.push(
+        element,
+      );
+
+      this.save();
+      return;
     }
 
     switch (this.entryMode) {
@@ -5058,11 +5211,17 @@ export default class Editor extends Vue {
     }
   }
 
-  addScoreElement(element: ScoreElement, insertAtIndex?: number) {
+  addScoreElement(
+    element: ScoreElement,
+    insertAtIndex?: number,
+    collection?: ScoreElement[],
+  ) {
+    collection = collection ?? this.elements;
+
     this.commandService.execute(
       this.scoreElementCommandFactory.create('add-to-collection', {
         elements: [element],
-        collection: this.elements,
+        collection,
         insertAtIndex,
       }),
     );
@@ -5094,11 +5253,14 @@ export default class Editor extends Vue {
     this.refreshStaffLyrics();
   }
 
-  removeScoreElement(element: ScoreElement) {
+  removeScoreElement(
+    element: ScoreElement,
+    collection: ScoreElement[] = this.elements,
+  ) {
     this.commandService.execute(
       this.scoreElementCommandFactory.create('remove-from-collection', {
         element,
-        collection: this.elements,
+        collection,
       }),
     );
 
@@ -5540,15 +5702,52 @@ export default class Editor extends Vue {
     this.save();
   }
 
-  removeAnnotation(note: NoteElement, annotation: AnnotationElement) {
+  removeAnnotation(
+    note: NoteElement,
+    annotation: AnnotationElement,
+    noHistory: boolean = false,
+  ) {
     this.commandService.execute(
       this.annotationCommandFactory.create('remove-from-collection', {
         element: annotation,
         collection: note.annotations,
       }),
+      noHistory,
     );
 
     this.selectedWorkspace.selectedAnnotationElement = null;
+
+    this.save();
+  }
+
+  updateAlternateLine(
+    element: AlternateLineElement,
+    newValues: Partial<AlternateLineElement>,
+  ) {
+    this.commandService.execute(
+      this.alternateLineCommandFactory.create('update-properties', {
+        target: element,
+        newValues: newValues,
+      }),
+    );
+
+    this.save();
+  }
+
+  removeAlternateLine(
+    note: NoteElement,
+    annotation: AlternateLineElement,
+    noHistory: boolean = false,
+  ) {
+    this.commandService.execute(
+      this.alternateLineCommandFactory.create('remove-from-collection', {
+        element: annotation,
+        collection: note.alternateLines,
+      }),
+      noHistory,
+    );
+
+    this.selectedWorkspace.selectedAlternateLineElement = null;
 
     this.save();
   }
@@ -6183,6 +6382,18 @@ export default class Editor extends Vue {
     }
 
     if (
+      this.selectedWorkspace.selectedAlternateLineElement != null &&
+      this.selectedElement?.elementType === ElementType.Note
+    ) {
+      this.removeAlternateLine(
+        this.selectedElement as NoteElement,
+        this.selectedWorkspace.selectedAlternateLineElement,
+      );
+
+      return;
+    }
+
+    if (
       this.selectedElement != null &&
       !this.isLastElement(this.selectedElement)
     ) {
@@ -6222,6 +6433,14 @@ export default class Editor extends Vue {
   }
 
   deletePreviousElement() {
+    if (this.selectedWorkspace.selectedAlternateLineElement) {
+      const elements =
+        this.selectedWorkspace.selectedAlternateLineElement.elements;
+      this.removeScoreElement(elements[this.elements.length - 1], elements);
+
+      return;
+    }
+
     if (
       this.selectedElement &&
       this.selectedElementIndex > 0 &&
@@ -6965,6 +7184,20 @@ export default class Editor extends Vue {
       el.y = -fontHeight;
       (this.selectedElement as NoteElement).annotations.push(el);
       this.selectedWorkspace.selectedAnnotationElement = el;
+      this.save();
+    }
+  }
+
+  onFileMenuInsertAlternateLine() {
+    if (this.selectedElement?.elementType === ElementType.Note) {
+      const el = new AlternateLineElement();
+      const fontHeight = TextMeasurementService.getFontHeight(
+        this.score.pageSetup.lyricsFont,
+      );
+      el.x = 0;
+      el.y = -fontHeight;
+      (this.selectedElement as NoteElement).alternateLines.push(el);
+      this.selectedWorkspace.selectedAlternateLineElement = el;
       this.save();
     }
   }

--- a/src/components/NeumeBoxSyllable.vue
+++ b/src/components/NeumeBoxSyllable.vue
@@ -69,7 +69,7 @@
       :style="tertiaryAccidentalStyle"
     />
     <Neume
-      v-if="note.noteIndicator"
+      v-if="note.noteIndicator && note.noteIndicatorNeume"
       :neume="note.noteIndicatorNeume"
       :style="noteIndicatorStyle"
     />

--- a/src/components/NeumeBoxSyllable.vue
+++ b/src/components/NeumeBoxSyllable.vue
@@ -121,6 +121,7 @@ import { withZoom } from '@/utils/withZoom';
 export default class NeumeBoxSyllable extends Vue {
   @Prop() note!: NoteElement;
   @Prop() pageSetup!: PageSetup;
+  @Prop({ default: false }) alternateLine!: boolean;
 
   TimeNeume = TimeNeume;
   VocalExpressionNeume = VocalExpressionNeume;
@@ -214,8 +215,12 @@ export default class NeumeBoxSyllable extends Vue {
   get style() {
     return {
       fontFamily: this.pageSetup.neumeDefaultFontFamily,
-      fontSize: withZoom(this.pageSetup.neumeDefaultFontSize),
-      color: this.pageSetup.neumeDefaultColor,
+      fontSize: this.alternateLine
+        ? withZoom(this.pageSetup.alternateLineDefaultFontSize)
+        : withZoom(this.pageSetup.neumeDefaultFontSize),
+      color: this.alternateLine
+        ? this.pageSetup.alternateLineDefaultColor
+        : this.pageSetup.neumeDefaultColor,
       webkitTextStrokeWidth: withZoom(this.pageSetup.neumeDefaultStrokeWidth),
     } as StyleValue;
   }

--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -1082,6 +1082,30 @@
               </div>
             </div>
 
+            <div class="form-group">
+              <div class="name">
+                {{ $t('dialog:pageSetup.alternateLineStyling') }}
+              </div>
+              <div class="description">
+                {{ $t('dialog:pageSetup.alternateLineDescription') }}
+              </div>
+              <div class="form-group row">
+                <label class="drop-caps-label name">{{
+                  $t('dialog:pageSetup.color')
+                }}</label>
+                <ColorPicker v-model="form.alternateLineDefaultColor" />
+              </div>
+              <div class="form-group">
+                <label class="drop-caps-label name">{{
+                  $t('dialog:pageSetup.size')
+                }}</label>
+                <InputFontSize
+                  class="drop-caps-input"
+                  v-model="form.alternateLineDefaultFontSize"
+                />
+              </div>
+            </div>
+
             <div class="subheader" ref="neumeStylesRef">
               {{ $t('dialog:pageSetup.neumeStyles') }}
             </div>

--- a/src/i18n/el/menu.json
+++ b/src/i18n/el/menu.json
@@ -31,6 +31,7 @@
   },
   "insert": {
     "root": "Εισαγωγή",
+    "annotation": "Επισήμανση",
     "dropCapBefore": "Αρχιγράμμα Πριν",
     "dropCapAfter": "Αρχιγράμμα Μετά",
     "textBox": "Πλαίσιο Κειμένου",

--- a/src/i18n/en/dialog.json
+++ b/src/i18n/en/dialog.json
@@ -112,6 +112,8 @@
     "disableGreekMelismata": "Disable Greek Melismata",
     "disableGreekMelismataDescription": "Prevents automatic use of the Greek melismatic convention, even when Greek text is detected. Useful for languages that use the Greek script but follow different notational conventions.",
     "defaultStyling": "Default Styling",
+    "alternateLineStyling": "Alternate Line Styling",
+    "alternateLineDescription": "The default styling for all alternate lines in the score.",
     "dropCaps": "Drop Caps",
     "dropCapsDescription": "The default styling for all drop caps in the score.",
     "color": "Color",

--- a/src/i18n/en/menu.json
+++ b/src/i18n/en/menu.json
@@ -34,6 +34,7 @@
   },
   "insert": {
     "root": "Insert",
+    "annotation": "Annotation",
     "dropCapBefore": "Drop Cap Before",
     "dropCapAfter": "Drop Cap After",
     "textBox": "Text Box",

--- a/src/i18n/en/menu.json
+++ b/src/i18n/en/menu.json
@@ -34,6 +34,7 @@
   },
   "insert": {
     "root": "Insert",
+    "alternateLine": "Alternate Line",
     "annotation": "Annotation",
     "dropCapBefore": "Drop Cap Before",
     "dropCapAfter": "Drop Cap After",

--- a/src/i18n/ro/menu.json
+++ b/src/i18n/ro/menu.json
@@ -31,6 +31,7 @@
   },
   "insert": {
     "root": "Inserare",
+    "annotation": "Anotare",
     "dropCapBefore": "Majusculă Înainte",
     "dropCapAfter": "Majusculă După",
     "textBox": "Caseta de Text",

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -32,6 +32,7 @@ export enum IpcMainChannels {
 
   FileMenuPreferences = 'FileMenuPreferences',
 
+  FileMenuInsertAnnotation = 'FileMenuInsertAnnotation',
   FileMenuInsertTextBox = 'FileMenuInsertTextBox',
   FileMenuInsertRichTextBox = 'FileMenuInsertRichTextBox',
   FileMenuInsertModeKey = 'FileMenuInsertModeKey',

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -33,6 +33,7 @@ export enum IpcMainChannels {
   FileMenuPreferences = 'FileMenuPreferences',
 
   FileMenuInsertAnnotation = 'FileMenuInsertAnnotation',
+  FileMenuInsertAlternateLine = 'FileMenuInsertAlternateLine',
   FileMenuInsertTextBox = 'FileMenuInsertTextBox',
   FileMenuInsertRichTextBox = 'FileMenuInsertRichTextBox',
   FileMenuInsertModeKey = 'FileMenuInsertModeKey',

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -42,6 +42,7 @@ export enum ElementType {
   DropCap = 'DropCap',
   ModeKey = 'ModeKey',
   ImageBox = 'ImageBox',
+  Annotation = 'Annotation',
 }
 
 export enum LineBreakType {
@@ -118,6 +119,8 @@ export class NoteElement extends ScoreElement {
   public isHyphen: boolean = false;
   public spaceAfter: number = 0;
   public ignoreAttractions: boolean = false;
+
+  public annotations: AnnotationElement[] = [];
 
   public chromaticFthoraNote: ScaleNote | null = null;
   public secondaryChromaticFthoraNote: ScaleNote | null = null;
@@ -1048,6 +1051,27 @@ export class ModeKeyElement extends ScoreElement {
       permanentEnharmonicZo: this.permanentEnharmonicZo,
       showAmbitus: this.showAmbitus,
     } as Partial<ModeKeyElement>;
+  }
+}
+
+export class AnnotationElement extends ScoreElement {
+  public readonly elementType: ElementType = ElementType.Annotation;
+  public x: number = 0;
+  public y: number = 0;
+  public text: string = 'annotation';
+
+  public clone() {
+    const clone = new ModeKeyElement();
+
+    Object.assign(clone, this.getClipboardProperties());
+
+    return clone;
+  }
+
+  public getClipboardProperties() {
+    return {
+      text: this.text,
+    } as Partial<AnnotationElement>;
   }
 }
 

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -1056,8 +1056,6 @@ export class ModeKeyElement extends ScoreElement {
 
 export class AnnotationElement extends ScoreElement {
   public readonly elementType: ElementType = ElementType.Annotation;
-  public x: number = 0;
-  public y: number = 0;
   public text: string = 'annotation';
 
   public clone() {

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -1056,7 +1056,7 @@ export class ModeKeyElement extends ScoreElement {
 
 export class AnnotationElement extends ScoreElement {
   public readonly elementType: ElementType = ElementType.Annotation;
-  public text: string = 'annotation';
+  public text: string = '';
 
   public clone() {
     const clone = new ModeKeyElement();

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -43,6 +43,7 @@ export enum ElementType {
   ModeKey = 'ModeKey',
   ImageBox = 'ImageBox',
   Annotation = 'Annotation',
+  AlternateLine = 'AlternateLine',
 }
 
 export enum LineBreakType {
@@ -121,6 +122,7 @@ export class NoteElement extends ScoreElement {
   public ignoreAttractions: boolean = false;
 
   public annotations: AnnotationElement[] = [];
+  public alternateLines: AlternateLineElement[] = [];
 
   public chromaticFthoraNote: ScaleNote | null = null;
   public secondaryChromaticFthoraNote: ScaleNote | null = null;
@@ -1059,7 +1061,7 @@ export class AnnotationElement extends ScoreElement {
   public text: string = '';
 
   public clone() {
-    const clone = new ModeKeyElement();
+    const clone = new AnnotationElement();
 
     Object.assign(clone, this.getClipboardProperties());
 
@@ -1073,6 +1075,24 @@ export class AnnotationElement extends ScoreElement {
   }
 }
 
+export class AlternateLineElement extends ScoreElement {
+  public readonly elementType: ElementType = ElementType.AlternateLine;
+  public elements: ScoreElement[] = [];
+
+  public clone() {
+    const clone = new AlternateLineElement();
+
+    Object.assign(clone, this.getClipboardProperties());
+
+    return clone;
+  }
+
+  public getClipboardProperties() {
+    return {
+      elements: this.elements.map((note) => note.clone()),
+    } as Partial<AlternateLineElement>;
+  }
+}
 export class DropCapElement extends ScoreElement {
   public readonly elementType: ElementType = ElementType.DropCap;
   public content: string = 'A';

--- a/src/models/PageSetup.ts
+++ b/src/models/PageSetup.ts
@@ -133,6 +133,9 @@ export class PageSetup {
   public neumeDefaultSpacing = Unit.fromInch(0.03);
   public neumeDefaultStrokeWidth = 0;
 
+  public alternateLineDefaultFontSize = Unit.fromPt(12);
+  public alternateLineDefaultColor = '#ED0000';
+
   public modeKeyDefaultColor = '#ED0000';
   public modeKeyDefaultStrokeWidth = 0;
   public modeKeyDefaultFontSize = Unit.fromPt(20);

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { EntryMode } from '@/models/EntryMode';
 import { CommandService } from '@/services/history/CommandService';
 
-import { NoteElement, ScoreElement } from './Element';
+import { AnnotationElement, NoteElement, ScoreElement } from './Element';
 import { Score } from './Score';
 import { ScoreElementSelectionRange } from './ScoreElementSelectionRange';
 
@@ -15,6 +15,7 @@ export class Workspace {
   public hasUnsavedChanges: boolean = false;
   public commandService: CommandService = new CommandService();
   public selectedElement: ScoreElement | null = null;
+  public selectedAnnotationElement: AnnotationElement | null = null;
   public selectedHeaderFooterElement: ScoreElement | null = null;
   public selectedLyrics: NoteElement | null = null;
   public selectionRange: ScoreElementSelectionRange | null = null;

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -3,7 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { EntryMode } from '@/models/EntryMode';
 import { CommandService } from '@/services/history/CommandService';
 
-import { AnnotationElement, NoteElement, ScoreElement } from './Element';
+import {
+  AlternateLineElement,
+  AnnotationElement,
+  NoteElement,
+  ScoreElement,
+} from './Element';
 import { Score } from './Score';
 import { ScoreElementSelectionRange } from './ScoreElementSelectionRange';
 
@@ -16,6 +21,7 @@ export class Workspace {
   public commandService: CommandService = new CommandService();
   public selectedElement: ScoreElement | null = null;
   public selectedAnnotationElement: AnnotationElement | null = null;
+  public selectedAlternateLineElement: AlternateLineElement | null = null;
   public selectedHeaderFooterElement: ScoreElement | null = null;
   public selectedLyrics: NoteElement | null = null;
   public selectionRange: ScoreElementSelectionRange | null = null;

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -29,6 +29,7 @@ export enum ElementType {
   Tempo = 'Tempo',
   ImageBox = 'ImageBox',
   Annotation = 'Annotation',
+  AlternateLine = 'AlternateLine',
 }
 
 export enum LineBreakType {
@@ -98,6 +99,7 @@ export class NoteElement extends ScoreElement {
   public ignoreAttractions: boolean | undefined = undefined;
 
   public annotations: AnnotationElement[] | undefined = undefined;
+  public alternateLines: AlternateLineElement[] | undefined = undefined;
 
   public accidentalOffsetX: number | undefined = undefined;
   public accidentalOffsetY: number | undefined = undefined;
@@ -277,6 +279,13 @@ export class AnnotationElement extends ScoreElement {
   public x: number = 0;
   public y: number = 0;
   public text: string = '';
+}
+
+export class AlternateLineElement extends ScoreElement {
+  public readonly elementType: ElementType = ElementType.AlternateLine;
+  public x: number = 0;
+  public y: number = 0;
+  public elements: ScoreElement[] = [];
 }
 
 export class DropCapElement extends ScoreElement {

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -28,6 +28,7 @@ export enum ElementType {
   ModeKey = 'ModeKey',
   Tempo = 'Tempo',
   ImageBox = 'ImageBox',
+  Annotation = 'Annotation',
 }
 
 export enum LineBreakType {
@@ -95,6 +96,8 @@ export class NoteElement extends ScoreElement {
   public isHyphen: boolean | undefined = undefined;
   public spaceAfter: number | undefined = undefined;
   public ignoreAttractions: boolean | undefined = undefined;
+
+  public annotations: AnnotationElement[] | undefined = undefined;
 
   public accidentalOffsetX: number | undefined = undefined;
   public accidentalOffsetY: number | undefined = undefined;
@@ -267,6 +270,13 @@ export class ModeKeyElement extends ScoreElement {
   public ambitusHighNote: Note = Note.Pa;
   public ambitusHighRootSign: RootSign = RootSign.Alpha;
   public showAmbitus: boolean | undefined = undefined;
+}
+
+export class AnnotationElement extends ScoreElement {
+  public readonly elementType: ElementType = ElementType.Annotation;
+  public x: number = 0;
+  public y: number = 0;
+  public text: string = '';
 }
 
 export class DropCapElement extends ScoreElement {

--- a/src/models/save/v1/PageSetup.ts
+++ b/src/models/save/v1/PageSetup.ts
@@ -68,6 +68,9 @@ export class PageSetup {
   public neumeDefaultSpacing = Unit.fromInch(0.03);
   public neumeDefaultStrokeWidth = 0;
 
+  public alternateLineDefaultFontSize = Unit.fromPt(12);
+  public alternateLineDefaultColor = '#ED0000';
+
   public modeKeyDefaultColor = '#ED0000';
   public modeKeyDefaultStrokeWidth = 0;
   public modeKeyDefaultFontSize = Unit.fromPt(20);

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -1,5 +1,6 @@
 import {
   AcceptsLyricsOption,
+  AnnotationElement,
   DropCapElement,
   ElementType,
   EmptyElement,
@@ -20,6 +21,7 @@ import { modeKeyTemplates } from '@/models/ModeKeys';
 import { QuantitativeNeume } from '@/models/Neumes';
 import { PageSetup, pageSizes } from '@/models/PageSetup';
 import {
+  AnnotationElement as AnnotationElement_v1,
   DropCapElement as DropCapElement_v1,
   ElementType as ElementType_v1,
   EmptyElement as EmptyElement_v1,
@@ -536,6 +538,16 @@ export class SaveService {
 
     if (e.acceptsLyrics !== AcceptsLyricsOption.Default) {
       element.acceptsLyrics = e.acceptsLyrics;
+    }
+
+    if (e.annotations.length > 0) {
+      element.annotations = e.annotations.map((a) => {
+        const annotation = new AnnotationElement_v1();
+        annotation.x = a.x;
+        annotation.y = a.y;
+        annotation.text = a.text;
+        return annotation;
+      });
     }
   }
 
@@ -1326,6 +1338,22 @@ export class SaveService {
       element.acceptsLyrics = e.acceptsLyrics;
     } else {
       element.acceptsLyrics = AcceptsLyricsOption.Default;
+    }
+
+    try {
+      if (e.annotations) {
+        element.annotations = e.annotations.map((a) => {
+          const annotation = new AnnotationElement();
+          annotation.text = a.text;
+          annotation.x = a.x;
+          annotation.y = a.y;
+
+          return annotation;
+        });
+      }
+    } catch (error) {
+      console.warn('Error loading annotations:', error);
+      element.annotations = [];
     }
   }
 


### PR DESCRIPTION
This PR addresses #1363 and #1589 by adding two new types of elements: annotations and alternate lines. Both elements are anchored to a single note element.

Annotations provide a rich text box.

Alternate lines can take neumes, which are entered by the usual neume selector. The neume editor for an alternate line is simpler than the full page editor in that there is only one entry mode and the toolbar can only add fthores, accidentals, etc. to the last element of the alternate line.