### PR TITLE
feat: scrollable rich text boxes

### DIFF
--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -69,6 +69,17 @@
       </div>
     </div>
     <ckeditor
+      v-if="element.scrollable"
+      ref="editor"
+      class="rich-text-editor single scrollable"
+      :editor="editor"
+      :model-value="content"
+      @blur="onBlur"
+      @ready="onEditorReady"
+      :config="editorConfig"
+      :style="textBoxStyle"
+    />
+    <ckeditor
       v-else
       ref="editor"
       class="rich-text-editor single"
@@ -254,7 +265,7 @@ export default defineComponent({
     },
 
     containerStyle() {
-      const style = {
+      const style: StyleValue = {
         width: withZoom(this.element.width),
         height: withZoom(this.element.height),
         '--ck-content-font-family': getFontFamilyWithFallback(
@@ -265,7 +276,7 @@ export default defineComponent({
           ? `${this.pageSetup.lyricsDefaultFontSize}px`
           : `${this.pageSetup.textBoxDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
         '--ck-content-line-height': 'normal',
-      } as StyleValue;
+      };
 
       return style;
     },
@@ -273,6 +284,11 @@ export default defineComponent({
     textBoxStyle() {
       const style: StyleValue = {
         width: `${this.element.width}px`, // no zoom because we scale with the transform
+        maxHeight: withZoom(
+          this.pageSetup.pageHeight -
+            this.element.y -
+            this.pageSetup.bottomMargin,
+        ),
       };
 
       return style;
@@ -706,6 +722,10 @@ export default defineComponent({
 .selected .inline-container,
 .selected .rich-text-editor.single {
   outline: 1px solid goldenrod;
+}
+
+.rich-text-editor.scrollable {
+  overflow-y: auto;
 }
 
 .rich-text-editor.inline-top {

--- a/src/components/ToolbarTextBoxRich.vue
+++ b/src/components/ToolbarTextBoxRich.vue
@@ -259,6 +259,22 @@
     </div>
     <span class="divider"></span>
     <div class="form-group">
+      <input
+        id="toolbar-text-box-scrollable"
+        type="checkbox"
+        :checked="element.scrollable"
+        @change="
+          $emit('update', {
+            scrollable: ($event.target as HTMLInputElement).checked,
+          } as Partial<RichTextBoxElement>)
+        "
+      />
+      <label for="toolbar-text-box-scrollable">{{
+        $t('toolbar:textbox.scrollable')
+      }}</label>
+    </div>
+    <span class="divider"></span>
+    <div class="form-group">
       <label class="right-space">{{ $t('toolbar:common.sectionName') }}</label>
       <input
         type="text"

--- a/src/i18n/en/toolbar.json
+++ b/src/i18n/en/toolbar.json
@@ -97,6 +97,7 @@
   "textbox": {
     "multipanel": "Multipanel",
     "rtl": "RTL",
+    "scrollable": "Scrollable",
     "modeChange": "Change Mode",
     "virtualNote": "Parallage Note",
     "centerOnPage": "Center on Page",

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -893,6 +893,7 @@ export class RichTextBoxElement extends ScoreElement {
   public contentLeft: string = '';
   public contentRight: string = '';
   public contentCenter: string = '';
+  public scrollable: boolean = false;
   public multipanel: boolean = false;
   public rtl: boolean = false;
   public inline: boolean = false;

--- a/src/models/save/v1/Element.ts
+++ b/src/models/save/v1/Element.ts
@@ -218,6 +218,7 @@ export class RichTextBoxElement extends ScoreElement {
   public contentLeft: string = '';
   public contentRight: string = '';
   public contentCenter: string = '';
+  public scrollable: boolean | undefined = undefined;
   public multipanel: boolean | undefined = undefined;
   public rtl: boolean | undefined = undefined;
   public inline: boolean | undefined = undefined;

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -648,6 +648,7 @@ export class SaveService {
     element.marginTop = e.marginTop ?? undefined;
     element.marginBottom = e.marginBottom ?? undefined;
     element.rtl = e.rtl || undefined;
+    element.scrollable = e.scrollable || undefined;
   }
 
   public static SaveModeKey(element: ModeKeyElement_v1, e: ModeKeyElement) {
@@ -1497,6 +1498,7 @@ export class SaveService {
     element.inline = e.inline === true;
     element.multipanel = e.multipanel === true;
     element.rtl = e.rtl === true;
+    element.scrollable = e.scrollable === true;
   }
 
   public static LoadModeKey_v1(element: ModeKeyElement, e: ModeKeyElement_v1) {


### PR DESCRIPTION
This PR adds an option to make text boxes scrollable for users who want to use Neanes as a sort of "digital chant stand".

Note about the extra `ckeditor` component in `TextBoxRich.vue`: a new `ckeditor` component seemed to be necessary because the `ckeditor` element did not function properly when the class or style bindings were changed after the component had been initialized. Maybe there is a better way to address the issue, but this seems to work well enough.