### PR TITLE
Fix build warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,10 @@ jobs:
       - name: Build Windows and Linux
         if: runner.os != 'macOS'
         run: npm run build
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build macOS
         if: runner.os == 'macOS'
         run: npm run build -- --x64 && npm run build -- --arm64
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Publish
         uses: actions/upload-artifact@v6

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build && electron-builder",
-    "release": "vue-tsc --noEmit && vite build && electron-builder",
+    "build": "vue-tsc --noEmit && vite build && electron-builder --publish never",
+    "release": "vue-tsc --noEmit && vite build && electron-builder --publish always",
     "lint": "eslint && prettier --check \"./**/*.{ts,js,vue}\"",
     "lint:fix": "eslint --fix && prettier --write \"./**/*.{ts,js,vue}\"",
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
Fixes #1943. See https://www.electron.build/publish

> **Deprecation Notice: Implicit Publishing**
> 
> electron-builder currently auto-detects when to publish based on CI environment conditions:
> 
>   * Running via `npm run release` -> publishes always
>   * Git tag detected in CI -> publishes on tag
>   * CI environment detected -> publishes to draft releases
> 
> **This implicit publishing behavior is deprecated and will be disabled in electron-builder v27.**
> 
> To prepare for this change, please explicitly specify your publish intent using the `--publish` CLI flag (e.g., `--publish always`, `--publish onTag`) or set the `publish` configuration in your `package.json` or `electron-builder.yml`.