### PR TITLE
chore: migrate docs deploy to actions/deploy-pages and use github.token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,9 @@ name: docs
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -29,11 +32,25 @@ jobs:
       - name: Build VitePress site
         run: npm run docs:build
 
-      # deploy
-      - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          target_branch: gh-pages
-          build_dir: docs/.vitepress/dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: docs
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -3,6 +3,9 @@ name: Publish Web
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -35,10 +38,10 @@ jobs:
         if: runner.os != 'macOS'
         run: npm run release
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build macOS
         if: runner.os == 'macOS'
         run: npm run release -- --x64 && npm run release -- --arm64
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/rebuild-example-pdfs.yml
+++ b/.github/workflows/rebuild-example-pdfs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get the latest AppImage
         run: gh release download --repo neanes/neanes --pattern '*AppImage*' --output neanes-cli
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Make AppImage Executable
         run: chmod +x neanes-cli

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,5 +16,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Migrate docs workflow from crazy-max/ghaction-github-pages to the official actions/deploy-pages for modern GitHub Pages deployment. Use github.token instead of secrets.GITHUB_TOKEN across workflows and add top-level permissions blocks.