### PR TITLE
Support measure subdivisions in MusicXML

### DIFF
--- a/src/components/ExportDialog.vue
+++ b/src/components/ExportDialog.vue
@@ -81,6 +81,16 @@
               $t('dialog:export.displayTimeSignatures')
             }}</label>
           </div>
+          <div class="form-group row">
+            <input
+              id="export-dialog-display-measure-subdivisions"
+              type="checkbox"
+              v-model="musicXmlOptions.displayMeasureSubdivisions"
+            />
+            <label for="export-dialog-display-time-signatures">{{
+              $t('dialog:export.displayMeasureSubdivisions')
+            }}</label>
+          </div>
 
           <div class="separator"></div>
 

--- a/src/i18n/en/dialog.json
+++ b/src/i18n/en/dialog.json
@@ -22,6 +22,7 @@
     "openDestinationFolderAfterExport": "Open Destination Folder After Export",
     "calculateTimeSignatures": "Include Time Signatures",
     "displayTimeSignatures": "Display Time Signatures",
+    "displayMeasureSubdivisions": "Display Measure Subdivisions",
     "includeModeKeys": "Include Mode Keys",
     "includeTextBoxes": "Include Text Boxes",
     "exporting": "Exporting…",

--- a/src/services/integration/MusicXmlExporter.ts
+++ b/src/services/integration/MusicXmlExporter.ts
@@ -7,7 +7,7 @@ import {
   ScoreElement,
   TempoElement,
 } from '@/models/Element';
-import { QuantitativeNeume } from '@/models/Neumes';
+import { MeasureBar, QuantitativeNeume } from '@/models/Neumes';
 import {
   getScaleNoteFromValue,
   getScaleNoteValue,
@@ -95,6 +95,8 @@ export class MusicXmlExporterOptions {
   calculateTimeSignatures: boolean = false;
   /** Indicates whether the time signature should be printed in each measure */
   displayTimeSignatures: boolean = false;
+  /** Indicates whether subdivisions should be printed in each measure */
+  displayMeasureSubdivisions: boolean = false;
   /** Indicates whether Vou should be extra flat in the legetos scale */
   useLegetos: boolean = false;
 }
@@ -244,6 +246,23 @@ export class MusicXmlExporter {
               currentMeasure.notes.length > 0) ||
             (workspace.needNewMeasure && currentMeasure.notes.length > 0)
           ) {
+            if (
+              noteElement.measureBarLeft &&
+              [
+                MeasureBar.MeasureBarTheseos,
+                MeasureBar.MeasureBarShortTheseos,
+                MeasureBar.MeasureBarTheseosAbove,
+                MeasureBar.MeasureBarShortTheseosAbove,
+              ].includes(noteElement.measureBarLeft)
+            ) {
+              const barline = new MusicXmlBarline();
+              barline.barStyle = new MusicXmlBarStyle(
+                workspace.options.displayMeasureSubdivisions
+                  ? 'dashed'
+                  : 'none',
+              );
+              currentMeasure.contents.push(barline);
+            }
             currentMeasure = new MusicXmlMeasure(measureNumber++);
             measures.push(currentMeasure);
             workspace.needNewMeasure = false;


### PR DESCRIPTION
Fixes #1621. Theseos barlines are an inner division of a Karas-style measure and it is incorrect to give them a solid barline. This changes the default behavior for them to have no barline at all, which keeps the default output simple and easy-to-read. People who are targeting a more advanced demographic may wish to follow the established Western convention for subdividing a measure, which (as documented in Gould's _Behind Bars_ and the Dorico Pro manual) is a full-height dashed/dotted barline. This has been provided as a new checkbox option named "Display Measure Subdivisions". Tick and half-height measures have a specific meaning in Gregorian chant notation which does not apply here (though the concept could _possibly_ be carried over to represent imperfect and perfect cadences in Western notation transcriptions of Byzantine music that don't use any barlines at all).