### PR TITLE
Add line break metrics collection and reporting

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -86,6 +86,7 @@ const maxRecentFiles = 20;
 const storeFilePath = path.join(userDataPath, 'settings.json');
 
 const isMac = process.platform === 'darwin';
+const metrics = process.argv.includes('--metrics');
 const silentPdf = process.argv.includes('--silent-pdf');
 const silentHtml = process.argv.includes('--silent-html');
 const silentLatex = process.argv.includes('--silent-latex');
@@ -374,6 +375,7 @@ async function openFileFromArgs(argv: string[]) {
 
   return {
     files: result,
+    metrics,
     silentPdf,
     silentHtml,
     silentLatex,
@@ -1778,6 +1780,10 @@ async function createWindow() {
 app.setAboutPanelOptions({
   applicationName: app.getName(),
   applicationVersion: app.getVersion(),
+});
+
+ipcMain.on(IpcRendererChannels.Log, (_event, ...args: unknown[]) => {
+  console.log(...args);
 });
 
 ipcMain.on(IpcRendererChannels.SetCanUndo, async (event, data) => {

--- a/scripts/process_line_break_metrics.py
+++ b/scripts/process_line_break_metrics.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt  # type: ignore
+
+RATIO_THRESHOLDS = [1.0, 1.1, 1.2, 1.3, 1.5, 2.0]
+HISTOGRAM_EDGES = [
+    -1.0,
+    -0.75,
+    -0.5,
+    -0.25,
+    0.0,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    1.25,
+    1.5,
+    1.75,
+    2.0,
+]
+TOP_DOCUMENT_REPORTS = (
+    ("nonFinalRatioSummary.max", "Top Documents by Worst Non-final Ratio"),
+    ("adjacentIncompatibleCount", "Top Documents by Adjacent Incompatible Count"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def load_raw_documents(path: Path) -> list[dict[str, Any]]:
+    """Parse LINE_BREAK_METRICS_DOCUMENT records from a log file.
+
+    Each record has ``filePath`` and ``lines`` (list of raw per-line dicts).
+    """
+    documents: list[dict[str, Any]] = []
+
+    for line in path.read_text(errors="replace").splitlines():
+        if line.startswith("LINE_BREAK_METRICS_DOCUMENT "):
+            documents.append(json.loads(line.split(" ", 1)[1]))
+
+    return documents
+
+
+# ---------------------------------------------------------------------------
+# Numeric helpers
+# ---------------------------------------------------------------------------
+
+
+def summarize_values(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {
+            "count": 0,
+            "mean": None,
+            "standardDeviation": None,
+            "min": None,
+            "max": None,
+        }
+
+    n = len(values)
+    mean = sum(values) / n
+    variance = sum((v - mean) ** 2 for v in values) / n
+
+    return {
+        "count": n,
+        "mean": mean,
+        "standardDeviation": math.sqrt(variance),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def build_histogram(values: list[float]) -> list[dict[str, Any]]:
+    edges = HISTOGRAM_EDGES
+    bins: list[dict[str, Any]] = []
+
+    bins.append({"label": f"< {edges[0]:.2f}", "count": 0})
+    for i in range(len(edges) - 1):
+        bins.append({"label": f"{edges[i]:.2f} to < {edges[i + 1]:.2f}", "count": 0})
+    bins.append({"label": f">= {edges[-1]:.2f}", "count": 0})
+
+    for v in values:
+        if v < edges[0]:
+            bins[0]["count"] += 1
+            continue
+        if v >= edges[-1]:
+            bins[-1]["count"] += 1
+            continue
+        for i in range(len(edges) - 1):
+            if edges[i] <= v < edges[i + 1]:
+                bins[i + 1]["count"] += 1
+                break
+
+    return bins
+
+
+def build_threshold_counts(values: list[float]) -> dict[str, int]:
+    return {f">{t:.1f}": sum(1 for v in values if v > t) for t in RATIO_THRESHOLDS}
+
+
+def fitness_class(ratio: float) -> int:
+    if ratio < -0.5:
+        return 0
+    if ratio < 0.5:
+        return 1
+    if ratio < 1:
+        return 2
+    return 3
+
+
+# ---------------------------------------------------------------------------
+# Document-level aggregation
+# ---------------------------------------------------------------------------
+
+
+def flatten_document_lists(documents: list[dict[str, Any]], field: str) -> list[Any]:
+    return [item for doc in documents for item in doc[field]]
+
+
+def sum_document_field(documents: list[dict[str, Any]], field: str) -> int:
+    return sum(doc[field] for doc in documents)
+
+
+def build_document_overview(doc: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "filePath": doc["filePath"],
+        "paragraphCount": doc["paragraphCount"],
+        "totalLineCount": doc["totalLineCount"],
+        "nonFinalLineCount": doc["nonFinalLineCount"],
+        "nonFinalRatioSummary": doc["nonFinalRatioSummary"],
+        "paragraphMaxRatioSummary": doc["paragraphMaxRatioSummary"],
+        "adjacentIncompatibleCount": doc["adjacentIncompatibleCount"],
+        "adjacentPairCount": doc["adjacentPairCount"],
+    }
+
+
+def annotate_line_positions(lines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Derive paragraph and in-paragraph line indices from line order.
+
+    The frontend emits lines in paragraph order, and each paragraph's lines are
+    emitted in line order. `isParagraphFinalLine` marks the paragraph boundary.
+    """
+    annotated: list[dict[str, Any]] = []
+    paragraph_index = 0
+    line_index_in_paragraph = 0
+
+    for line in lines:
+        annotated_line = dict(line)
+        annotated_line["paragraphIndex"] = paragraph_index
+        annotated_line["lineIndexInParagraph"] = line_index_in_paragraph
+        annotated.append(annotated_line)
+
+        if line["isParagraphFinalLine"]:
+            paragraph_index += 1
+            line_index_in_paragraph = 0
+        else:
+            line_index_in_paragraph += 1
+
+    return annotated
+
+
+def group_lines_by_paragraph(
+    lines: list[dict[str, Any]],
+) -> dict[int, list[dict[str, Any]]]:
+    grouped: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for line in lines:
+        grouped[line["paragraphIndex"]].append(line)
+    return grouped
+
+
+def summarize_paragraphs(
+    by_paragraph: dict[int, list[dict[str, Any]]],
+) -> tuple[list[float], int, int]:
+    paragraph_max_ratios: list[float] = []
+    adjacent_pair_count = 0
+    adjacent_incompatible_count = 0
+
+    for para_lines in by_paragraph.values():
+        para_lines.sort(key=lambda ln: ln["lineIndexInParagraph"])
+
+        measured = [ln for ln in para_lines if not ln["isParagraphFinalLine"]]
+        source = measured if measured else para_lines
+        paragraph_max_ratios.append(max(ln["adjustmentRatio"] for ln in source))
+
+        for left, right in zip(para_lines, para_lines[1:]):
+            adjacent_pair_count += 1
+            delta = abs(
+                fitness_class(left["adjustmentRatio"])
+                - fitness_class(right["adjustmentRatio"])
+            )
+            if delta > 1:
+                adjacent_incompatible_count += 1
+
+    return paragraph_max_ratios, adjacent_pair_count, adjacent_incompatible_count
+
+
+def build_worst_lines(
+    file_path: str, lines: list[dict[str, Any]], limit: int
+) -> list[dict[str, Any]]:
+    worst = sorted(lines, key=lambda ln: ln["adjustmentRatio"], reverse=True)[:limit]
+    return [
+        {
+            "filePath": file_path,
+            "paragraphIndex": line["paragraphIndex"],
+            "lineIndexInParagraph": line["lineIndexInParagraph"],
+            "ratio": line["adjustmentRatio"],
+            "isParagraphFinalLine": line["isParagraphFinalLine"],
+        }
+        for line in worst
+    ]
+
+
+def build_document_metrics(raw: dict[str, Any]) -> dict[str, Any]:
+    file_path: str = raw["filePath"]
+    all_lines = annotate_line_positions(raw["lines"])
+    non_final = [ln for ln in all_lines if not ln["isParagraphFinalLine"]]
+
+    all_ratios = [ln["adjustmentRatio"] for ln in all_lines]
+    non_final_ratios = [ln["adjustmentRatio"] for ln in non_final]
+    by_paragraph = group_lines_by_paragraph(all_lines)
+    (
+        paragraph_max_ratios,
+        adjacent_pair_count,
+        adjacent_incompatible_count,
+    ) = summarize_paragraphs(by_paragraph)
+
+    return {
+        "filePath": file_path,
+        "paragraphCount": len(by_paragraph),
+        "totalLineCount": len(all_lines),
+        "finalLineCount": len(all_lines) - len(non_final),
+        "nonFinalLineCount": len(non_final),
+        "allRatios": all_ratios,
+        "nonFinalRatios": non_final_ratios,
+        "paragraphMaxRatios": paragraph_max_ratios,
+        "allRatioSummary": summarize_values(all_ratios),
+        "nonFinalRatioSummary": summarize_values(non_final_ratios),
+        "paragraphMaxRatioSummary": summarize_values(paragraph_max_ratios),
+        "nonFinalRatioHistogram": build_histogram(non_final_ratios),
+        "ratioThresholdCounts": build_threshold_counts(non_final_ratios),
+        "paragraphMaxThresholdCounts": build_threshold_counts(paragraph_max_ratios),
+        "adjacentPairCount": adjacent_pair_count,
+        "adjacentIncompatibleCount": adjacent_incompatible_count,
+        "worstLines": build_worst_lines(file_path, non_final, limit=10),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Corpus-level aggregation
+# ---------------------------------------------------------------------------
+
+
+def build_corpus_metrics(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    all_ratios = flatten_document_lists(documents, "allRatios")
+    non_final_ratios = flatten_document_lists(documents, "nonFinalRatios")
+    paragraph_max_ratios = flatten_document_lists(documents, "paragraphMaxRatios")
+
+    worst_lines = sorted(
+        flatten_document_lists(documents, "worstLines"),
+        key=lambda wl: wl["ratio"],
+        reverse=True,
+    )[:20]
+
+    non_final_count = sum_document_field(documents, "nonFinalLineCount")
+
+    return {
+        "fileCount": len(documents),
+        "paragraphCount": sum_document_field(documents, "paragraphCount"),
+        "totalLineCount": sum_document_field(documents, "totalLineCount"),
+        "finalLineCount": sum_document_field(documents, "finalLineCount"),
+        "nonFinalLineCount": non_final_count,
+        "allRatioSummary": summarize_values(all_ratios),
+        "nonFinalRatioSummary": summarize_values(non_final_ratios),
+        "paragraphMaxRatioSummary": summarize_values(paragraph_max_ratios),
+        "nonFinalRatioHistogram": build_histogram(non_final_ratios),
+        "ratioThresholdCounts": build_threshold_counts(non_final_ratios),
+        "paragraphMaxThresholdCounts": build_threshold_counts(paragraph_max_ratios),
+        "adjacentPairCount": sum_document_field(documents, "adjacentPairCount"),
+        "adjacentIncompatibleCount": sum_document_field(
+            documents, "adjacentIncompatibleCount"
+        ),
+        "worstLines": worst_lines,
+        "documents": [build_document_overview(doc) for doc in documents],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+
+def pct(numerator: int, denominator: int) -> str:
+    if denominator == 0:
+        return "n/a"
+    return f"{(100 * numerator / denominator):.2f}%"
+
+
+def fmt_number(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, int):
+        return str(value)
+    return f"{value:.{digits}f}"
+
+
+def get_nested(mapping: dict[str, Any], path: str) -> Any:
+    current: Any = mapping
+    for part in path.split("."):
+        current = current[part]
+    return current
+
+
+def print_corpus_summary(corpus: dict[str, Any]) -> None:
+    non_final_count = corpus["nonFinalLineCount"]
+    paragraph_count = corpus["paragraphCount"]
+    adjacent_pairs = corpus["adjacentPairCount"]
+
+    print("Corpus Summary")
+    print(f"  Files: {corpus['fileCount']}")
+    print(f"  Paragraphs: {paragraph_count}")
+    print(f"  Total lines: {corpus['totalLineCount']}")
+    print(f"  Non-final lines: {non_final_count}")
+    print(f"  Mean r (non-final): {fmt_number(corpus['nonFinalRatioSummary']['mean'])}")
+    print(
+        f"  Std dev r (non-final): {fmt_number(corpus['nonFinalRatioSummary']['standardDeviation'])}"
+    )
+    print(f"  Max r (non-final): {fmt_number(corpus['nonFinalRatioSummary']['max'])}")
+    print(
+        f"  Mean paragraph max r: {fmt_number(corpus['paragraphMaxRatioSummary']['mean'])}"
+    )
+    print(
+        f"  Adjacent incompatible pairs: {corpus['adjacentIncompatibleCount']} / {adjacent_pairs} "
+        f"({pct(corpus['adjacentIncompatibleCount'], adjacent_pairs)})"
+    )
+    print()
+
+    print("Ratio Thresholds")
+    for label, count in corpus["ratioThresholdCounts"].items():
+        print(f"  {label}: {count} ({pct(count, non_final_count)})")
+    print()
+
+    print("Paragraph Max Thresholds")
+    for label, count in corpus["paragraphMaxThresholdCounts"].items():
+        print(f"  {label}: {count} ({pct(count, paragraph_count)})")
+    print()
+
+
+def print_top_documents(
+    documents: list[dict[str, Any]], metric_path: str, label: str, limit: int
+) -> None:
+    print(label)
+    for doc in top_documents(documents, metric_path, limit):
+        print(
+            f"  {fmt_number(get_nested(doc, metric_path))}  "
+            f"{doc['filePath']}  "
+            f"(non-final lines: {doc['nonFinalLineCount']})"
+        )
+    print()
+
+
+def print_worst_lines(corpus: dict[str, Any], limit: int) -> None:
+    print("Worst Lines")
+    for item in corpus["worstLines"][:limit]:
+        print(
+            f"  r={fmt_number(item['ratio'])}  "
+            f"{item['filePath']}  "
+            f"paragraph {item['paragraphIndex']}, line {item['lineIndexInParagraph']}"
+        )
+    print()
+
+
+def top_documents(
+    documents: list[dict[str, Any]], metric_path: str, limit: int
+) -> list[dict[str, Any]]:
+    usable = [doc for doc in documents if get_nested(doc, metric_path) is not None]
+    return sorted(usable, key=lambda doc: get_nested(doc, metric_path), reverse=True)[
+        :limit
+    ]
+
+
+def mapping_rows(mapping: dict[str, int], key_name: str) -> list[dict[str, int]]:
+    return [{key_name: key, "count": count} for key, count in mapping.items()]
+
+
+# ---------------------------------------------------------------------------
+# Report output
+# ---------------------------------------------------------------------------
+
+
+def write_json_outputs(
+    output_dir: Path, documents: list[dict[str, Any]], corpus: dict[str, Any]
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    (output_dir / "corpus-summary.json").write_text(json.dumps(corpus, indent=2) + "\n")
+
+    (output_dir / "document-metrics.json").write_text(
+        json.dumps(documents, indent=2) + "\n"
+    )
+
+    (output_dir / "worst-lines.json").write_text(
+        json.dumps(corpus["worstLines"], indent=2) + "\n"
+    )
+
+
+def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> None:
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown_report(
+    output_dir: Path,
+    corpus: dict[str, Any],
+    documents: list[dict[str, Any]],
+    top: int,
+    plots_written: list[str],
+) -> None:
+    non_final_count = corpus["nonFinalLineCount"]
+    paragraph_count = corpus["paragraphCount"]
+
+    lines: list[str] = []
+    lines.append("# Line Break Metrics Report")
+    lines.append("")
+    lines.append("## Corpus Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | ---: |")
+    lines.append(f"| Files | {corpus['fileCount']} |")
+    lines.append(f"| Paragraphs | {paragraph_count} |")
+    lines.append(f"| Total lines | {corpus['totalLineCount']} |")
+    lines.append(f"| Non-final lines | {non_final_count} |")
+    lines.append(
+        f"| Mean r (non-final) | {fmt_number(corpus['nonFinalRatioSummary']['mean'])} |"
+    )
+    lines.append(
+        f"| Std dev r (non-final) | {fmt_number(corpus['nonFinalRatioSummary']['standardDeviation'])} |"
+    )
+    lines.append(
+        f"| Max r (non-final) | {fmt_number(corpus['nonFinalRatioSummary']['max'])} |"
+    )
+    lines.append(
+        f"| Mean paragraph max r | {fmt_number(corpus['paragraphMaxRatioSummary']['mean'])} |"
+    )
+    lines.append(
+        f"| Adjacent incompatible pair rate | {pct(corpus['adjacentIncompatibleCount'], corpus['adjacentPairCount'])} |"
+    )
+    lines.append("")
+
+    lines.append("## Ratio Thresholds")
+    lines.append("")
+    lines.append("| Threshold | Count | Share of non-final lines |")
+    lines.append("| --- | ---: | ---: |")
+    for label, count in corpus["ratioThresholdCounts"].items():
+        lines.append(f"| {label} | {count} | {pct(count, non_final_count)} |")
+    lines.append("")
+
+    lines.append("## Paragraph Max Thresholds")
+    lines.append("")
+    lines.append("| Threshold | Count | Share of paragraphs |")
+    lines.append("| --- | ---: | ---: |")
+    for label, count in corpus["paragraphMaxThresholdCounts"].items():
+        lines.append(f"| {label} | {count} | {pct(count, paragraph_count)} |")
+    lines.append("")
+
+    lines.append("## Worst Lines")
+    lines.append("")
+    lines.append("| Ratio | File | Paragraph | Line |")
+    lines.append("| ---: | --- | ---: | ---: |")
+    for item in corpus["worstLines"][:top]:
+        lines.append(
+            f"| {fmt_number(item['ratio'])} | {item['filePath']} | {item['paragraphIndex']} | {item['lineIndexInParagraph']} |"
+        )
+    lines.append("")
+
+    def add_top_docs_section(
+        title: str, docs: list[dict[str, Any]], metric_path: str
+    ) -> None:
+        lines.append(f"## {title}")
+        lines.append("")
+        lines.append("| Metric | File | Non-final lines |")
+        lines.append("| ---: | --- | ---: |")
+        for doc in docs:
+            lines.append(
+                f"| {fmt_number(get_nested(doc, metric_path))} | {doc['filePath']} | {doc['nonFinalLineCount']} |"
+            )
+        lines.append("")
+
+    for metric_path, title in TOP_DOCUMENT_REPORTS:
+        add_top_docs_section(
+            title, top_documents(documents, metric_path, top), metric_path
+        )
+
+    if plots_written:
+        lines.append("## Plots")
+        lines.append("")
+        for plot in plots_written:
+            lines.append(f"- `{plot}`")
+        lines.append("")
+
+    (output_dir / "report.md").write_text("\n".join(lines) + "\n")
+
+
+def write_csv_outputs(
+    output_dir: Path, corpus: dict[str, Any], documents: list[dict[str, Any]]
+) -> None:
+    write_csv(
+        output_dir / "documents.csv",
+        [
+            "filePath",
+            "paragraphCount",
+            "totalLineCount",
+            "finalLineCount",
+            "nonFinalLineCount",
+            "nonFinalMean",
+            "nonFinalStdDev",
+            "nonFinalMax",
+            "paragraphMaxMean",
+            "paragraphMaxMax",
+            "adjacentIncompatibleCount",
+            "adjacentPairCount",
+        ],
+        [
+            {
+                "filePath": doc["filePath"],
+                "paragraphCount": doc["paragraphCount"],
+                "totalLineCount": doc["totalLineCount"],
+                "finalLineCount": doc["finalLineCount"],
+                "nonFinalLineCount": doc["nonFinalLineCount"],
+                "nonFinalMean": doc["nonFinalRatioSummary"]["mean"],
+                "nonFinalStdDev": doc["nonFinalRatioSummary"]["standardDeviation"],
+                "nonFinalMax": doc["nonFinalRatioSummary"]["max"],
+                "paragraphMaxMean": doc["paragraphMaxRatioSummary"]["mean"],
+                "paragraphMaxMax": doc["paragraphMaxRatioSummary"]["max"],
+                "adjacentIncompatibleCount": doc["adjacentIncompatibleCount"],
+                "adjacentPairCount": doc["adjacentPairCount"],
+            }
+            for doc in documents
+        ],
+    )
+
+    write_csv(
+        output_dir / "worst_lines.csv",
+        [
+            "ratio",
+            "filePath",
+            "paragraphIndex",
+            "lineIndexInParagraph",
+            "isParagraphFinalLine",
+        ],
+        corpus["worstLines"],
+    )
+
+    write_csv(
+        output_dir / "nonfinal_ratio_histogram.csv",
+        ["label", "count"],
+        corpus["nonFinalRatioHistogram"],
+    )
+
+    write_csv(
+        output_dir / "ratio_threshold_counts.csv",
+        ["threshold", "count"],
+        mapping_rows(corpus["ratioThresholdCounts"], "threshold"),
+    )
+
+    write_csv(
+        output_dir / "paragraph_max_threshold_counts.csv",
+        ["threshold", "count"],
+        mapping_rows(corpus["paragraphMaxThresholdCounts"], "threshold"),
+    )
+
+
+def write_plot_outputs(output_dir: Path, corpus: dict[str, Any]) -> list[str]:
+    written: list[str] = []
+
+    histogram = corpus["nonFinalRatioHistogram"]
+    labels = [item["label"] for item in histogram]
+    counts = [item["count"] for item in histogram]
+
+    plt.figure(figsize=(12, 5))
+    plt.bar(range(len(labels)), counts)
+    plt.xticks(range(len(labels)), labels, rotation=45, ha="right")
+    plt.ylabel("Line count")
+    plt.title("Non-final adjustment ratio histogram")
+    plt.tight_layout()
+    plt.savefig(output_dir / "nonfinal_ratio_histogram.png", dpi=150)
+    plt.close()
+    written.append("nonfinal_ratio_histogram.png")
+
+    thresholds = list(corpus["ratioThresholdCounts"].items())
+    plt.figure(figsize=(8, 4))
+    plt.bar([label for label, _ in thresholds], [count for _, count in thresholds])
+    plt.ylabel("Line count")
+    plt.title("Non-final ratio threshold counts")
+    plt.tight_layout()
+    plt.savefig(output_dir / "ratio_threshold_counts.png", dpi=150)
+    plt.close()
+    written.append("ratio_threshold_counts.png")
+
+    return written
+
+
+def write_report_outputs(
+    output_dir: Path, documents: list[dict[str, Any]], corpus: dict[str, Any], top: int
+) -> list[str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json_outputs(output_dir, documents, corpus)
+    write_csv_outputs(output_dir, corpus, documents)
+    plots_written = write_plot_outputs(output_dir, corpus)
+    write_markdown_report(output_dir, corpus, documents, top, plots_written)
+    return plots_written
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize LINE_BREAK_METRICS_* records from a --silent-pdf log."
+    )
+    parser.add_argument("logfile", help="Path to the captured stdout/stderr log file")
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="How many top documents/worst lines to print",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        help="Optional directory to write normalized JSON outputs into",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Optional directory to write a Markdown report, CSV tables, JSON, and plots into",
+    )
+    args = parser.parse_args()
+
+    raw_documents = load_raw_documents(Path(args.logfile))
+    if not raw_documents:
+        raise SystemExit("No LINE_BREAK_METRICS_DOCUMENT records found in the log.")
+
+    documents = [build_document_metrics(raw) for raw in raw_documents]
+    corpus = build_corpus_metrics(documents)
+
+    print_corpus_summary(corpus)
+    print_worst_lines(corpus, args.top)
+    for metric_path, label in TOP_DOCUMENT_REPORTS:
+        print_top_documents(documents, metric_path, label, args.top)
+
+    if args.json_out is not None:
+        write_json_outputs(args.json_out, documents, corpus)
+
+    if args.out is not None:
+        plots_written = write_report_outputs(args.out, documents, corpus, args.top)
+        if plots_written:
+            print(f"Wrote report outputs to {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -119,7 +119,7 @@ import {
   TimeNeume,
   VocalExpressionNeume,
 } from '@/models/Neumes';
-import { Page } from '@/models/Page';
+import { Line, Page } from '@/models/Page';
 import { PageSetup } from '@/models/PageSetup';
 import { ScaleNote } from '@/models/Scales';
 import { Score } from '@/models/Score';
@@ -145,7 +145,7 @@ import { MusicXmlExporter } from '@/services/integration/MusicXmlExporter';
 import { OcrImporter } from '@/services/integration/OcrImporter';
 import { IIpcService } from '@/services/ipc/IIpcService';
 import { IpcService } from '@/services/ipc/IpcService';
-import { LayoutService } from '@/services/LayoutService';
+import { LayoutService, type LineBreakMetric } from '@/services/LayoutService';
 import { LyricService } from '@/services/LyricService';
 import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 import { IPlatformService } from '@/services/platform/IPlatformService';
@@ -308,6 +308,7 @@ export default defineComponent({
       printMode: false,
 
       showGuides: false,
+      showAdjustmentRatios: false,
 
       workspaces: [] as Workspace[],
       selectedWorkspaceValue: new Workspace(),
@@ -315,6 +316,7 @@ export default defineComponent({
       tabs: [] as Tab[],
 
       pages: [] as Page[],
+      metrics: [] as LineBreakMetric[],
 
       currentPageNumber: 0,
 
@@ -1436,6 +1438,40 @@ export default defineComponent({
         right: this.rtl ? withZoom(element.x) : undefined,
         top: withZoom(element.y),
       } as StyleValue;
+    },
+
+    getAdjustmentRatioStyle(line: Line) {
+      const fontSize = this.score.pageSetup.lyricsDefaultFontSize * 0.8;
+      const gap = fontSize * 0.5;
+      return {
+        position: 'absolute',
+        left: withZoom(
+          this.rtl
+            ? this.score.pageSetup.leftMargin - gap - fontSize * 3
+            : this.score.pageSetup.pageWidth -
+                this.score.pageSetup.rightMargin +
+                gap,
+        ),
+        width: withZoom(fontSize * 3),
+        textAlign: 'right',
+        top: withZoom(
+          line.elements[0].y +
+            this.score.pageSetup.lineHeight / 3 -
+            fontSize / 2,
+        ),
+        fontSize: withZoom(fontSize),
+        fontFamily: this.score.pageSetup.lyricsDefaultFontFamily,
+        color: this.score.pageSetup.gorgonDefaultColor,
+      } as StyleValue;
+    },
+
+    logStructuredMetric(label: string, payload: unknown) {
+      const message = `${label} ${JSON.stringify(payload)}`;
+      if (window.ipcRenderer) {
+        window.ipcRenderer.send(IpcRendererChannels.Log, message);
+      } else {
+        console.log(message);
+      }
     },
 
     getMelismaStyle(element: NoteElement) {
@@ -3446,7 +3482,9 @@ export default defineComponent({
         .map((_, i) => i)
         .filter((i) => this.pages[i].isVisible);
 
-      const pages = LayoutService.processPages(toRaw(this.selectedWorkspace));
+      const { pages, metrics } = LayoutService.processPages(
+        toRaw(this.selectedWorkspace),
+      );
 
       // Set page visibility for the newly processed pages
       pages.forEach((x, index) => (x.isVisible = visiblePages.includes(index)));
@@ -3472,6 +3510,7 @@ export default defineComponent({
         });
 
       this.pages = pages;
+      this.metrics = metrics;
 
       // If using the browser, save the workspace to local storage
       if (this.isBrowser) {
@@ -3545,11 +3584,19 @@ export default defineComponent({
         await this.ipcService.openWorkspaceFromArgv();
 
       if (openWorkspaceResults.silentPdf) {
+        const emitMetrics = openWorkspaceResults.metrics ?? false;
+
         for (const file of openWorkspaceResults.files.filter(
           (x) => x.success,
         )) {
           this.openScore(file);
           await this.onFileMenuExportAsPdf();
+          if (emitMetrics) {
+            this.logStructuredMetric('LINE_BREAK_METRICS_DOCUMENT', {
+              filePath: file.filePath,
+              lines: this.metrics,
+            });
+          }
           this.removeWorkspace(this.selectedWorkspace);
         }
       }
@@ -3632,7 +3679,11 @@ export default defineComponent({
       this.selectedElement =
         this.score.staff.elements[this.score.staff.elements.length - 1];
 
-      this.pages = LayoutService.processPages(this.selectedWorkspace);
+      const { pages, metrics } = LayoutService.processPages(
+        this.selectedWorkspace,
+      );
+      this.pages = pages;
+      this.metrics = metrics;
     },
 
     async saveWorkspace(workspace: Workspace) {
@@ -6840,6 +6891,16 @@ export default defineComponent({
                     />
                   </template>
                 </div>
+                <span
+                  v-if="
+                    showAdjustmentRatios &&
+                    line.adjustmentRatio != null &&
+                    line.elements.length > 0
+                  "
+                  class="adjustment-ratio"
+                  :style="getAdjustmentRatioStyle(line)"
+                  >{{ line.adjustmentRatio.toFixed(2) }}</span
+                >
               </div>
               <template v-if="score.pageSetup.showFooter">
                 <div
@@ -7370,6 +7431,12 @@ export default defineComponent({
 
 .element-box {
   position: absolute;
+}
+
+.adjustment-ratio {
+  pointer-events: none;
+  white-space: nowrap;
+  font-variant-numeric: lining-nums tabular-nums;
 }
 
 .neume-box {

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -81,6 +81,8 @@ export enum IpcRendererChannels {
   OpenContextMenuForTab = 'OpenContextMenuForTab',
 
   Paste = 'Paste',
+
+  Log = 'Log',
 }
 
 export interface FileMenuOpenScoreArgs {
@@ -91,6 +93,7 @@ export interface FileMenuOpenScoreArgs {
 
 export interface OpenWorkspaceFromArgvArgs {
   files: FileMenuOpenScoreArgs[];
+  metrics?: boolean;
   silentPdf?: boolean;
   silentHtml?: boolean;
   silentLatex?: boolean;

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -15,6 +15,7 @@ export class Page {
 export class Line {
   public elements: ScoreElement[] = [];
   public indentation = 0;
+  public adjustmentRatio: number | null = null;
 
   // A line is empty if it contains only the empty element
   public get isEmpty() {

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -73,8 +73,19 @@ interface GetNoteWidthArgs {
   runningElaphronWidth: number;
   elaphronWidth: number;
 }
+
+export interface LineBreakMetric {
+  adjustmentRatio: number;
+  isParagraphFinalLine: boolean;
+}
+
+export interface ProcessPagesResult {
+  pages: Page[];
+  metrics: LineBreakMetric[];
+}
+
 export class LayoutService {
-  public static processPages(workspace: Workspace): Page[] {
+  public static processPages(workspace: Workspace): ProcessPagesResult {
     const score = workspace.score;
     const pageSetup = score.pageSetup;
     const elements = score.staff.elements;
@@ -924,7 +935,7 @@ export class LayoutService {
       }
     }
 
-    this.justifyLines(pages, pageSetup);
+    const metrics = this.justifyLines(pages, pageSetup);
 
     this.addMelismas(pages, pageSetup);
 
@@ -941,7 +952,7 @@ export class LayoutService {
       this.checkElementState(element);
     });
 
-    return pages;
+    return { pages, metrics };
   }
 
   private static isFillWidthElement(element: ScoreElement): boolean {
@@ -1658,7 +1669,12 @@ export class LayoutService {
     );
   }
 
-  public static justifyLines(pages: Page[], pageSetup: PageSetup) {
+  public static justifyLines(
+    pages: Page[],
+    pageSetup: PageSetup,
+  ): LineBreakMetric[] {
+    const metrics: LineBreakMetric[] = [];
+
     for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
       const page = pages[pageIndex];
 
@@ -1675,45 +1691,22 @@ export class LayoutService {
           nextLine = nextPage.lines[0];
         }
 
-        if (
-          pages.indexOf(page) === pages.length - 1 &&
-          page.lines.indexOf(line) === page.lines.length - 1
-        ) {
-          continue;
-        }
+        const isLastLineOfScore =
+          pageIndex === pages.length - 1 && lineIndex === page.lines.length - 1;
 
-        if (
-          line.elements.some(
-            (x) =>
-              x.lineBreak == true && x.lineBreakType === LineBreakType.Left,
-          )
-        ) {
-          continue;
-        }
+        const hasLeftLineBreak = line.elements.some(
+          (x) => x.lineBreak == true && x.lineBreakType === LineBreakType.Left,
+        );
 
-        if (line.elements.some((x) => x.pageBreak == true)) {
-          continue;
-        }
+        const hasPageBreak = line.elements.some((x) => x.pageBreak == true);
 
-        if (
-          line.elements.some(
-            (x) =>
-              x.elementType === ElementType.Martyria &&
-              (x as MartyriaElement).alignRight == true,
-          )
-        ) {
-          continue;
-        }
+        const hasAlignRightMartyria = line.elements.some(
+          (x) =>
+            x.elementType === ElementType.Martyria &&
+            (x as MartyriaElement).alignRight == true,
+        );
 
-        // We treat text boxes and mode keys as paragraph breaks,
-        // so we only justify if there is a justified line break
-        if (
-          !line.elements.some(
-            (x) =>
-              x.lineBreak == true &&
-              (x.lineBreakType === LineBreakType.Justify ||
-                x.lineBreakType === LineBreakType.Center),
-          ) &&
+        const nextLineStartsParagraph =
           nextLine?.elements.some(
             (x) =>
               (x.elementType === ElementType.TextBox &&
@@ -1721,12 +1714,74 @@ export class LayoutService {
               (x.elementType === ElementType.RichTextBox &&
                 !(x as RichTextBoxElement).inline) ||
               x.elementType === ElementType.ModeKey,
-          )
-        ) {
-          continue;
+          ) ?? false;
+
+        const hasJustifiedOrCenterBreak = line.elements.some(
+          (x) =>
+            x.lineBreak == true &&
+            (x.lineBreakType === LineBreakType.Justify ||
+              x.lineBreakType === LineBreakType.Center),
+        );
+
+        // Determine if this line is a paragraph final line
+        const isParagraphFinalLine =
+          isLastLineOfScore ||
+          hasLeftLineBreak ||
+          hasPageBreak ||
+          hasAlignRightMartyria ||
+          nextLineStartsParagraph;
+
+        // Determine whether to skip justification
+        const skipJustification =
+          isLastLineOfScore ||
+          hasLeftLineBreak ||
+          hasPageBreak ||
+          hasAlignRightMartyria ||
+          (!hasJustifiedOrCenterBreak && nextLineStartsParagraph) ||
+          line.elements.length < 2;
+
+        // Compute the natural width and adjustment ratio for all lines
+        // (even ones we skip justification for)
+        if (line.elements.length > 0) {
+          // Compute currentWidthPx without modifying martyria padding yet
+          let currentWidthPx = line.elements
+            .map((x) => x.width)
+            .reduce((sum, x) => sum + x, 0);
+
+          const lastElementOnLine = line.elements[line.elements.length - 1];
+          let martyriaPadding = 0;
+
+          if (
+            lastElementOnLine.elementType === ElementType.Martyria &&
+            !(lastElementOnLine as MartyriaElement).alignRight
+          ) {
+            martyriaPadding = (lastElementOnLine as MartyriaElement).padding;
+            currentWidthPx -= martyriaPadding;
+          }
+
+          const lineLength = pageSetup.innerPageWidth - line.indentation;
+          const extraSpace = lineLength - currentWidthPx;
+
+          // Compute adjustment ratio on the same scale as ordinary
+          // Knuth-Plass glue: extraSpace / totalGlueStretch, where each
+          // inter-element gap stretches by standardGlue.stretch.
+          const ordinaryGapStretch = Math.max(
+            pageSetup.neumeDefaultSpacing * 0.5,
+            0.1,
+          );
+          const totalStretch = (line.elements.length - 1) * ordinaryGapStretch;
+          const adjustmentRatio =
+            totalStretch > 0 ? extraSpace / totalStretch : 0;
+
+          line.adjustmentRatio = adjustmentRatio;
+
+          metrics.push({
+            adjustmentRatio,
+            isParagraphFinalLine,
+          });
         }
 
-        if (line.elements.length < 2) {
+        if (skipJustification) {
           continue;
         }
 
@@ -1768,6 +1823,8 @@ export class LayoutService {
         }
       }
     }
+
+    return metrics;
   }
 
   public static addMelismas(pages: Page[], pageSetup: PageSetup) {

--- a/src/services/ipc/BrowserIpcService.ts
+++ b/src/services/ipc/BrowserIpcService.ts
@@ -112,7 +112,7 @@ export class BrowserIpcService implements IIpcService {
   }
 
   public async openWorkspaceFromArgv(): Promise<OpenWorkspaceFromArgvArgs> {
-    return { files: [] };
+    return { files: [], metrics: false };
   }
 
   public async showMessageBox(): Promise<ShowMessageBoxReplyArgs> {


### PR DESCRIPTION
Add infrastructure to compute and report adjustment ratios during layout, enabling quality analysis of line breaking across a corpus of documents. Includes a --metrics CLI flag, structured metric emission during silent PDF export, in-editor ratio overlay, and a Python post-processing script for aggregate analysis.