### PR TITLE
Stop melisma underscore from extending past measure bars

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1744,6 +1744,23 @@ export class LayoutService {
       `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
     );
 
+    const neumeFont = `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`;
+    const melismaMeasureBarWidthMap = new Map<MeasureBar, number>();
+    for (const bar of [
+      MeasureBar.MeasureBarRight,
+      MeasureBar.MeasureBarTop,
+      MeasureBar.MeasureBarDouble,
+      MeasureBar.MeasureBarTheseos,
+      MeasureBar.MeasureBarShortDouble,
+      MeasureBar.MeasureBarShortTheseos,
+    ]) {
+      const mapping = NeumeMappingService.getMapping(bar);
+      melismaMeasureBarWidthMap.set(
+        bar,
+        TextMeasurementService.getTextWidth(mapping.text, neumeFont),
+      );
+    }
+
     let melismaSyllables: MelismaSyllables | null = null;
     let melismaLyricsEnd: number | null = null;
 
@@ -1924,7 +1941,12 @@ export class LayoutService {
               if (nextNoteElement == null) {
                 if (finalElement) {
                   end =
-                    finalElement.x + this.getFinalElementWidth(finalElement);
+                    finalElement.x +
+                    this.getFinalElementWidth(finalElement) -
+                    this.getFinalElementMeasureBarRightWidth(
+                      finalElement,
+                      melismaMeasureBarWidthMap,
+                    );
                 } else {
                   end = element.x + element.neumeWidth;
                 }
@@ -2037,7 +2059,12 @@ export class LayoutService {
                   end = element.x + element.neumeWidth;
                 } else {
                   end =
-                    finalElement.x + this.getFinalElementWidth(finalElement);
+                    finalElement.x +
+                    this.getFinalElementWidth(finalElement) -
+                    this.getFinalElementMeasureBarRightWidth(
+                      finalElement,
+                      melismaMeasureBarWidthMap,
+                    );
                 }
 
                 if (nextNoteElement != null && nextNoteElement.alignLeft) {
@@ -2088,7 +2115,12 @@ export class LayoutService {
               ) {
                 if (finalElement) {
                   end =
-                    finalElement.x + this.getFinalElementWidth(finalElement);
+                    finalElement.x +
+                    this.getFinalElementWidth(finalElement) -
+                    this.getFinalElementMeasureBarRightWidth(
+                      finalElement,
+                      melismaMeasureBarWidthMap,
+                    );
                 } else {
                   end = element.x + element.neumeWidth;
                 }
@@ -2952,6 +2984,26 @@ export class LayoutService {
     } else {
       return (element as TextBoxElement).width;
     }
+  }
+
+  private static getFinalElementMeasureBarRightWidth(
+    element: NoteElement | MartyriaElement | TempoElement | TextBoxElement,
+    measureBarWidthMap: Map<MeasureBar, number>,
+  ) {
+    let measureBarRight: MeasureBar | null = null;
+
+    if (element.elementType === ElementType.Note) {
+      const note = element as NoteElement;
+      measureBarRight = note.measureBarRight || note.computedMeasureBarRight;
+    } else if (element.elementType === ElementType.Martyria) {
+      measureBarRight = (element as MartyriaElement).measureBarRight;
+    }
+
+    if (measureBarRight != null) {
+      return measureBarWidthMap.get(measureBarRight) ?? 0;
+    }
+
+    return 0;
   }
 
   private static isPartOfSameMelisma(element: ScoreElement | null) {


### PR DESCRIPTION
The melisma end position was calculated using `neumeWidth`, which includes the measure bar right width. This caused the melisma underscore to visually extend past barlines. Now we subtract the measure bar width from the end position for all melisma types (hyphen, underscore, and RTL).

<img width="728" height="278" alt="image" src="https://github.com/user-attachments/assets/ce5e6e17-0b4f-4e20-bec4-18fc3f1a4fb5" />
