### PR TITLE
ci: Fix Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Neanes-${{ matrix.os }}
-          path: dist/Neanes-*
+          path: dist/Neanes*
           retention-days: 3


### PR DESCRIPTION
> No files were found with the provided path: `dist/Neanes-*`. No artifacts will be uploaded.