### PR TITLE
chore: Clean up build and fix test type errors

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,0 @@
-> 1%
-last 2 versions

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ yarn-error.log*
 /docs/.vitepress/dist
 /docs/.vitepress/cache
 
+# Vitest coverage output
+/coverage/
+
 #Electron-builder output
 /dist
 /dist-electron

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['@vue/cli-plugin-babel/preset'],
-};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,12 +5,7 @@ import pluginVue from 'eslint-plugin-vue';
 
 export default [
   {
-    ignores: [
-      'dist/**/*',
-      'dist-electron/**/*',
-      '.scripts/**/*',
-      '**/.vitepress/cache/**/*',
-    ],
+    ignores: ['dist/**/*', 'dist-electron/**/*', '**/.vitepress/cache/**/*'],
   },
   ...pluginVue.configs['flat/essential'],
   ...vueTsEslintConfig({

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <meta
       name="google-site-verification"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "neanes",
       "version": "0.5.8",
       "hasInstallScript": true,
-      "license": "GPL-3.0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "i18next": "^26.0.8",
         "i18next-pseudo": "^2.2.1",
@@ -26,7 +26,6 @@
         "@types/node": "^25.6.0",
         "@types/semver": "^7.7.1",
         "@types/throttle-debounce": "^5.0.2",
-        "@types/uuid": "^11.0.0",
         "@types/webpack-env": "^1.18.8",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-istanbul": "^4.1.5",
@@ -52,7 +51,6 @@
         "uuid": "^14.0.0",
         "vite": "^8.0.10",
         "vite-plugin-electron": "^0.29.1",
-        "vite-plugin-electron-renderer": "^0.14.7",
         "vite-plugin-pwa": "^1.3.0",
         "vite-plugin-vue-devtools": "^8.1.2",
         "vitepress": "^1.6.4",
@@ -65,6 +63,9 @@
         "vue3-observe-visibility": "^1.0.7",
         "vue3-tabs-chrome": "^0.3.3",
         "yaml": "^2.8.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -5138,17 +5139,6 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -15891,13 +15881,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vite-plugin-electron-renderer": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-electron-renderer/-/vite-plugin-electron-renderer-0.14.7.tgz",
-      "integrity": "sha512-hHBMKuZ24MB2SIxG7U7ix+DDEnvxou7Bgy/TdhYxNz3S5N3Yh7Hjvj9blfMeGEJ0oaZJn7y5z0V/RyDmJ5OuCA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite-plugin-pwa": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,12 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build && electron-builder --publish never",
     "release": "vue-tsc --noEmit && vite build && electron-builder --publish always",
-    "lint": "eslint --config eslint.config.mjs . && prettier --check \"./**/*.{md,ts,js,vue}\"",
-    "lint:fix": "eslint --config eslint.config.mjs --fix . && prettier --write \"./**/*.{md,ts,js,vue}\"",
+    "lint": "eslint . && prettier --check \"./**/*.{md,ts,js,vue}\"",
+    "lint:fix": "eslint --fix . && prettier --write \"./**/*.{md,ts,js,vue}\"",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "postinstall": "electron-builder install-app-deps",
-    "postuninstall": "electron-builder install-app-deps",
     "test": "vitest --run",
     "test:dev": "vitest",
     "coverage": "vitest run --coverage",
@@ -49,7 +48,6 @@
     "@types/node": "^25.6.0",
     "@types/semver": "^7.7.1",
     "@types/throttle-debounce": "^5.0.2",
-    "@types/uuid": "^11.0.0",
     "@types/webpack-env": "^1.18.8",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-istanbul": "^4.1.5",
@@ -75,7 +73,6 @@
     "uuid": "^14.0.0",
     "vite": "^8.0.10",
     "vite-plugin-electron": "^0.29.1",
-    "vite-plugin-electron-renderer": "^0.14.7",
     "vite-plugin-pwa": "^1.3.0",
     "vite-plugin-vue-devtools": "^8.1.2",
     "vitepress": "^1.6.4",
@@ -89,6 +86,9 @@
     "vue3-tabs-chrome": "^0.3.3",
     "yaml": "^2.8.4"
   },
-  "license": "GPL-3.0",
-  "packageManager": "npm@11.12.1"
+  "license": "GPL-3.0-only",
+  "packageManager": "npm@11.12.1",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/src/services/LayoutService.test.ts
+++ b/src/services/LayoutService.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it, Mock, vi } from 'vitest';
 import {
   MartyriaElement,
   NoteElement,
+  ScoreElement,
   TempoElement,
   TextBoxElement,
 } from '../models/Element';
+import { Ison, QuantitativeNeume } from '../models/Neumes';
 import { Line, Page } from '../models/Page';
+import { PageSetup } from '../models/PageSetup';
 import { fontService } from './FontService';
 import { LayoutService } from './LayoutService';
 import { NeumeMappingService } from './NeumeMappingService';
@@ -14,7 +17,7 @@ import { NeumeMappingService } from './NeumeMappingService';
 vi.mock('./NeumeMappingService');
 vi.mock('./FontService');
 
-const itif = (condition) => (condition ? it : it.skip);
+const itif = (condition: boolean) => (condition ? it : it.skip);
 
 describe.each([true, false])(
   'LayoutService.findFinalAndNextElement',
@@ -29,7 +32,7 @@ describe.each([true, false])(
       expectedFinalElement.isMelisma = true;
 
       const element = melismaStart;
-      const line = { elements: [melismaStart, expectedFinalElement] };
+      const line = getLine(melismaStart, expectedFinalElement);
       const firstElementOnNextLine = null;
 
       const { finalElement, nextElement } =
@@ -58,9 +61,11 @@ describe.each([true, false])(
       expectedNextElement.isMelismaStart = true;
 
       const element = melismaStart;
-      const line = {
-        elements: [melismaStart, expectedFinalElement, expectedNextElement],
-      };
+      const line = getLine(
+        melismaStart,
+        expectedFinalElement,
+        expectedNextElement,
+      );
       const firstElementOnNextLine = null;
 
       const { finalElement, nextElement } =
@@ -91,7 +96,7 @@ describe.each([true, false])(
       const martyria = new MartyriaElement();
 
       const element = melismaStart;
-      const line = { elements: [melismaStart, martyria, expectedFinalElement] };
+      const line = getLine(melismaStart, martyria, expectedFinalElement);
       const firstElementOnNextLine = null;
 
       const { finalElement, nextElement } =
@@ -126,14 +131,12 @@ describe.each([true, false])(
       expectedNextElement.isMelismaStart = true;
 
       const element = melismaStart;
-      const line = {
-        elements: [
-          melismaStart,
-          martyriaElement,
-          expectedFinalElement,
-          expectedNextElement,
-        ],
-      };
+      const line = getLine(
+        melismaStart,
+        martyriaElement,
+        expectedFinalElement,
+        expectedNextElement,
+      );
       const firstElementOnNextLine = null;
 
       const { finalElement, nextElement } =
@@ -171,15 +174,13 @@ describe.each([true, false])(
         expectedNextElement.isMelismaStart = true;
 
         const element = melismaStart;
-        const line = {
-          elements: [
-            melismaStart,
-            martyriaElement,
-            tempoElement,
-            expectedFinalElement,
-            expectedNextElement,
-          ],
-        };
+        const line = getLine(
+          melismaStart,
+          martyriaElement,
+          tempoElement,
+          expectedFinalElement,
+          expectedNextElement,
+        );
         const firstElementOnNextLine = null;
 
         const { finalElement, nextElement } =
@@ -218,15 +219,13 @@ describe.each([true, false])(
         newNote.isMelismaStart = true;
 
         const element = melismaStart;
-        const line = {
-          elements: [
-            melismaStart,
-            expectedFinalElement,
-            expectedNextElement,
-            martyriaNote,
-            newNote,
-          ],
-        };
+        const line = getLine(
+          melismaStart,
+          expectedFinalElement,
+          expectedNextElement,
+          martyriaNote,
+          newNote,
+        );
         const firstElementOnNextLine = null;
 
         const { finalElement, nextElement } =
@@ -256,14 +255,12 @@ describe.each([true, false])(
       expectedFinalElement.isMelisma = true;
 
       const element = melismaStart;
-      const line = {
-        elements: [
-          melismaStart,
-          expectedFinalElement,
-          expectedNextElement,
-          new NoteElement(),
-        ],
-      };
+      const line = getLine(
+        melismaStart,
+        expectedFinalElement,
+        expectedNextElement,
+        new NoteElement(),
+      );
       const firstElementOnNextLine = null;
 
       const { finalElement, nextElement } =
@@ -282,9 +279,7 @@ describe.each([true, false])(
 
 describe('LayoutService.alignIsonIndicators', () => {
   it('should adjust isonOffsetYAdjusted for notes with ison indicators', () => {
-    const mockPageSetup = {
-      neumeDefaultFontFamily: 'MockFont',
-    };
+    const mockPageSetup = getMockPageSetup();
 
     const mockBaseMapping1 = { glyphName: 'baseGlyph1' };
     const mockBaseMapping2 = { glyphName: 'baseGlyph2' };
@@ -294,8 +289,8 @@ describe('LayoutService.alignIsonIndicators', () => {
     const mockOffset2 = { y: 20 };
 
     (NeumeMappingService.getMapping as Mock).mockImplementation((neume) => {
-      if (neume === 'base1') return mockBaseMapping1;
-      if (neume === 'base2') return mockBaseMapping2;
+      if (neume === QuantitativeNeume.Ison) return mockBaseMapping1;
+      if (neume === QuantitativeNeume.Oligon) return mockBaseMapping2;
       return mockMarkMapping;
     });
 
@@ -308,15 +303,14 @@ describe('LayoutService.alignIsonIndicators', () => {
     );
 
     const note1 = new NoteElement();
-    note1.quantitativeNeume = 'base1';
-    note1.ison = 'mark';
+    note1.quantitativeNeume = QuantitativeNeume.Ison;
+    note1.ison = Ison.Unison;
 
     const note2 = new NoteElement();
-    note2.quantitativeNeume = 'base2';
-    note2.ison = 'mark';
+    note2.quantitativeNeume = QuantitativeNeume.Oligon;
+    note2.ison = Ison.Unison;
 
-    const line = new Line();
-    line.elements = [note1, note2];
+    const line = getLine(note1, note2);
 
     const page = new Page();
     page.lines = [line];
@@ -328,9 +322,7 @@ describe('LayoutService.alignIsonIndicators', () => {
   });
 
   it('should adjust isonOffsetYAdjusted for notes with ison indicators and ison offsets', () => {
-    const mockPageSetup = {
-      neumeDefaultFontFamily: 'MockFont',
-    };
+    const mockPageSetup = getMockPageSetup();
 
     const mockBaseMapping1 = { glyphName: 'baseGlyph1' };
     const mockBaseMapping2 = { glyphName: 'baseGlyph2' };
@@ -340,8 +332,8 @@ describe('LayoutService.alignIsonIndicators', () => {
     const mockOffset2 = { y: 20 };
 
     (NeumeMappingService.getMapping as Mock).mockImplementation((neume) => {
-      if (neume === 'base1') return mockBaseMapping1;
-      if (neume === 'base2') return mockBaseMapping2;
+      if (neume === QuantitativeNeume.Ison) return mockBaseMapping1;
+      if (neume === QuantitativeNeume.Oligon) return mockBaseMapping2;
       return mockMarkMapping;
     });
 
@@ -354,17 +346,16 @@ describe('LayoutService.alignIsonIndicators', () => {
     );
 
     const note1 = new NoteElement();
-    note1.quantitativeNeume = 'base1';
-    note1.ison = 'mark';
+    note1.quantitativeNeume = QuantitativeNeume.Ison;
+    note1.ison = Ison.Unison;
     note1.isonOffsetY = -5;
 
     const note2 = new NoteElement();
-    note2.quantitativeNeume = 'base2';
-    note2.ison = 'mark';
+    note2.quantitativeNeume = QuantitativeNeume.Oligon;
+    note2.ison = Ison.Unison;
     note2.isonOffsetY = -25;
 
-    const line = new Line();
-    line.elements = [note1, note2];
+    const line = getLine(note1, note2);
 
     const page = new Page();
     page.lines = [line];
@@ -376,16 +367,13 @@ describe('LayoutService.alignIsonIndicators', () => {
   });
 
   it('should handle cases with no notes having ison indicators', () => {
-    const mockPageSetup = {
-      neumeDefaultFontFamily: 'MockFont',
-    };
+    const mockPageSetup = getMockPageSetup();
 
     const note = new NoteElement();
-    note.quantitativeNeume = 'base';
+    note.quantitativeNeume = QuantitativeNeume.Ison;
     note.ison = null;
 
-    const line = new Line();
-    line.elements = [note];
+    const line = getLine(note);
 
     const page = new Page();
     page.lines = [line];
@@ -396,9 +384,7 @@ describe('LayoutService.alignIsonIndicators', () => {
   });
 
   it('should handle empty pages gracefully', () => {
-    const mockPageSetup = {
-      neumeDefaultFontFamily: 'MockFont',
-    };
+    const mockPageSetup = getMockPageSetup();
 
     const page = new Page();
     page.lines = [];
@@ -413,4 +399,16 @@ function getInlineTextBox() {
   const inlineTextBox = new TextBoxElement();
   inlineTextBox.inline = true;
   return inlineTextBox;
+}
+
+function getLine(...elements: ScoreElement[]) {
+  const line = new Line();
+  line.elements = elements;
+  return line;
+}
+
+function getMockPageSetup() {
+  const pageSetup = new PageSetup();
+  pageSetup.neumeDefaultFontFamily = 'MockFont';
+  return pageSetup;
 }

--- a/src/services/LyricService.test.ts
+++ b/src/services/LyricService.test.ts
@@ -223,7 +223,7 @@ describe('LyricService (English)', () => {
         .filter((x) =>
           [ElementType.Note, ElementType.DropCap].includes(x.elementType),
         )
-        .map((x: NoteElement | DropCapElement) =>
+        .map((x) =>
           x.elementType === ElementType.Note
             ? {
                 lyrics: (x as NoteElement).lyrics,

--- a/src/services/integration/ByzHtmlExporter.test.ts
+++ b/src/services/integration/ByzHtmlExporter.test.ts
@@ -29,7 +29,7 @@ describe('ByzHtmlExporter', () => {
 
     expect(
       Object.keys(glyphnames)
-        .filter((x) => !exceptions.includes(x))
+        .filter((x) => !exceptions.includes(x as SbmuflGlyphName))
         .every((x) => exporter.getTag(x as SbmuflGlyphName) !== undefined),
     ).toBe(true);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,17 +4,13 @@
     "module": "esnext",
     "strict": true,
     "jsx": "preserve",
-    "importHelpers": true,
     "moduleResolution": "bundler",
-    "experimentalDecorators": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "types": [
       "vite/client"
     ],
-    "typeRoots": ["./node_modules/@types/", "./types", "./src/**/types"],
     "paths": {
       "@/*": [
         "./src/*"
@@ -22,15 +18,13 @@
     },
     "lib": [
       "esnext",
-      "dom",
-      "scripthost"
+      "dom"
     ]
   },
   "include": [
     "electron/**/*.ts",
     "src/**/*.ts",
-    "src/**/*.vue",
-    "tests/**/*.ts"
+    "src/**/*.vue"
   ],
   "exclude": [
     "node_modules",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -168,9 +168,6 @@ export default defineConfig(({ command, mode }) => {
           port: +url.port,
         };
       })(),
-    test: {
-      globals: true,
-    },
     clearScreen: false,
   };
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,18 +1,19 @@
-import Vue from '@vitejs/plugin-vue';
+import vue from '@vitejs/plugin-vue';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [Vue()],
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
   },
   test: {
+    globals: true,
     coverage: {
       provider: 'istanbul',
-      reporter: ['text'],
+      reporter: ['text', 'lcov'],
       excludeAfterRemap: true,
     },
   },


### PR DESCRIPTION
## Summary

AI-generated cleanup PR; description of changes below.

---

## Changes

### Delete `.browserslistrc`

**Motivation:** `.browserslistrc` is a Vue CLI / Babel artifact. The project now uses Vite for bundling, which has its own browser target handling and does not read this file.

**Implementation:** File deleted.

---

### Delete `babel.config.js`

**Motivation:** `babel.config.js` referenced `@vue/cli-plugin-babel/preset`, which belongs to the old Vue CLI build pipeline. With Vite handling transpilation, Babel is no longer involved in the build.

**Implementation:** File deleted.

---

### `index.html` -- remove `X-UA-Compatible` meta tag

**Motivation:** `<meta http-equiv="X-UA-Compatible" content="IE=edge">` was a directive to force Internet Explorer into its highest rendering mode. IE is end-of-life and the project targets modern browsers; the tag is dead weight.

**Implementation:** Line removed.

---

### `.gitignore` -- add coverage output directory and fix missing newline

**Motivation:** `vitest run --coverage` writes output to `/coverage/`. Without this entry the directory would appear as untracked noise in `git status`.  The file also lacked a trailing newline, which is corrected here.

**Implementation:** Added `/coverage/` entry under a `# Vitest coverage output` comment; added trailing newline after `/dist-electron`.

---

### `eslint.config.mjs` -- drop stale ignore entry

**Motivation:** The `.scripts/**/*` ignore pattern referenced a directory that does not exist in the project (the actual script directory is `scripts/` without the leading dot). It was dead configuration.

**Implementation:** Removed `.scripts/**/*` from the `ignores` array; remaining entries collapsed onto a single line by Prettier.

---

### `package.json` / `package-lock.json` -- fix SPDX license, clean up scripts, prune unused deps, declare engines

**Motivation (license):** `GPL-3.0` is not a valid SPDX identifier; the correct form is `GPL-3.0-only`. This matters for automated license scanning tools.

**Motivation (`postuninstall` removal):** The `postuninstall` lifecycle hook ran `electron-builder install-app-deps` on every `npm uninstall`, which is incorrect -- native deps only need rebuilding after install, not uninstall.

**Motivation (lint scripts):** ESLint v9+ uses a flat config (`eslint.config.mjs`) by default and no longer requires `--config eslint.config.mjs` to be specified explicitly. Passing it explicitly is redundant.

**Motivation (`@types/uuid` removal):** `uuid` v14 ships its own type definitions, so the separate `@types/uuid` stub package is no longer needed (npm even surfaces a deprecation notice for it).

**Motivation (`vite-plugin-electron-renderer` removal):** The plugin was listed as a devDependency but is not imported or referenced anywhere in the build configuration -- dead weight.

**Motivation (`engines` field):** Declares a minimum supported Node.js version (`>=22`) so contributors and CI fail fast on older runtimes rather than hitting obscure runtime errors.

**Implementation:** `"license"` changed from `"GPL-3.0"` to `"GPL-3.0-only"` in both files; `"postuninstall"` script removed; `--config eslint.config.mjs` flag dropped from `lint` and `lint:fix` scripts; `@types/uuid` and `vite-plugin-electron-renderer` removed from `devDependencies` (and `package-lock.json` updated accordingly); `engines: { node: ">=22" }` added.

---

### `tsconfig.json` -- remove obsolete compiler options

**Motivation:** Several options are either defaults, redundant with `moduleResolution: "bundler"`, or are Vue CLI / legacy artifacts:

- `importHelpers`: injects tslib helpers for older targets; not needed with modern bundler output.
- `experimentalDecorators`: the project does not use decorators.
- `allowSyntheticDefaultImports`: implied by `esModuleInterop: true`.
- `typeRoots`: unnecessary when `types` is specified explicitly and the compiler can find `@types` automatically.
- `"scripthost"` lib: targets the Windows Script Host runtime, irrelevant for a browser/Electron app.

**Motivation (include):** `tests/**/*.ts` is not a path used in this project (tests live under `src/`), so including it was a no-op.

**Implementation:** Removed `importHelpers`, `experimentalDecorators`, `allowSyntheticDefaultImports`, `typeRoots`, `"scripthost"` from `lib`, and `tests/**/*.ts` from `include`.

---

### `vite.config.mjs` -- move `test` config to `vitest.config.ts`

**Motivation:** Having `test: { globals: true }` inside `vite.config.mjs` is redundant once a dedicated `vitest.config.ts` exists. Vitest picks up `vitest.config.ts` by default, so the setting belongs there.

**Implementation:** Removed the `test` block from `vite.config.mjs`; `globals: true` added to `vitest.config.ts` instead.

---

### `vitest.config.ts` -- consolidate test config and improve coverage

**Motivation:** Three separate improvements:

1. **`globals: true`** moved here from `vite.config.mjs` so all Vitest configuration lives in one place.
2. **`lcov` coverage reporter** added alongside `text`. lcov output (`coverage/lcov.info`) is the standard format consumed by CI coverage services and IDE coverage overlays.
3. **Plugin import casing** -- `import Vue from '@vitejs/plugin-vue'` used a PascalCase default import for a factory function; the conventional name is lowercase `vue`.

**Implementation:** `globals: true` added; `reporter` extended to `['text', 'lcov']`; import renamed from `Vue` to `vue` and call site updated.

---

### `src/services/LayoutService.test.ts` -- use real types instead of inline object literals

**Motivation:** Tests were constructing plain object literals (`{ elements: [...] }`, `{ neumeDefaultFontFamily: '...' }`) in place of the actual model classes (`Line`, `PageSetup`). This means TypeScript cannot catch shape mismatches between the test doubles and the real types, and tests can silently pass even when the production types diverge. Similarly, string literals (`'base1'`, `'mark'`) were used where typed enum values (`QuantitativeNeume`, `Ison`) should be.

**Implementation:**
- Added `getLine(...elements: ScoreElement[]): Line` helper that constructs a real `Line` and assigns `elements`, replacing all inline `{ elements: [...] }` literals throughout the file.
- Added `getMockPageSetup(): PageSetup` helper that constructs a real `PageSetup` and sets `neumeDefaultFontFamily = 'MockFont'`, replacing all inline `{ neumeDefaultFontFamily: '...' }` literals.
- Replaced string literals `'base1'` / `'base2'` / `'mark'` with `QuantitativeNeume.Ison`, `QuantitativeNeume.Oligon`, and `Ison.Unison`.
- Added `itif` parameter type annotation (`condition: boolean`) so the helper has an explicit signature instead of an implicit `any`.
- Added imports for `ScoreElement`, `Ison`, `QuantitativeNeume`, and `PageSetup`.

---

### `src/services/LyricService.test.ts` -- remove redundant type annotation in `.map()` callback

**Motivation:** The explicit `(x: NoteElement | DropCapElement)` annotation in the `.map()` callback is unnecessary because TypeScript can infer the type from the preceding `.filter()`. With strict mode enforced across test files, the explicit annotation also risks becoming stale if the upstream type changes.

**Implementation:** Removed the explicit parameter type, letting TypeScript infer it.

---

### `src/services/integration/ByzHtmlExporter.test.ts` -- fix type error in `.filter()` callback

**Motivation:** `exceptions` is typed as `SbmuflGlyphName[]` but the `.filter()` callback passed a plain `string` to `Array.prototype.includes`, which TypeScript 5+ rejects under strict mode because `string` is not assignable to `SbmuflGlyphName`.

**Implementation:** Cast `x` to `SbmuflGlyphName` at the `includes` call site (`!exceptions.includes(x as SbmuflGlyphName)`), consistent with the cast already present on the `.every()` callback on the next line.