### PR TITLE
Exclude dist directory when linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,9 @@ import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import pluginVue from 'eslint-plugin-vue';
 
 export default [
+  {
+    ignores: ['dist/**/*', 'dist-electron/**/*'],
+  },
   ...pluginVue.configs['flat/essential'],
   ...vueTsEslintConfig({
     extends: ['recommended'],


### PR DESCRIPTION
Otherwise you cannot run `npm run lint[:fix]` after doing a build.