### PR TITLE
fix: pass --no-sandbox to Electron in rebuild-example-pdfs workflow

### DIFF
--- a/.github/workflows/rebuild-example-pdfs.yml
+++ b/.github/workflows/rebuild-example-pdfs.yml
@@ -29,7 +29,7 @@ jobs:
         run: chmod +x neanes-cli
 
       - name: Generate PDFs
-        run: find ./examples -type f -name '*.byzx' -print0 | xargs -0 ./neanes-cli --silent-pdf
+        run: find ./examples -type f -name '*.byzx' -print0 | xargs -0 ./neanes-cli --no-sandbox --silent-pdf
 
       - name: Archive PDFs
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The SUID sandbox requires chrome-sandbox to be root-owned with mode 4755, which isn't possible in a CI runner. Pass --no-sandbox per the Electron docs to fix the sandbox error.

See https://github.com/neanes/neanes/actions/runs/23862326017/job/69572061647