### PR TITLE
fix: Skip measure bar width reservation when note has explicit break

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -524,6 +524,8 @@ export class LayoutService {
             }
 
             if (
+              !noteElement.pageBreak &&
+              !noteElement.lineBreak &&
               nextNote.measureBarLeft != null &&
               !nextNote.measureBarLeft.endsWith('Above')
             ) {


### PR DESCRIPTION
When a note has an explicit line or page break, the line-breaking algorithm in `processPages` still reserves extra width for the next note's `measureBarLeft`. This `additionalWidth` can push the note onto a new line prematurely. The result is an unexpectedly short previous line followed by a single-note line and then another forced break. This fix adds `!noteElement.pageBreak && !noteElement.lineBreak` guards to the measure bar width reservation, matching the pattern already used by the tied-note and martyria keep-together checks. With an explicit break, the break position is fixed and there is no risk of the layout oscillation that the reservation was designed to prevent, so the extra width serves no purpose.

## Testing

Created a score with a nearly full line, set an explicit line break on the last note, and added a measure bar left to the following note. Adjusted the right margin in Page Setup to dial into the narrow pixel window where the bar width is the difference. Before the fix, the note with the line break jumped to the next line; after the fix, it stays on its original line and the break occurs after it as intended.

**Before**

<img width="1252" height="610" alt="before" src="https://github.com/user-attachments/assets/ff244925-4d45-4dee-9ba5-57fb0e3a6af5" />

**After**

<img width="1360" height="570" alt="after" src="https://github.com/user-attachments/assets/86c07365-ddea-47b8-8833-9b4d760dc408" />