### PR TITLE
chore: use setup-node built-in caching instead of actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v5
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-${{ runner.arch }}-modules-${{ hashFiles('package-lock.json') }}
+          cache: 'npm'
 
       - run: corepack enable npm && corepack prepare --activate
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - run: npm test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,17 +17,10 @@ jobs:
         with:
           # choose node.js version to use
           node-version: '22'
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v5
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
+          cache: 'npm'
 
       - run: corepack enable npm && corepack prepare --activate
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       # run build script

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -16,17 +16,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v5
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
+          cache: 'npm'
 
       - run: corepack enable npm && corepack prepare --activate
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,17 +19,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v5
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-${{ runner.arch }}-modules-${{ hashFiles('package-lock.json') }}
+          cache: 'npm'
 
       - run: corepack enable npm && corepack prepare --activate
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - run: npm test


### PR DESCRIPTION
Replace manual actions/cache steps with the `cache: 'npm'` option built into actions/setup-node, simplifying all four workflows.