### PR TITLE
Fix greek melisma lyrics not center aligned if line starts with vareia

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -1368,12 +1368,14 @@ export default defineComponent({
         direction: this.rtl ? 'rtl' : undefined,
         top: withZoom(element.lyricsVerticalOffset),
         paddingLeft:
-          (!element.isFullMelisma || element.melismaText) &&
+          (!element.isFullMelisma ||
+            (element.melismaText && !element.melismaText.endsWith(TATWEEL))) &&
           element.lyricsHorizontalOffset > 0
             ? withZoom(element.lyricsHorizontalOffset)
             : undefined,
         paddingRight:
-          (!element.isFullMelisma || element.melismaText) &&
+          (!element.isFullMelisma ||
+            (element.melismaText && !element.melismaText.endsWith(TATWEEL))) &&
           element.lyricsHorizontalOffset < 0
             ? withZoom(-element.lyricsHorizontalOffset)
             : undefined,


### PR DESCRIPTION
`src/components/Editor.vue`
`getLyricStyle()`

Fix #1690 issue.

Test files:
[bug_vareia_greek_melisma.zip](https://github.com/user-attachments/files/24387360/bug_vareia_greek_melisma.zip)
[bug_vareia_greek_melisma.byzx (source)](https://github.com/ilizol/neanes-examples/blob/main/bugs/bug_vareia_greek_melisma.byzx)
[bug_vareia_greek_melisma_disabled.byzx (source)](https://github.com/ilizol/neanes-examples/blob/main/bugs/bug_vareia_greek_melisma_disabled.byzx)
[bug_vareia_greek_melisma_disabled_rtl.byzx (source)](https://github.com/ilizol/neanes-examples/blob/main/bugs/bug_vareia_greek_melisma_disabled_rtl.byzx)

[bug_vareia_greek_melisma.pdf](https://github.com/user-attachments/files/24387404/bug_vareia_greek_melisma.pdf) - [source](https://github.com/ilizol/neanes-examples/blob/main/bugs/bug_vareia_greek_melisma.pdf)

<img width="2000" height="2588" src="https://github.com/user-attachments/assets/3b2f3bae-3ad1-417c-af20-c1734f3e1843" />

[bug_vareia_greek_melisma_disabled.pdf](https://github.com/user-attachments/files/24387406/bug_vareia_greek_melisma_disabled.pdf) - [source](https://github.com/ilizol/neanes-examples/blob/main/bugs/bug_vareia_greek_melisma_disabled.pdf)

<img width="2000" height="2588" src="https://github.com/user-attachments/assets/3ed272c6-4a4f-4cbe-a578-081867b2488b" />

[bug_vareia_greek_melisma_disabled_rtl.pdf](https://github.com/user-attachments/files/24423232/bug_vareia_greek_melisma_disabled_rtl.pdf) - [source](https://github.com/ilizol/neanes-examples/blob/main/bugs/bug_vareia_greek_melisma_disabled_rtl.pdf)

<img width="2000" height="2588" src="https://github.com/user-attachments/assets/08611f1c-1c7e-47af-a5fa-4103f43ce25a" />