### PR TITLE
chore: switch Vue ESLint config from essential to recommended

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ export default [
   {
     ignores: ['dist/**/*', 'dist-electron/**/*', '**/.vitepress/cache/**/*'],
   },
-  ...pluginVue.configs['flat/essential'],
+  ...pluginVue.configs['flat/recommended'],
   ...vueTsEslintConfig({
     extends: ['recommended'],
   }),

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <router-view />
-  <div class="update-notification" v-if="updateExists">
+  <div v-if="updateExists" class="update-notification">
     An update is available.
     <button class="ok" @click="refreshApp">Update</button>
     <button class="cancel" @click="updateExists = false">Not now</button>
@@ -12,8 +12,8 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   components: {},
-  emits: [],
   props: {},
+  emits: [],
 
   data() {
     return {

--- a/src/components/AlternateLine.vue
+++ b/src/components/AlternateLine.vue
@@ -9,8 +9,8 @@
         v-if="childElement.elementType === ElementType.Note"
         class="syllable-box"
         :note="childElement as NoteElement"
-        :pageSetup="pageSetup"
-        :alternateLine="true"
+        :page-setup="pageSetup"
+        :alternate-line="true"
       />
     </template>
   </div>
@@ -31,7 +31,6 @@ import NeumeBoxSyllable from './NeumeBoxSyllable.vue';
 
 export default defineComponent({
   components: { NeumeBoxSyllable },
-  emits: ['update'],
   props: {
     element: {
       type: Object as PropType<AlternateLineElement>,
@@ -42,6 +41,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update'],
 
   data() {
     return {

--- a/src/components/ButtonWithMenu.vue
+++ b/src/components/ButtonWithMenu.vue
@@ -6,14 +6,14 @@
   >
     <button class="neume-button" :disabled="disabled">
       <img
+        v-if="mainIcon"
         draggable="false"
         :src="mainIcon"
-        v-if="mainIcon"
         :style="imgStyle"
       />
-      <span :style="textStyle" v-if="mainText">{{ mainText }}</span>
+      <span v-if="mainText" :style="textStyle">{{ mainText }}</span>
     </button>
-    <div class="menu" :class="direction" v-if="showMenu">
+    <div v-if="showMenu" class="menu" :class="direction">
       <div
         v-for="option in options"
         :key="getKey(option)"
@@ -22,12 +22,12 @@
         @mouseenter="handleMouseEnter(option.neume)"
       >
         <img
+          v-if="option.icon"
           draggable="false"
           :src="option.icon"
-          v-if="option.icon"
           :style="imgStyle"
         />
-        <span :style="textStyle" v-if="option.text">{{ option.text }}</span>
+        <span v-if="option.text" :style="textStyle">{{ option.text }}</span>
       </div>
     </div>
   </div>
@@ -46,9 +46,8 @@ export interface ButtonWithMenuOption {
 }
 
 export default defineComponent({
-  inject: ['editorPreferences'],
   components: {},
-  emits: ['select'],
+  inject: ['editorPreferences'],
   props: {
     direction: {
       type: String as PropType<'up' | 'down'>,
@@ -68,24 +67,16 @@ export default defineComponent({
     },
     imgSize: {
       type: String,
-      required: false,
+      default: undefined,
     },
   },
+  emits: ['select'],
 
   data() {
     return {
       showMenu: false,
       selectedOption: null as Neume | Neume[] | null,
     };
-  },
-
-  mounted() {
-    window.addEventListener('pointerdown', this.handleGlobalPointerDown);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('mouseup', this.onMouseUp);
-    window.removeEventListener('pointerdown', this.handleGlobalPointerDown);
   },
 
   computed: {
@@ -116,6 +107,15 @@ export default defineComponent({
         width: this.imgSize ?? undefined,
       } as StyleValue;
     },
+  },
+
+  mounted() {
+    window.addEventListener('pointerdown', this.handleGlobalPointerDown);
+  },
+
+  beforeUnmount() {
+    window.removeEventListener('mouseup', this.onMouseUp);
+    window.removeEventListener('pointerdown', this.handleGlobalPointerDown);
   },
 
   methods: {

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -7,10 +7,10 @@
       <div class="popover" :style="popupStyle">
         <div class="cover" @click="close" />
         <Sketch
-          @update:modelValue="onColorChanged"
-          :modelValue="color"
-          :presetColors="presetColors"
-          :disableAlpha="true"
+          :model-value="color"
+          :preset-colors="presetColors"
+          :disable-alpha="true"
+          @update:model-value="onColorChanged"
         />
       </div>
     </template>
@@ -27,7 +27,6 @@ interface Color {
 
 export default defineComponent({
   components: { Sketch },
-  emits: ['update:modelValue'],
   props: {
     modelValue: {
       type: String,
@@ -38,6 +37,7 @@ export default defineComponent({
       default: 'colorPicker_presetColors',
     },
   },
+  emits: ['update:modelValue'],
 
   data() {
     return {
@@ -51,16 +51,6 @@ export default defineComponent({
 
       color: '#000000',
     };
-  },
-
-  created() {
-    this.color = this.modelValue;
-  },
-
-  watch: {
-    modelValue(newValue: string) {
-      this.color = newValue;
-    },
   },
 
   computed: {
@@ -79,6 +69,16 @@ export default defineComponent({
         top: `${this.popupPositionTop}px`,
       } as StyleValue;
     },
+  },
+
+  watch: {
+    modelValue(newValue: string) {
+      this.color = newValue;
+    },
+  },
+
+  created() {
+    this.color = this.modelValue;
   },
 
   methods: {

--- a/src/components/ContentEditable.vue
+++ b/src/components/ContentEditable.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- eslint-disable vue/no-v-html -->
   <span
     class="contenteditable"
     :contenteditable="contentEditable"
@@ -8,6 +9,7 @@
     @click="$emit('click')"
     v-html="content"
   />
+  <!-- eslint-enable vue/no-v-html -->
 </template>
 
 <script lang="ts">
@@ -15,7 +17,6 @@ import { defineComponent, StyleValue } from 'vue';
 
 export default defineComponent({
   components: {},
-  emits: ['click', 'focus', 'blur', 'onEditorReady'],
   props: {
     content: {
       type: String,
@@ -38,13 +39,10 @@ export default defineComponent({
       default: 'break-spaces',
     },
   },
+  emits: ['click', 'focus', 'blur', 'onEditorReady'],
 
   data() {
     return {};
-  },
-
-  mounted() {
-    this.$emit('onEditorReady');
   },
 
   computed: {
@@ -65,6 +63,10 @@ export default defineComponent({
         whiteSpace: this.whiteSpace,
       } as StyleValue;
     },
+  },
+
+  mounted() {
+    this.$emit('onEditorReady');
   },
 
   methods: {

--- a/src/components/DragHandle.vue
+++ b/src/components/DragHandle.vue
@@ -13,7 +13,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: {},
-  emits: ['update'],
   props: {
     x: {
       type: [Number, null],
@@ -52,6 +51,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update'],
 
   data() {
     return {
@@ -60,15 +60,6 @@ export default defineComponent({
 
       offset: { x: 0, y: 0 } as ScoreElementOffset,
     };
-  },
-
-  created() {
-    this.offset = this.getOffset(this.mark);
-  },
-
-  beforeUnmount() {
-    document.removeEventListener('mouseup', this.handleMouseUp);
-    document.removeEventListener('mousemove', this.handleMouseMove);
   },
 
   computed: {
@@ -85,6 +76,15 @@ export default defineComponent({
         width: withZoom(this.width),
       } as StyleValue;
     },
+  },
+
+  created() {
+    this.offset = this.getOffset(this.mark);
+  },
+
+  beforeUnmount() {
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('mousemove', this.handleMouseMove);
   },
 
   methods: {

--- a/src/components/DropCap.vue
+++ b/src/components/DropCap.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     class="drop-cap-container"
-    @click="$emit('select-single')"
     :style="containerStyle"
+    @click="$emit('select-single')"
   >
     <span class="handle"></span>
 
@@ -28,7 +28,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { ContentEditable },
-  emits: ['update:content', 'select-single'],
   props: {
     element: {
       type: Object as PropType<DropCapElement>,
@@ -43,6 +42,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update:content', 'select-single'],
 
   data() {
     return {};

--- a/src/components/EditorPreferencesDialog.vue
+++ b/src/components/EditorPreferencesDialog.vue
@@ -23,11 +23,11 @@
           <Neume
             class="tempo-neume"
             :neume="tempo"
-            :fontFamily="pageSetup.neumeDefaultFontFamily"
+            :font-family="pageSetup.neumeDefaultFontFamily"
           />
           <InputBpm
-            :modelValue="form.tempoDefaults[tempo]!"
-            @update:modelValue="onTempoChanged(tempo, $event)"
+            :model-value="form.tempoDefaults[tempo]!"
+            @update:model-value="onTempoChanged(tempo, $event)"
           />
           <span class="unit-label">{{ $t('dialog:preferences.bpm') }}</span>
         </div>
@@ -71,7 +71,6 @@ const tempoSigns = [
 
 export default defineComponent({
   components: { ModalDialog, Neume, InputBpm },
-  emits: ['close', 'update'],
   props: {
     options: {
       type: Object as PropType<EditorPreferences>,
@@ -82,6 +81,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['close', 'update'],
 
   data() {
     return {
@@ -90,6 +90,8 @@ export default defineComponent({
       ButtonMenuMode,
     };
   },
+
+  computed: {},
 
   mounted() {
     this.form = JSON.parse(JSON.stringify(this.options));
@@ -100,8 +102,6 @@ export default defineComponent({
   beforeUnmount() {
     window.removeEventListener('keydown', this.onKeyDown);
   },
-
-  computed: {},
 
   methods: {
     onKeyDown(event: KeyboardEvent) {

--- a/src/components/ExportDialog.vue
+++ b/src/components/ExportDialog.vue
@@ -22,24 +22,24 @@
           </select>
         </div>
         <template v-if="exportFormatIsImage">
-          <div class="form-group row" v-if="format === ExportFormat.PNG">
+          <div v-if="format === ExportFormat.PNG" class="form-group row">
             <label class="medium">{{ $t('dialog:export.resolution') }}</label>
             <InputUnit
+              v-model="dpi"
               unit="unitless"
               class="dpi"
               :min="32"
               :max="999"
               :step="1"
               :round="round"
-              v-model="dpi"
             />
             <span class="unit-label">{{ $t('dialog:export.dpi') }}</span>
           </div>
-          <div class="form-group row" v-if="format === ExportFormat.PNG">
+          <div v-if="format === ExportFormat.PNG" class="form-group row">
             <input
               id="export-dialog-transparent-bg"
-              type="checkbox"
               v-model="transparentBackground"
+              type="checkbox"
             />
             <label for="export-dialog-transparent-bg">{{
               $t('dialog:export.transparentBackground')
@@ -52,8 +52,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-open-folder"
-              type="checkbox"
               v-model="openFolder"
+              type="checkbox"
             />
             <label for="export-dialog-open-folder">{{
               $t('dialog:export.openDestinationFolderAfterExport')
@@ -64,8 +64,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-calculate-time-signatures"
-              type="checkbox"
               v-model="musicXmlOptions.calculateTimeSignatures"
+              type="checkbox"
             />
             <label for="export-dialog-calculate-time-signatures">{{
               $t('dialog:export.calculateTimeSignatures')
@@ -74,8 +74,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-display-time-signatures"
-              type="checkbox"
               v-model="musicXmlOptions.displayTimeSignatures"
+              type="checkbox"
             />
             <label for="export-dialog-display-time-signatures">{{
               $t('dialog:export.displayTimeSignatures')
@@ -84,8 +84,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-display-measure-subdivisions"
-              type="checkbox"
               v-model="musicXmlOptions.displayMeasureSubdivisions"
+              type="checkbox"
             />
             <label for="export-dialog-display-measure-subdivisions">{{
               $t('dialog:export.displayMeasureSubdivisions')
@@ -97,8 +97,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-open-folder"
-              type="checkbox"
               v-model="openFolder"
+              type="checkbox"
             />
             <label for="export-dialog-open-folder">{{
               $t('dialog:export.openDestinationFolderAfterExport')
@@ -109,8 +109,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-include-mode-keys"
-              type="checkbox"
               v-model="latexOptions.includeModeKeys"
+              type="checkbox"
             />
             <label for="export-dialog-include-mode-keys">{{
               $t('dialog:export.includeModeKeys')
@@ -119,8 +119,8 @@
           <div class="form-group row">
             <input
               id="export-dialog-include-text-boxes"
-              type="checkbox"
               v-model="latexOptions.includeTextBoxes"
+              type="checkbox"
             />
             <label for="export-dialog-include-text-boxes">{{
               $t('dialog:export.includeTextBoxes')
@@ -182,13 +182,6 @@ export interface ExportAsLatexSettings {
 
 export default defineComponent({
   components: { ModalDialog, InputUnit },
-  emits: [
-    'close',
-    'exportAsLatex',
-    'exportAsMusicXml',
-    'exportAsPng',
-    'exportAsSvg',
-  ],
   props: {
     defaultFormat: {
       type: String as PropType<ExportFormat>,
@@ -199,6 +192,13 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: [
+    'close',
+    'exportAsLatex',
+    'exportAsMusicXml',
+    'exportAsPng',
+    'exportAsSvg',
+  ],
 
   data() {
     return {
@@ -214,6 +214,14 @@ export default defineComponent({
     };
   },
 
+  computed: {
+    exportFormatIsImage() {
+      return (
+        this.format === ExportFormat.PNG || this.format === ExportFormat.SVG
+      );
+    },
+  },
+
   mounted() {
     if (this.defaultFormat != null) {
       this.format = this.defaultFormat;
@@ -224,14 +232,6 @@ export default defineComponent({
 
   beforeUnmount() {
     window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  computed: {
-    exportFormatIsImage() {
-      return (
-        this.format === ExportFormat.PNG || this.format === ExportFormat.SVG
-      );
-    },
   },
 
   methods: {

--- a/src/components/FileMenuBar.vue
+++ b/src/components/FileMenuBar.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="file-menu-bar" @focusout="isMenuOpen = false" tabindex="-1">
+  <div class="file-menu-bar" tabindex="-1" @focusout="isMenuOpen = false">
     <FileMenuBarItem
       :label="$t('menu:file.root')"
+      :is-open="isMenuOpen && selectedMenu === 'File'"
       @click="toggleMenu"
       @mouseenter="selectedMenu = 'File'"
-      :isOpen="isMenuOpen && selectedMenu === 'File'"
     >
       <FileMenuItem :label="$t('menu:file.new')" @click="onClickNew" />
       <FileMenuItem :label="$t('menu:file.open')" @click="onClickOpen" />
@@ -35,9 +35,9 @@
     </FileMenuBarItem>
     <FileMenuBarItem
       :label="$t('menu:edit.root')"
+      :is-open="isMenuOpen && selectedMenu === 'Edit'"
       @click="toggleMenu"
       @mouseenter="selectedMenu = 'Edit'"
-      :isOpen="isMenuOpen && selectedMenu === 'Edit'"
     >
       <FileMenuItem :label="$t('menu:edit.undo')" @click="onClickUndo" />
       <FileMenuItem :label="$t('menu:edit.redo')" @click="onClickRedo" />
@@ -74,9 +74,9 @@
     </FileMenuBarItem>
     <FileMenuBarItem
       :label="$t('menu:insert.root')"
+      :is-open="isMenuOpen && selectedMenu === 'Insert'"
       @click="toggleMenu"
       @mouseenter="selectedMenu = 'Insert'"
-      :isOpen="isMenuOpen && selectedMenu === 'Insert'"
     >
       <FileMenuItem
         :label="$t('menu:insert.alternateLine')"
@@ -123,9 +123,9 @@
     </FileMenuBarItem>
     <FileMenuBarItem
       :label="$t('menu:help.root')"
+      :is-open="isMenuOpen && selectedMenu === 'Help'"
       @click="toggleMenu"
       @mouseenter="selectedMenu = 'Help'"
-      :isOpen="isMenuOpen && selectedMenu === 'Help'"
     >
       <FileMenuItem :label="$t('menu:help.guide')" @click="onClickGuide" />
       <div class="separator" />
@@ -140,21 +140,21 @@
       <div class="separator" />
       <FileMenuItem :label="$t('menu:help.about')" @click="onClickAbout" />
     </FileMenuBarItem>
-    <div class="browser-warning" v-if="!isChrome">
+    <div v-if="!isChrome" class="browser-warning">
       {{ $t('menu:warning') }}
     </div>
     <input
+      v-show="false"
       ref="file"
       type="file"
       :accept="accept"
-      v-show="false"
       @change="onSelectFile"
     />
     <input
+      v-show="false"
       ref="imagefile"
       type="file"
       :accept="acceptImage"
-      v-show="false"
       @change="onSelectImageFile"
     />
   </div>
@@ -179,8 +179,8 @@ import {
 
 export default defineComponent({
   components: { FileMenuBarItem, FileMenuItem },
-  emits: [],
   props: {},
+  emits: [],
 
   data() {
     return {
@@ -190,6 +190,16 @@ export default defineComponent({
       acceptImage: '.bmp,.jpg,.jpeg,.jpe,.png,.gif,.svg,.webp,.ico',
       isChrome: (window as any).chrome != null,
     };
+  },
+
+  computed: {
+    fileSelector() {
+      return this.$refs.file as HTMLInputElement;
+    },
+
+    imageFileSelector() {
+      return this.$refs.imagefile as HTMLInputElement;
+    },
   },
 
   mounted() {
@@ -203,16 +213,6 @@ export default defineComponent({
   beforeUnmount() {
     window.removeEventListener('keydown', this.onKeyDown);
     EventBus.$off(IpcRendererChannels.OpenImageDialog, this.onClickAddImage);
-  },
-
-  computed: {
-    fileSelector() {
-      return this.$refs.file as HTMLInputElement;
-    },
-
-    imageFileSelector() {
-      return this.$refs.imagefile as HTMLInputElement;
-    },
   },
 
   methods: {

--- a/src/components/FileMenuBarItem.vue
+++ b/src/components/FileMenuBarItem.vue
@@ -5,7 +5,7 @@
     @mouseenter="$emit('mouseenter')"
   >
     {{ label }}
-    <div class="file-menu-item-container" v-if="isOpen">
+    <div v-if="isOpen" class="file-menu-item-container">
       <slot />
     </div>
   </div>
@@ -16,7 +16,6 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   components: {},
-  emits: ['click', 'mouseenter'],
   props: {
     label: {
       type: String,
@@ -27,6 +26,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['click', 'mouseenter'],
 
   data() {
     return {};

--- a/src/components/FileMenuItem.vue
+++ b/src/components/FileMenuItem.vue
@@ -9,13 +9,13 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   components: {},
-  emits: ['click'],
   props: {
     label: {
       type: String,
       required: true,
     },
   },
+  emits: ['click'],
 
   data() {
     return {};

--- a/src/components/ImageBox.vue
+++ b/src/components/ImageBox.vue
@@ -16,12 +16,12 @@
       :lock-aspect-ratio="element.lockAspectRatio"
       :w="imageWidthZoomed"
       :h="imageHeightZoomed"
-      :minHeight="10"
-      :minWidth="10"
+      :min-height="10"
+      :min-width="10"
       :draggable="false"
       :z="1"
       @resizing="onResize"
-      @resizeStop="onResizeStop"
+      @resize-stop="onResizeStop"
     >
       <img class="image-box" :src="element.data" :style="imageStyle" />
     </vue-draggable-resizable>
@@ -39,7 +39,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { VueDraggableResizable },
-  emits: ['update:size', 'select-single'],
   props: {
     element: {
       type: Object as PropType<ImageBoxElement>,
@@ -54,6 +53,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update:size', 'select-single'],
 
   data() {
     return {
@@ -95,11 +95,6 @@ export default defineComponent({
     },
   },
 
-  created() {
-    this.imageWidth = this.element.imageWidth;
-    this.imageHeight = this.element.imageHeight;
-  },
-
   watch: {
     'element.imageWidth'(newValue: number) {
       this.imageWidth = newValue;
@@ -107,6 +102,11 @@ export default defineComponent({
     'element.imageHeight'(newValue: number) {
       this.imageHeight = newValue;
     },
+  },
+
+  created() {
+    this.imageWidth = this.element.imageWidth;
+    this.imageHeight = this.element.imageHeight;
   },
 
   methods: {

--- a/src/components/InputBpm.vue
+++ b/src/components/InputBpm.vue
@@ -5,9 +5,9 @@
     :max="999"
     :step="1"
     :round="round"
-    :modelValue="modelValue"
+    :model-value="modelValue"
     :disabled="disabled"
-    @update:modelValue="$emit('update:modelValue', $event)"
+    @update:model-value="$emit('update:modelValue', $event)"
   />
 </template>
 
@@ -18,7 +18,6 @@ import InputUnit from '@/components/InputUnit.vue';
 
 export default defineComponent({
   components: { InputUnit },
-  emits: ['update:modelValue'],
   props: {
     modelValue: {
       type: Number,
@@ -29,6 +28,7 @@ export default defineComponent({
       default: false,
     },
   },
+  emits: ['update:modelValue'],
 
   data() {
     return {};

--- a/src/components/InputFontSize.vue
+++ b/src/components/InputFontSize.vue
@@ -5,8 +5,8 @@
     :max="max"
     :step="1"
     :round="round"
-    :modelValue="modelValue"
-    @update:modelValue="$emit('update:modelValue', $event)"
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
   />
 </template>
 
@@ -17,7 +17,6 @@ import InputUnit from '@/components/InputUnit.vue';
 
 export default defineComponent({
   components: { InputUnit },
-  emits: ['update:modelValue'],
   props: {
     modelValue: {
       type: Number,
@@ -28,6 +27,7 @@ export default defineComponent({
       default: 100,
     },
   },
+  emits: ['update:modelValue'],
 
   data() {
     return {};

--- a/src/components/InputStrokeWidth.vue
+++ b/src/components/InputStrokeWidth.vue
@@ -5,8 +5,8 @@
     :max="strokeWidthMax"
     :step="strokeWidthStep"
     :precision="strokeWidthPrecision"
-    :modelValue="modelValue"
-    @update:modelValue="$emit('update:modelValue', $event)"
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
   />
 </template>
 
@@ -21,13 +21,13 @@ const strokeWidthPrecision = 2;
 
 export default defineComponent({
   components: { InputUnit },
-  emits: ['update:modelValue'],
   props: {
     modelValue: {
       type: Number,
       required: true,
     },
   },
+  emits: ['update:modelValue'],
 
   data() {
     return {

--- a/src/components/InputUnit.vue
+++ b/src/components/InputUnit.vue
@@ -1,12 +1,12 @@
 <template>
   <input
     :value="displayValue"
-    @change="onChange(($event.target as HTMLInputElement).value)"
     type="number"
     :min="min"
     :max="max"
     :step="step"
     :disabled="disabled"
+    @change="onChange(($event.target as HTMLInputElement).value)"
   />
 </template>
 
@@ -26,7 +26,6 @@ export type UnitOfMeasure =
 
 export default defineComponent({
   components: {},
-  emits: ['update:modelValue'],
   props: {
     modelValue: {
       type: [Number, null],
@@ -45,28 +44,28 @@ export default defineComponent({
      */
     min: {
       type: Number,
-      required: false,
+      default: undefined,
     },
     /**
      * The maximum value allowed, in display units.
      */
     max: {
       type: Number,
-      required: false,
+      default: undefined,
     },
     /**
      * The step size, in display units.
      */
     step: {
       type: Number,
-      required: false,
+      default: undefined,
     },
     /**
      * The number of decimal places that will be displayed.
      */
     precision: {
       type: Number,
-      required: false,
+      default: undefined,
     },
     /**
      * The default value if the value is cleared
@@ -88,9 +87,10 @@ export default defineComponent({
      */
     round: {
       type: Function as PropType<(x: number) => number>,
-      required: false,
+      default: undefined,
     },
   },
+  emits: ['update:modelValue'],
 
   data() {
     return {};

--- a/src/components/ModeKey.vue
+++ b/src/components/ModeKey.vue
@@ -40,7 +40,7 @@
       :style="tempoStyle"
     />
     <span class="right-container">
-      <span class="ambitus" v-if="element.showAmbitus">
+      <span v-if="element.showAmbitus" class="ambitus">
         <span class="ambitus-text">(</span>
         <span class="ambitus-low" :style="ambitusStyle">
           <Neume :neume="element.ambitusLowNote" />
@@ -74,7 +74,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { Neume },
-  emits: ['select-single'],
   props: {
     element: {
       type: Object as PropType<ModeKeyElement>,
@@ -85,6 +84,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['select-single'],
 
   data() {
     return {

--- a/src/components/ModeKeyDialog.vue
+++ b/src/components/ModeKeyDialog.vue
@@ -58,15 +58,15 @@
         <div class="right-pane">
           <ul class="mode-list">
             <li
-              @click="selectedTemplateId = template.templateId"
-              @dblclick="updateModeKey"
               v-for="(template, index) in modeKeyTemplatesForSelectedMode"
+              :key="index"
               :class="{
                 selected: selectedTemplateId === template.templateId,
               }"
-              :key="index"
+              @click="selectedTemplateId = template.templateId"
+              @dblclick="updateModeKey"
             >
-              <ModeKey :element="template" :pageSetup="pageSetup" />
+              <ModeKey :element="template" :page-setup="pageSetup" />
               <div class="mode-key-description">
                 {{ $t(template.description) }}
               </div>
@@ -118,7 +118,6 @@ import { TextMeasurementService } from '@/services/TextMeasurementService';
 
 export default defineComponent({
   components: { ModalDialog, ModeKey },
-  emits: ['close', 'update', 'update:useOptionalDiatonicFthoras'],
   props: {
     element: {
       type: Object as PropType<ModeKeyElement>,
@@ -129,6 +128,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['close', 'update', 'update:useOptionalDiatonicFthoras'],
 
   data() {
     return {

--- a/src/components/NeumeBoxMartyria.vue
+++ b/src/components/NeumeBoxMartyria.vue
@@ -56,7 +56,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { Neume },
-  emits: ['select-single', 'select-range'],
   props: {
     neume: {
       type: Object as PropType<MartyriaElement>,
@@ -67,6 +66,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['select-single', 'select-range'],
 
   data() {
     return {

--- a/src/components/NeumeBoxSyllable.vue
+++ b/src/components/NeumeBoxSyllable.vue
@@ -113,7 +113,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { Neume: NeumeVue },
-  emits: ['select-single', 'select-range'],
   props: {
     note: {
       type: Object as PropType<NoteElement>,
@@ -128,6 +127,7 @@ export default defineComponent({
       default: false,
     },
   },
+  emits: ['select-single', 'select-range'],
 
   data() {
     return {

--- a/src/components/NeumeBoxTempo.vue
+++ b/src/components/NeumeBoxTempo.vue
@@ -7,7 +7,7 @@
   >
     <Neume
       :neume="neume.neume"
-      :fontFamily="pageSetup.neumeDefaultFontFamily"
+      :font-family="pageSetup.neumeDefaultFontFamily"
     />
   </div>
 </template>
@@ -22,7 +22,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { Neume },
-  emits: ['select-single', 'select-range'],
   props: {
     neume: {
       type: Object as PropType<TempoElement>,
@@ -33,6 +32,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['select-single', 'select-range'],
 
   data() {
     return {};

--- a/src/components/NeumeComboSelector.vue
+++ b/src/components/NeumeComboSelector.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="neume-combo-selector-panel">
     <div
-      class="row"
       v-for="(combo, index) in combos"
       :key="index"
+      class="row"
       @click="$emit('select-neume-combo', combo)"
     >
       <SyllableNeumeBox
-        v-for="(neume, index) in combo.elements"
-        :key="index"
+        v-for="(neume, neumeIndex) in combo.elements"
+        :key="neumeIndex"
         :note="neume"
-        :pageSetup="pageSetup"
+        :page-setup="pageSetup"
         class="neume"
       />
     </div>

--- a/src/components/NeumeGlyph.vue
+++ b/src/components/NeumeGlyph.vue
@@ -12,15 +12,21 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: {},
-  emits: ['update'],
   props: {
     neume: {
       type: String as PropType<NeumeType>,
       required: true,
     },
-    offset: Object as PropType<ScoreElementOffset>,
-    fontFamily: String,
+    offset: {
+      type: Object as PropType<ScoreElementOffset>,
+      default: undefined,
+    },
+    fontFamily: {
+      type: String,
+      default: undefined,
+    },
   },
+  emits: ['update'],
 
   data() {
     return {};

--- a/src/components/NeumeSelector.vue
+++ b/src/components/NeumeSelector.vue
@@ -12,21 +12,21 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.VareiaDotted"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showVareiaDottedMenu">
+            <div v-if="showVareiaDottedMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in vareiaDottedMenuItems"
                 :key="menuItem"
+                class="menu-item"
                 @mouseenter="selectedVareiaDotted = menuItem"
               >
                 <Neume
                   class="neume"
                   :neume="menuItem"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
               </div>
@@ -35,10 +35,10 @@
         </template>
         <template v-else>
           <Neume
-            class="neume"
             :key="`ascendingNeumes-${index}`"
+            class="neume"
             :neume="neume"
-            :fontFamily="pageSetup.neumeDefaultFontFamily"
+            :font-family="pageSetup.neumeDefaultFontFamily"
             :title="tooltip(neume)"
             @click="$emit('select-quantitative-neume', neume)"
           />
@@ -47,22 +47,22 @@
     </div>
     <div class="row">
       <Neume
-        class="neume"
         v-for="(neume, index) in ascendingNeumesWithPetasti"
         :key="`ascendingNeumesWithPetasti-${index}`"
+        class="neume"
         :neume="neume"
-        :fontFamily="pageSetup.neumeDefaultFontFamily"
+        :font-family="pageSetup.neumeDefaultFontFamily"
         :title="tooltip(neume)"
         @click="$emit('select-quantitative-neume', neume)"
       />
     </div>
     <div class="row">
       <Neume
-        class="neume"
         v-for="(neume, index) in descendingNeumes"
         :key="`descendingNeumes-${index}`"
+        class="neume"
         :neume="neume"
-        :fontFamily="pageSetup.neumeDefaultFontFamily"
+        :font-family="pageSetup.neumeDefaultFontFamily"
         :title="tooltip(neume)"
         @click="$emit('select-quantitative-neume', neume)"
       />
@@ -81,29 +81,29 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.OligonPlusHyporoePlusKentemata"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showHyporoeKentemataMenu">
+            <div v-if="showHyporoeKentemataMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItems"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
                   class="neume"
                   :neume="QuantitativeNeume.OligonPlusHyporoePlusKentemata"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -121,29 +121,29 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.OligonPlusIsonPlusKentemata"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu down" v-if="showIsonKentemataMenu">
+            <div v-if="showIsonKentemataMenu" class="menu down">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItemsDown"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
                   class="neume"
                   :neume="QuantitativeNeume.OligonPlusIsonPlusKentemata"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -163,29 +163,29 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.OligonPlusApostrophosPlusKentemata"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showApostrophosKentemataMenu">
+            <div v-if="showApostrophosKentemataMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItems"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
                   class="neume"
                   :neume="QuantitativeNeume.OligonPlusApostrophosPlusKentemata"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -205,29 +205,29 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.OligonPlusElaphronPlusKentemata"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showElaphronKentemataMenu">
+            <div v-if="showElaphronKentemataMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItems"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
                   class="neume"
                   :neume="QuantitativeNeume.OligonPlusElaphronPlusKentemata"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -250,15 +250,15 @@
               :neume="
                 QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata
               "
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showElaphronApostrophosKentemataMenu">
+            <div v-if="showElaphronApostrophosKentemataMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItems"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
@@ -266,15 +266,15 @@
                   :neume="
                     QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata
                   "
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -292,29 +292,29 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.OligonPlusHamiliPlusKentemata"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showHamiliKentemataMenu">
+            <div v-if="showHamiliKentemataMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItems"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
                   class="neume"
                   :neume="QuantitativeNeume.OligonPlusHamiliPlusKentemata"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -334,15 +334,15 @@
             <Neume
               class="neume"
               :neume="QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
+              :font-family="pageSetup.neumeDefaultFontFamily"
               :title="tooltip(neume)"
             />
 
-            <div class="menu" v-if="showRunningElaphronKentemataMenu">
+            <div v-if="showRunningElaphronKentemataMenu" class="menu">
               <div
-                class="menu-item"
                 v-for="menuItem in secondaryGorgonMenuItems"
                 :key="menuItem.gorgon as string"
+                class="menu-item"
                 @mouseenter="selectedSecondaryGorgon = menuItem"
               >
                 <Neume
@@ -350,15 +350,15 @@
                   :neume="
                     QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata
                   "
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
                 />
                 <Neume
+                  v-if="menuItem.gorgon != null"
                   class="neume"
                   :neume="menuItem.gorgon"
-                  :fontFamily="pageSetup.neumeDefaultFontFamily"
+                  :font-family="pageSetup.neumeDefaultFontFamily"
                   :title="tooltip(neume)"
-                  v-if="menuItem.gorgon != null"
                 />
               </div>
             </div>
@@ -366,10 +366,10 @@
         </template>
         <template v-else>
           <Neume
-            class="neume"
             :key="`combinationNeumes-${index}`"
+            class="neume"
             :neume="neume"
-            :fontFamily="pageSetup.neumeDefaultFontFamily"
+            :font-family="pageSetup.neumeDefaultFontFamily"
             :title="tooltip(neume)"
             @click="$emit('select-quantitative-neume', neume)"
           />
@@ -507,7 +507,6 @@ const vareiaDottedMenuItems: QuantitativeNeume[] = [
 
 export default defineComponent({
   components: { Neume },
-  emits: ['select-quantitative-neume'],
   props: {
     pageSetup: {
       type: Object as PropType<PageSetup>,
@@ -518,6 +517,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['select-quantitative-neume'],
 
   data() {
     return {

--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -84,18 +84,18 @@
             </div>
           </div>
           <div
-            class="right-pane"
             ref="rightPaneRef"
+            class="right-pane"
             @scroll="updateCurrentSectionThrottled!"
           >
-            <div class="subheader" ref="pageSizeRef">
+            <div ref="pageSizeRef" class="subheader">
               {{ $t('dialog:pageSetup.pageSize') }}
             </div>
             <div class="form-group full">
               <div class="name">
                 {{ $t('dialog:pageSetup.paperSize') }}
               </div>
-              <select class="standard-select" v-model="pageSize">
+              <select v-model="pageSize" class="standard-select">
                 <!-- TODO localize -->
                 <option v-for="size in pageSizes" :key="size.name">
                   {{ size.name }}
@@ -108,6 +108,7 @@
                   $t('dialog:pageSetup.width')
                 }}</label>
                 <InputUnit
+                  v-model="form.pageWidthCustom"
                   class="unit-input"
                   type="number"
                   :unit="form.pageSizeUnit"
@@ -115,7 +116,6 @@
                   :max="10000"
                   :step="marginStep"
                   :precision="2"
-                  v-model="form.pageWidthCustom"
                   @change="updatePageSize"
                 />
                 <span class="units">{{ $t(marginUnitLabel!) }}</span>
@@ -125,6 +125,7 @@
                   $t('dialog:pageSetup.height')
                 }}</label>
                 <InputUnit
+                  v-model="form.pageHeightCustom"
                   class="unit-input"
                   type="number"
                   :unit="form.pageSizeUnit"
@@ -132,7 +133,6 @@
                   :max="10000"
                   :step="marginStep"
                   :precision="2"
-                  v-model="form.pageHeightCustom"
                   @change="updatePageSize"
                 />
                 <span class="units">{{ $t(marginUnitLabel!) }}</span>
@@ -182,7 +182,7 @@
                 </option>
               </select>
             </div>
-            <div class="subheader" ref="marginsRef">
+            <div ref="marginsRef" class="subheader">
               {{ $t('dialog:pageSetup.margins') }}
             </div>
             <div class="form-group">
@@ -287,7 +287,7 @@
                 "
               /><span class="units">{{ $t(marginUnitLabel!) }}</span>
             </div>
-            <div class="subheader" ref="spacingRef">
+            <div ref="spacingRef" class="subheader">
               {{ $t('dialog:pageSetup.spacing') }}
             </div>
             <div class="form-group full">
@@ -298,6 +298,7 @@
                 {{ $t('dialog:pageSetup.neumeSpacingDescription') }}
               </div>
               <InputUnit
+                v-model="form.neumeDefaultSpacing"
                 class="unit-input"
                 type="number"
                 :unit="form.pageSizeUnit"
@@ -305,7 +306,6 @@
                 :max="neumeSpacingMax"
                 :step="spacingStep"
                 :precision="3"
-                v-model="form.neumeDefaultSpacing"
               /><span class="units">{{ $t(marginUnitLabel!) }}</span>
             </div>
             <div class="form-group full">
@@ -316,6 +316,7 @@
                 {{ $t('dialog:pageSetup.martyriaVerticalOffsetDescription') }}
               </div>
               <InputUnit
+                v-model="form.martyriaVerticalOffset"
                 class="unit-input"
                 type="number"
                 :unit="form.pageSizeUnit"
@@ -323,7 +324,6 @@
                 :max="neumeSpacingMax"
                 :step="spacingStep"
                 :precision="3"
-                v-model="form.martyriaVerticalOffset"
               /><span class="units">{{ $t(marginUnitLabel!) }}</span>
             </div>
             <div class="form-group full">
@@ -397,15 +397,15 @@
                 "
               /><span class="units">{{ $t(marginUnitLabel!) }}</span>
             </div>
-            <div class="subheader" ref="headersFootersRef">
+            <div ref="headersFootersRef" class="subheader">
               {{ $t('dialog:pageSetup.headersAndFooters') }}
             </div>
 
             <div class="form-group">
               <input
                 id="page-setup-dialog-show-header"
-                type="checkbox"
                 v-model="form.showHeader"
+                type="checkbox"
               />
               <label for="page-setup-dialog-show-header">{{
                 $t('dialog:pageSetup.includeHeader')
@@ -415,8 +415,8 @@
             <div class="form-group">
               <input
                 id="page-setup-dialog-show-footer"
-                type="checkbox"
                 v-model="form.showFooter"
+                type="checkbox"
               />
               <label for="page-setup-dialog-show-footer">{{
                 $t('dialog:pageSetup.includeFooter')
@@ -426,8 +426,8 @@
             <div class="form-group">
               <input
                 id="page-setup-dialog-different-first-page"
-                type="checkbox"
                 v-model="form.headerDifferentFirstPage"
+                type="checkbox"
               />
               <label for="page-setup-dialog-different-first-page">{{
                 $t('dialog:pageSetup.differentFirstPage')
@@ -436,8 +436,8 @@
             <div class="form-group">
               <input
                 id="page-setup-dialog-different-odd-even"
-                type="checkbox"
                 v-model="form.headerDifferentOddEven"
+                type="checkbox"
               />
               <label for="page-setup-dialog-different-odd-even">{{
                 $t('dialog:pageSetup.differentOddAndEven')
@@ -446,8 +446,8 @@
             <div class="form-group">
               <input
                 id="page-setup-dialog-rich-header-footer"
-                type="checkbox"
                 v-model="form.richHeaderFooter"
+                type="checkbox"
               />
               <label for="page-setup-dialog-rich-header-footer">{{
                 $t('dialog:pageSetup.richHeaderFooter')
@@ -462,12 +462,12 @@
                 {{ $t('dialog:pageSetup.firstPageNumberDescription') }}
               </div>
               <InputUnit
+                v-model="form.firstPageNumber"
                 class="unit-input"
                 unit="unitless"
                 :step="1"
                 :precision="0"
-                :defaultValue="1"
-                v-model="form.firstPageNumber"
+                :default-value="1"
               />
             </div>
 
@@ -477,8 +477,8 @@
               </div>
               <input
                 id="page-setup-dialog-header-hr"
-                type="checkbox"
                 v-model="form.showHeaderHorizontalRule"
+                type="checkbox"
               />
               <label for="page-setup-dialog-header-hr">
                 {{ $t('dialog:pageSetup.showHeaderHorizontalRuleDescription') }}
@@ -490,8 +490,8 @@
                     $t('dialog:pageSetup.color')
                   }}</label>
                   <ColorPicker
-                    class="neume-colors-input"
                     v-model="form.headerHorizontalRuleColor"
+                    class="neume-colors-input"
                   />
                 </div>
 
@@ -500,12 +500,12 @@
                     $t('dialog:pageSetup.thickness')
                   }}</label>
                   <InputUnit
+                    v-model="form.headerHorizontalRuleThickness"
                     class="margin-input"
                     unit="pt"
                     :min="0"
                     :max="100"
                     :step="0.5"
-                    v-model="form.headerHorizontalRuleThickness"
                     :precision="1"
                   />
                 </div>
@@ -515,12 +515,12 @@
                     $t('dialog:pageSetup.marginTop')
                   }}</label>
                   <InputUnit
+                    v-model="form.headerHorizontalRuleMarginTop"
                     class="margin-input"
                     unit="pt"
                     :min="0"
                     :max="1000"
                     :step="0.5"
-                    v-model="form.headerHorizontalRuleMarginTop"
                     :precision="1"
                   />
                 </div>
@@ -530,12 +530,12 @@
                     $t('dialog:pageSetup.marginBottom')
                   }}</label>
                   <InputUnit
+                    v-model="form.headerHorizontalRuleMarginBottom"
                     class="margin-input"
                     unit="pt"
                     :min="0"
                     :max="1000"
                     :step="0.5"
-                    v-model="form.headerHorizontalRuleMarginBottom"
                     :precision="1"
                   />
                 </div>
@@ -544,9 +544,9 @@
                   <div class="form-group">
                     <input
                       id="page-setup-dialog-header-excludeHeaderHorizontalRuleFirstPage"
+                      v-model="form.excludeHeaderHorizontalRuleFirstPage"
                       class="header-rule-checkbox"
                       type="checkbox"
-                      v-model="form.excludeHeaderHorizontalRuleFirstPage"
                     />
                     <label
                       for="page-setup-dialog-header-excludeHeaderHorizontalRuleFirstPage"
@@ -563,9 +563,9 @@
                   <div class="form-group">
                     <input
                       id="page-setup-dialog-header-excludeHeaderHorizontalRuleOddPage"
+                      v-model="form.excludeHeaderHorizontalRuleOddPage"
                       class="header-rule-checkbox"
                       type="checkbox"
-                      v-model="form.excludeHeaderHorizontalRuleOddPage"
                     />
                     <label
                       for="page-setup-dialog-header-excludeHeaderHorizontalRuleOddPage"
@@ -580,9 +580,9 @@
                   <div class="form-group">
                     <input
                       id="page-setup-dialog-header-excludeHeaderHorizontalRuleEvenPage"
+                      v-model="form.excludeHeaderHorizontalRuleEvenPage"
                       class="header-rule-checkbox"
                       type="checkbox"
-                      v-model="form.excludeHeaderHorizontalRuleEvenPage"
                     />
                     <label
                       for="page-setup-dialog-header-excludeHeaderHorizontalRuleEvenPage"
@@ -604,8 +604,8 @@
               </div>
               <input
                 id="page-setup-dialog-footer-hr"
-                type="checkbox"
                 v-model="form.showFooterHorizontalRule"
+                type="checkbox"
               />
               <label for="page-setup-dialog-footer-hr">{{
                 $t('dialog:pageSetup.showFooterHorizontalRuleDescription')
@@ -617,8 +617,8 @@
                     $t('dialog:pageSetup.color')
                   }}</label>
                   <ColorPicker
-                    class="neume-colors-input"
                     v-model="form.footerHorizontalRuleColor"
+                    class="neume-colors-input"
                   />
                 </div>
 
@@ -627,12 +627,12 @@
                     $t('dialog:pageSetup.thickness')
                   }}</label>
                   <InputUnit
+                    v-model="form.footerHorizontalRuleThickness"
                     class="margin-input"
                     unit="pt"
                     :min="0"
                     :max="100"
                     :step="0.5"
-                    v-model="form.footerHorizontalRuleThickness"
                     :precision="1"
                   />
                 </div>
@@ -642,12 +642,12 @@
                     $t('dialog:pageSetup.marginTop')
                   }}</label>
                   <InputUnit
+                    v-model="form.footerHorizontalRuleMarginTop"
                     class="margin-input"
                     unit="pt"
                     :min="0"
                     :max="1000"
                     :step="0.5"
-                    v-model="form.footerHorizontalRuleMarginTop"
                     :precision="1"
                   />
                 </div>
@@ -657,12 +657,12 @@
                     $t('dialog:pageSetup.marginBottom')
                   }}</label>
                   <InputUnit
+                    v-model="form.footerHorizontalRuleMarginBottom"
                     class="margin-input"
                     unit="pt"
                     :min="0"
                     :max="1000"
                     :step="0.5"
-                    v-model="form.footerHorizontalRuleMarginBottom"
                     :precision="1"
                   />
                 </div>
@@ -670,9 +670,9 @@
                   <div class="form-group">
                     <input
                       id="page-setup-dialog-header-excludeFooterHorizontalRuleFirstPage"
+                      v-model="form.excludeFooterHorizontalRuleFirstPage"
                       class="header-rule-checkbox"
                       type="checkbox"
-                      v-model="form.excludeFooterHorizontalRuleFirstPage"
                     />
                     <label
                       for="page-setup-dialog-header-excludeFooterHorizontalRuleFirstPage"
@@ -689,9 +689,9 @@
                   <div class="form-group">
                     <input
                       id="page-setup-dialog-footer-excludeFooterHorizontalRuleOddPage"
+                      v-model="form.excludeFooterHorizontalRuleOddPage"
                       class="header-rule-checkbox"
                       type="checkbox"
-                      v-model="form.excludeFooterHorizontalRuleOddPage"
                     />
                     <label
                       for="page-setup-dialog-footer-excludeFooterHorizontalRuleOddPage"
@@ -706,9 +706,9 @@
                   <div class="form-group">
                     <input
                       id="page-setup-dialog-footer-excludeFooterHorizontalRuleEvenPage"
+                      v-model="form.excludeFooterHorizontalRuleEvenPage"
                       class="header-rule-checkbox"
                       type="checkbox"
-                      v-model="form.excludeFooterHorizontalRuleEvenPage"
                     />
                     <label
                       for="page-setup-dialog-footer-excludeFooterHorizontalRuleEvenPage"
@@ -724,7 +724,7 @@
               </template>
             </div>
 
-            <div class="subheader" ref="miscellaneousRef">
+            <div ref="miscellaneousRef" class="subheader">
               {{ $t('dialog:pageSetup.miscellaneous') }}
             </div>
 
@@ -734,8 +734,8 @@
               </div>
               <input
                 id="page-setup-dialog-chrysanthine-accidentals"
-                type="checkbox"
                 v-model="form.chrysanthineAccidentals"
+                type="checkbox"
               />
               <label for="page-setup-dialog-chrysanthine-accidentals">{{
                 $t('dialog:pageSetup.useChrysanthineAccidentalsDescription')
@@ -748,8 +748,8 @@
               </div>
               <input
                 id="page-setup-dialog-no-fthora-restrictions"
-                type="checkbox"
                 v-model="form.noFthoraRestrictions"
+                type="checkbox"
               />
               <label for="page-setup-dialog-no-fthora-restrictions">{{
                 $t('dialog:pageSetup.disableFthoraRestrictionsDescription')
@@ -762,8 +762,8 @@
               </div>
               <input
                 id="page-setup-dialog-align-ison-indicators"
-                type="checkbox"
                 v-model="form.alignIsonIndicators"
+                type="checkbox"
               />
               <label for="page-setup-dialog-align-ison-indicators">{{
                 $t('dialog:pageSetup.alignIsonIndicatorsDescription')
@@ -776,8 +776,8 @@
               </div>
               <input
                 id="page-setup-dialog-melkite-rtl"
-                type="checkbox"
                 v-model="form.melkiteRtl"
+                type="checkbox"
                 @change="onChangeMelkiteRtl"
               />
               <label for="page-setup-dialog-melkite-rtl">{{
@@ -790,8 +790,8 @@
               </div>
               <input
                 id="page-setup-dialog-disable-melismata"
-                type="checkbox"
                 v-model="form.disableGreekMelismata"
+                type="checkbox"
               />
               <label for="page-setup-dialog-disable-melismata">{{
                 $t('dialog:pageSetup.disableGreekMelismataDescription')
@@ -805,16 +805,16 @@
                 {{ $t('dialog:pageSetup.lyricsMelismaCutoffWidthDescription') }}
               </div>
               <InputUnit
+                v-model="form.lyricsMelismaCutoffWidth"
                 class="unit-input"
                 unit="pt"
                 :min="0"
                 :step="1"
                 :precision="0"
-                v-model="form.lyricsMelismaCutoffWidth"
               />
             </div>
 
-            <div class="subheader" ref="dropCapsRef">
+            <div ref="dropCapsRef" class="subheader">
               {{ $t('dialog:pageSetup.dropCaps') }}
             </div>
             <div class="form-group">
@@ -836,9 +836,9 @@
                   $t('dialog:pageSetup.size')
                 }}</label>
                 <InputFontSize
+                  v-model="form.dropCapDefaultFontSize"
                   class="drop-caps-input"
                   :max="500"
-                  v-model="form.dropCapDefaultFontSize"
                 />
               </div>
               <div class="form-group">
@@ -846,13 +846,13 @@
                   $t('dialog:pageSetup.lineSpan')
                 }}</label>
                 <InputUnit
+                  v-model="form.dropCapDefaultLineSpan"
                   class="drop-caps-input"
                   unit="unitless"
                   :min="1"
                   :max="10"
                   :step="1"
                   :precision="0"
-                  v-model="form.dropCapDefaultLineSpan"
                 />
               </div>
               <div class="form-group">
@@ -860,6 +860,7 @@
                   $t('dialog:pageSetup.lineHeight')
                 }}</label>
                 <InputUnit
+                  v-model="form.dropCapDefaultLineHeight"
                   class="drop-caps-input"
                   :min="0"
                   :step="0.1"
@@ -867,7 +868,6 @@
                   :precision="2"
                   placeholder="normal"
                   :nullable="true"
-                  v-model="form.dropCapDefaultLineHeight"
                 />
               </div>
               <div class="form-group">
@@ -875,8 +875,8 @@
                   $t('dialog:pageSetup.font')
                 }}</label>
                 <select
-                  class="drop-caps-select"
                   v-model="form.dropCapDefaultFontFamily"
+                  class="drop-caps-select"
                 >
                   <option v-for="family in dropCapFontFamilies" :key="family">
                     {{ family }}
@@ -889,8 +889,8 @@
                 }}</label>
                 <input
                   id="page-setup-dialog-drop-cap-bold"
-                  type="checkbox"
                   v-model="form.dropCapDefaultFontWeight"
+                  type="checkbox"
                   true-value="700"
                   false-value="400"
                 />
@@ -900,8 +900,8 @@
                 <span class="checkbox-spacer"></span>
                 <input
                   id="page-setup-dialog-drop-cap-italic"
-                  type="checkbox"
                   v-model="form.dropCapDefaultFontStyle"
+                  type="checkbox"
                   true-value="italic"
                   false-value="normal"
                 />
@@ -915,13 +915,13 @@
                 }}</label>
 
                 <InputStrokeWidth
-                  class="drop-caps-input"
                   v-model="form.dropCapDefaultStrokeWidth"
+                  class="drop-caps-input"
                 />
               </div>
             </div>
 
-            <div class="subheader" ref="lyricsRef">
+            <div ref="lyricsRef" class="subheader">
               {{ $t('dialog:pageSetup.lyrics') }}
             </div>
             <div class="form-group">
@@ -942,8 +942,8 @@
                   $t('dialog:pageSetup.size')
                 }}</label>
                 <InputFontSize
-                  class="drop-caps-input"
                   v-model="form.lyricsDefaultFontSize"
+                  class="drop-caps-input"
                 />
               </div>
 
@@ -952,8 +952,8 @@
                   $t('dialog:pageSetup.font')
                 }}</label>
                 <select
-                  class="drop-caps-select"
                   v-model="form.lyricsDefaultFontFamily"
+                  class="drop-caps-select"
                 >
                   <option v-for="family in lyricsFontFamilies" :key="family">
                     {{ family }}
@@ -966,8 +966,8 @@
                 }}</label>
                 <input
                   id="page-setup-dialog-lyrics-bold"
-                  type="checkbox"
                   v-model="form.lyricsDefaultFontWeight"
+                  type="checkbox"
                   true-value="700"
                   false-value="400"
                 />
@@ -978,8 +978,8 @@
 
                 <input
                   id="page-setup-dialog-lyrics-italic"
-                  type="checkbox"
                   v-model="form.lyricsDefaultFontStyle"
+                  type="checkbox"
                   true-value="italic"
                   false-value="normal"
                 />
@@ -992,12 +992,12 @@
                   $t('dialog:pageSetup.outline')
                 }}</label>
                 <InputStrokeWidth
-                  class="drop-caps-input"
                   v-model="form.lyricsDefaultStrokeWidth"
+                  class="drop-caps-input"
                 />
               </div>
             </div>
-            <div class="subheader" ref="textBoxesRef">
+            <div ref="textBoxesRef" class="subheader">
               {{ $t('dialog:pageSetup.textBoxes') }}
             </div>
             <div class="form-group">
@@ -1018,8 +1018,8 @@
                   $t('dialog:pageSetup.size')
                 }}</label>
                 <InputFontSize
-                  class="drop-caps-input"
                   v-model="form.textBoxDefaultFontSize"
+                  class="drop-caps-input"
                 />
               </div>
               <div class="form-group">
@@ -1027,6 +1027,7 @@
                   $t('dialog:pageSetup.lineHeight')
                 }}</label>
                 <InputUnit
+                  v-model="form.textBoxDefaultLineHeight"
                   class="drop-caps-input"
                   :min="0"
                   :step="0.1"
@@ -1034,7 +1035,6 @@
                   :precision="2"
                   placeholder="normal"
                   :nullable="true"
-                  v-model="form.textBoxDefaultLineHeight"
                 />
               </div>
               <div class="form-group">
@@ -1042,8 +1042,8 @@
                   $t('dialog:pageSetup.font')
                 }}</label>
                 <select
-                  class="drop-caps-select"
                   v-model="form.textBoxDefaultFontFamily"
+                  class="drop-caps-select"
                 >
                   <option v-for="family in lyricsFontFamilies" :key="family">
                     {{ family }}
@@ -1056,8 +1056,8 @@
                 }}</label>
                 <input
                   id="page-setup-dialog-text-box-bold"
-                  type="checkbox"
                   v-model="form.textBoxDefaultFontWeight"
+                  type="checkbox"
                   true-value="700"
                   false-value="400"
                 />
@@ -1068,8 +1068,8 @@
 
                 <input
                   id="page-setup-dialog-text-box-italic"
-                  type="checkbox"
                   v-model="form.textBoxDefaultFontStyle"
+                  type="checkbox"
                   true-value="italic"
                   false-value="normal"
                 />
@@ -1083,13 +1083,13 @@
                 }}</label>
 
                 <InputStrokeWidth
-                  class="drop-caps-input"
                   v-model="form.textBoxDefaultStrokeWidth"
+                  class="drop-caps-input"
                 />
               </div>
             </div>
 
-            <div class="subheader" ref="modeKeysRef">
+            <div ref="modeKeysRef" class="subheader">
               {{ $t('dialog:pageSetup.modeKeys') }}
             </div>
             <div class="form-group">
@@ -1110,8 +1110,8 @@
                   $t('dialog:pageSetup.size')
                 }}</label>
                 <InputFontSize
-                  class="drop-caps-input"
                   v-model="form.modeKeyDefaultFontSize"
+                  class="drop-caps-input"
                 />
               </div>
               <div class="form-group">
@@ -1119,8 +1119,8 @@
                   $t('dialog:pageSetup.outline')
                 }}</label>
                 <InputStrokeWidth
-                  class="drop-caps-input"
                   v-model="form.modeKeyDefaultStrokeWidth"
+                  class="drop-caps-input"
                 />
               </div>
               <div class="form-group">
@@ -1129,17 +1129,17 @@
                 }}</label>
 
                 <InputUnit
+                  v-model="form.modeKeyDefaultHeightAdjustment"
                   class="drop-caps-input"
                   unit="pt"
                   :min="heightAdjustmentMin"
                   :max="heightAdjustmentMax"
                   :step="0.5"
                   :precision="2"
-                  v-model="form.modeKeyDefaultHeightAdjustment"
                 />
               </div>
             </div>
-            <div class="subheader" ref="neumesRef">
+            <div ref="neumesRef" class="subheader">
               {{ $t('dialog:pageSetup.neumes') }}
             </div>
             <div class="form-group">
@@ -1160,8 +1160,8 @@
                   $t('dialog:pageSetup.size')
                 }}</label>
                 <InputFontSize
-                  class="drop-caps-input"
                   v-model="form.neumeDefaultFontSize"
+                  class="drop-caps-input"
                 />
               </div>
               <div class="form-group">
@@ -1169,8 +1169,8 @@
                   $t('dialog:pageSetup.font')
                 }}</label>
                 <select
-                  class="drop-caps-select"
                   v-model="form.neumeDefaultFontFamily"
+                  class="drop-caps-select"
                   :disabled="form.melkiteRtl"
                 >
                   <option
@@ -1187,8 +1187,8 @@
                   $t('dialog:pageSetup.outline')
                 }}</label>
                 <InputStrokeWidth
-                  class="drop-caps-input"
                   v-model="form.neumeDefaultStrokeWidth"
+                  class="drop-caps-input"
                 />
               </div>
             </div>
@@ -1211,13 +1211,13 @@
                   $t('dialog:pageSetup.size')
                 }}</label>
                 <InputFontSize
-                  class="drop-caps-input"
                   v-model="form.alternateLineDefaultFontSize"
+                  class="drop-caps-input"
                 />
               </div>
             </div>
 
-            <div class="subheader" ref="neumeStylesRef">
+            <div ref="neumeStylesRef" class="subheader">
               {{ $t('dialog:pageSetup.neumeStyles') }}
             </div>
             <div class="form-group row">
@@ -1235,274 +1235,274 @@
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Accidentals"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.accidentals')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.accidentalDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.accidentalDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Breath"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.breath')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.breathDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.breathDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Cross"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.cross')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.crossDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.crossDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Fthoras"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.fthoras')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.fthoraDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.fthoraDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Gorgons"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.gorgons')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.gorgonDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.gorgonDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Heterons"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.heterons')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.heteronDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.heteronDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Ison"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.ison')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.isonDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.isonDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Koronis"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.koronis')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.koronisDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.koronisDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Martyria"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.martyriae')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.martyriaDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.martyriaDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.MeasureBars"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.measureBars')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.measureBarDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.measureBarDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.MeasureNumbers"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.measureNo')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.measureNumberDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.measureNumberDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.NoteIndicators"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.noteIndicators')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.noteIndicatorDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.noteIndicatorDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group row">
               <div class="neume-colors-checkbox-container">
                 <input
+                  v-model="selectedNeumeColorOptions"
                   type="checkbox"
                   class="neume-colors-checkbox"
                   :value="NeumeColorOptions.Tempos"
-                  v-model="selectedNeumeColorOptions"
                 />
               </div>
               <label class="neume-colors-label">{{
                 $t('dialog:pageSetup.tempos')
               }}</label>
               <ColorPicker
-                class="neume-colors-input"
                 v-model="form.tempoDefaultColor"
+                class="neume-colors-input"
               />
               <InputStrokeWidth
-                class="drop-caps-input"
                 v-model="form.tempoDefaultStrokeWidth"
+                class="drop-caps-input"
               />
             </div>
             <div class="form-group">
@@ -1514,8 +1514,8 @@
               </div>
               <div class="row">
                 <ColorPicker
-                  class="neume-colors-input"
                   v-model="neumeBulkColor"
+                  class="neume-colors-input"
                 />
                 <button @click="changeNeumeColorInBulk">Apply Color</button>
               </div>
@@ -1529,26 +1529,26 @@
           <template v-for="(element, index) in previewNeumes">
             <template v-if="isSyllableElement(element.elementType)">
               <NeumeBoxSyllable
-                class="syllable-box"
                 :key="index"
+                class="syllable-box"
                 :note="element as NoteElement"
-                :pageSetup="form"
+                :page-setup="form"
               />
             </template>
             <template v-if="isMartyriaElement(element.elementType)">
               <NeumeBoxMartyria
-                class="marytria-neume-box"
                 :key="index"
+                class="marytria-neume-box"
                 :neume="element as MartyriaElement"
-                :pageSetup="form"
+                :page-setup="form"
               />
             </template>
             <template v-if="isTempoElement(element.elementType)">
               <NeumeBoxTempo
-                class="tempo-neume-box"
                 :key="index"
+                class="tempo-neume-box"
                 :neume="element as TempoElement"
-                :pageSetup="form"
+                :page-setup="form"
               />
             </template>
           </template>
@@ -1680,7 +1680,6 @@ export default defineComponent({
     NeumeBoxMartyria,
     NeumeBoxTempo,
   },
-  emits: ['close', 'update'],
   props: {
     pageSetup: {
       type: Object as PropType<PageSetup>,
@@ -1691,6 +1690,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['close', 'update'],
 
   data() {
     return {

--- a/src/components/PlaybackSettingsDialog.vue
+++ b/src/components/PlaybackSettingsDialog.vue
@@ -32,11 +32,11 @@
             $t('dialog:playbackSettings.melody')
           }}</span>
           <input
+            v-model="volumeMelody"
             type="range"
             class="volume-slider"
             min="0"
             max="100"
-            v-model="volumeMelody"
           />
           <span class="db-label">{{ options.volumeMelody.toFixed(1) }} dB</span>
         </div>
@@ -46,11 +46,11 @@
             $t('dialog:playbackSettings.ison')
           }}</span>
           <input
+            v-model="volumeIson"
             type="range"
             class="volume-slider"
             min="0"
             max="100"
-            v-model="volumeIson"
           />
           <span class="db-label">{{ options.volumeIson.toFixed(1) }} dB</span>
         </div>
@@ -60,8 +60,8 @@
         <div class="form-group">
           <input
             id="playback-settings-dialog-diatonic-zo"
-            type="checkbox"
             v-model="options.useDefaultAttractionZo"
+            type="checkbox"
           />
           <label for="playback-settings-dialog-diatonic-zo">{{
             $t('dialog:playbackSettings.diatonicZoAttraction')
@@ -94,8 +94,8 @@
         <div class="form-group">
           <input
             id="playback-settings-dialog-legetos"
-            type="checkbox"
             v-model="options.useLegetos"
+            type="checkbox"
           />
           <label for="playback-settings-dialog-legetos">{{
             $t('dialog:playbackSettings.classicLegetos')
@@ -123,9 +123,9 @@
             $t('dialog:playbackSettings.diatonic')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Ni', 'Pa', 'Vou']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -152,9 +152,9 @@
             $t('dialog:playbackSettings.legetos')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Pa', 'Vou', 'Ga']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -181,9 +181,9 @@
             $t('dialog:playbackSettings.softChromatic')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Ni', 'Pa', 'Vou']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -210,9 +210,9 @@
             $t('dialog:playbackSettings.hardChromatic')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Pa', 'Vou', 'Ga']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -239,9 +239,9 @@
             $t('dialog:playbackSettings.zygos')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Ni', 'Pa', 'Vou', 'Ga']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -268,9 +268,9 @@
             $t('dialog:playbackSettings.zygosLegetos')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Ni', 'Pa', 'Vou', 'Ga']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -297,9 +297,9 @@
             $t('dialog:playbackSettings.kliton')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Pa', 'Vou', 'Ga']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -326,9 +326,9 @@
             $t('dialog:playbackSettings.spathi')
           }}</span>
           <div
-            class="row"
             v-for="(note, index) in ['Ga', 'Di', 'Ke', 'Zo']"
             :key="index"
+            class="row"
           >
             <span class="interval-label">{{ note }}</span>
             <input
@@ -647,13 +647,13 @@ const FREQUENCY_G3 = 196;
 
 export default defineComponent({
   components: { ModalDialog },
-  emits: ['close', 'play-test-tone'],
   props: {
     options: {
       type: Object as PropType<PlaybackOptions>,
       required: true,
     },
   },
+  emits: ['close', 'play-test-tone'],
 
   data() {
     return {

--- a/src/components/SearchText.vue
+++ b/src/components/SearchText.vue
@@ -32,13 +32,13 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   components: {},
-  emits: ['close', 'search', 'update:query'],
   props: {
     query: {
       type: String,
       required: true,
     },
   },
+  emits: ['close', 'search', 'update:query'],
 
   data() {
     return {};

--- a/src/components/SyllablePositioningDialog.vue
+++ b/src/components/SyllablePositioningDialog.vue
@@ -9,7 +9,7 @@
               v-if="previousElement.elementType === ElementType.Note"
               class="other-neume"
               :note="previousElement as NoteElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
               :style="previousElementStyle"
             />
 
@@ -17,7 +17,7 @@
               v-if="previousElement.elementType === ElementType.Martyria"
               class="other-neume"
               :neume="previousElement as MartyriaElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
               :style="previousElementStyle"
             />
 
@@ -25,7 +25,7 @@
               v-if="previousElement.elementType === ElementType.Tempo"
               class="other-neume"
               :neume="previousElement as TempoElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
               :style="previousElementStyle"
             />
           </template>
@@ -33,14 +33,14 @@
           <div class="neume-container" :style="mainStyle">
             <NeumeBoxSyllable
               :note="form as NoteElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
             />
             <DragHandle
               v-if="hasAccidental"
               :note="form as NoteElement"
               :mark="form.accidental!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.accidentalOffsetX"
               :y="form.accidentalOffsetY"
@@ -50,8 +50,8 @@
               v-if="hasSecondaryAccidental"
               :note="form as NoteElement"
               :mark="form.secondaryAccidental!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.secondaryAccidentalOffsetX"
               :y="form.secondaryAccidentalOffsetY"
@@ -61,8 +61,8 @@
               v-if="hasTertiaryAccidental"
               :note="form as NoteElement"
               :mark="form.tertiaryAccidental!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.tertiaryAccidentalOffsetX"
               :y="form.tertiaryAccidentalOffsetY"
@@ -94,8 +94,8 @@
               v-if="hasFthora"
               :note="form as NoteElement"
               :mark="form.fthora!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.fthoraOffsetX"
               :y="form.fthoraOffsetY"
@@ -105,8 +105,8 @@
               v-if="hasSecondaryFthora"
               :note="form as NoteElement"
               :mark="form.secondaryFthora!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.secondaryFthoraOffsetX"
               :y="form.secondaryFthoraOffsetY"
@@ -116,8 +116,8 @@
               v-if="hasTertiaryFthora"
               :note="form as NoteElement"
               :mark="form.tertiaryFthora!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.tertiaryFthoraOffsetX"
               :y="form.tertiaryFthoraOffsetY"
@@ -127,8 +127,8 @@
               v-if="hasGorgonNeume"
               :note="form as NoteElement"
               :mark="form.gorgonNeume!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.gorgonNeumeOffsetX"
               :y="form.gorgonNeumeOffsetY"
@@ -138,8 +138,8 @@
               v-if="hasSecondaryGorgonNeume"
               :note="form as NoteElement"
               :mark="form.secondaryGorgonNeume!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.secondaryGorgonNeumeOffsetX"
               :y="form.secondaryGorgonNeumeOffsetY"
@@ -149,8 +149,8 @@
               v-if="hasIson"
               :note="form as NoteElement"
               :mark="form.ison!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.isonOffsetX"
               :y="form.isonOffsetY"
@@ -160,8 +160,8 @@
               v-if="form.koronis"
               :note="form as NoteElement"
               :mark="TimeNeume.Koronis"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.koronisOffsetX"
               :y="form.koronisOffsetY"
@@ -171,8 +171,8 @@
               v-if="hasMeasureNumber"
               :note="form as NoteElement"
               :mark="form.measureNumber!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.measureNumberOffsetX"
               :y="form.measureNumberOffsetY"
@@ -182,8 +182,8 @@
               v-if="form.noteIndicator"
               :note="form as NoteElement"
               :mark="form.noteIndicatorNeume!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.noteIndicatorOffsetX"
               :y="form.noteIndicatorOffsetY"
@@ -193,8 +193,8 @@
               v-if="form.stavros"
               :note="form as NoteElement"
               :mark="VocalExpressionNeume.Cross_Top"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.stavrosOffsetX"
               :y="form.stavrosOffsetY"
@@ -204,8 +204,8 @@
               v-if="hasTie"
               :note="form as NoteElement"
               :mark="form.tie!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.tieOffsetX"
               :y="form.tieOffsetY"
@@ -215,8 +215,8 @@
               v-if="hasTimeNeume"
               :note="form as NoteElement"
               :mark="form.timeNeume!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.timeNeumeOffsetX"
               :y="form.timeNeumeOffsetY"
@@ -237,8 +237,8 @@
               v-if="hasVocalExpressionNeume"
               :note="form as NoteElement"
               :mark="form.vocalExpressionNeume!"
-              :fontFamily="pageSetup.neumeDefaultFontFamily"
-              :fontSize="pageSetup.neumeDefaultFontSize"
+              :font-family="pageSetup.neumeDefaultFontFamily"
+              :font-size="pageSetup.neumeDefaultFontSize"
               :zoom="zoom"
               :x="form.vocalExpressionNeumeOffsetX"
               :y="form.vocalExpressionNeumeOffsetY"
@@ -250,7 +250,7 @@
               v-if="nextElement.elementType === ElementType.Note"
               class="other-neume"
               :note="nextElement as NoteElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
               :style="nextElementStyle"
             />
 
@@ -258,7 +258,7 @@
               v-if="nextElement.elementType === ElementType.Martyria"
               class="other-neume"
               :neume="nextElement as MartyriaElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
               :style="nextElementStyle"
             />
 
@@ -266,7 +266,7 @@
               v-if="nextElement.elementType === ElementType.Tempo"
               class="other-neume"
               :neume="nextElement as TempoElement"
-              :pageSetup="pageSetup"
+              :page-setup="pageSetup"
               :style="nextElementStyle"
             />
           </template>
@@ -280,362 +280,362 @@
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.accidental') }}</label>
             <InputUnit
+              v-model="form.accidentalOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.accidentalOffsetX"
             />
             <InputUnit
+              v-model="form.accidentalOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.accidentalOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.accidental2') }}</label>
             <InputUnit
+              v-model="form.secondaryAccidentalOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.secondaryAccidentalOffsetX"
             />
             <InputUnit
+              v-model="form.secondaryAccidentalOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.secondaryAccidentalOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.accidental3') }}</label>
             <InputUnit
+              v-model="form.tertiaryAccidentalOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.tertiaryAccidentalOffsetX"
             />
             <InputUnit
+              v-model="form.tertiaryAccidentalOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.tertiaryAccidentalOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.barLineL') }}</label>
             <InputUnit
+              v-model="form.measureBarLeftOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.measureBarLeftOffsetX"
             />
             <InputUnit
+              v-model="form.measureBarLeftOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.measureBarLeftOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.barLineR') }}</label>
             <InputUnit
+              v-model="form.measureBarRightOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.measureBarRightOffsetX"
             />
             <InputUnit
+              v-model="form.measureBarRightOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.measureBarRightOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.fthora') }}</label>
             <InputUnit
+              v-model="form.fthoraOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.fthoraOffsetX"
             />
             <InputUnit
+              v-model="form.fthoraOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.fthoraOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.fthora2') }}</label>
             <InputUnit
+              v-model="form.secondaryFthoraOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.secondaryFthoraOffsetX"
             />
             <InputUnit
+              v-model="form.secondaryFthoraOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.secondaryFthoraOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.fthora3') }}</label>
             <InputUnit
+              v-model="form.tertiaryFthoraOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.tertiaryFthoraOffsetX"
             />
             <InputUnit
+              v-model="form.tertiaryFthoraOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.tertiaryFthoraOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.gorgon') }}</label>
             <InputUnit
+              v-model="form.gorgonNeumeOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.gorgonNeumeOffsetX"
             />
             <InputUnit
+              v-model="form.gorgonNeumeOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.gorgonNeumeOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.gorgon2') }}</label>
             <InputUnit
+              v-model="form.secondaryGorgonNeumeOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.secondaryGorgonNeumeOffsetX"
             />
             <InputUnit
+              v-model="form.secondaryGorgonNeumeOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.secondaryGorgonNeumeOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.ison') }}</label>
             <InputUnit
+              v-model="form.isonOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.isonOffsetX"
             />
             <InputUnit
+              v-model="form.isonOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.isonOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.koronis') }}</label>
             <InputUnit
+              v-model="form.koronisOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.koronisOffsetX"
             />
             <InputUnit
+              v-model="form.koronisOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.koronisOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.measureNo') }}</label>
             <InputUnit
+              v-model="form.measureNumberOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.measureNumberOffsetX"
             />
             <InputUnit
+              v-model="form.measureNumberOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.measureNumberOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.note') }}</label>
             <InputUnit
+              v-model="form.noteIndicatorOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.noteIndicatorOffsetX"
             />
             <InputUnit
+              v-model="form.noteIndicatorOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.noteIndicatorOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.cross') }}</label>
             <InputUnit
+              v-model="form.stavrosOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.stavrosOffsetX"
             />
             <InputUnit
+              v-model="form.stavrosOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.stavrosOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.tie') }}</label>
             <InputUnit
+              v-model="form.tieOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.tieOffsetX"
             />
             <InputUnit
+              v-model="form.tieOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.tieOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.time') }}</label>
             <InputUnit
+              v-model="form.timeNeumeOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.timeNeumeOffsetX"
             />
             <InputUnit
+              v-model="form.timeNeumeOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.timeNeumeOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.vareia') }}</label>
             <InputUnit
+              v-model="form.vareiaOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.vareiaOffsetX"
             />
             <InputUnit
+              v-model="form.vareiaOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.vareiaOffsetY"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('dialog:neumePositioning.quality') }}</label>
             <InputUnit
+              v-model="form.vocalExpressionNeumeOffsetX"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.vocalExpressionNeumeOffsetX"
             />
             <InputUnit
+              v-model="form.vocalExpressionNeumeOffsetY"
               :unit="unit"
               :min="min"
               :max="max"
               :step="stepSize"
               :precision="precision"
-              v-model="form.vocalExpressionNeumeOffsetY"
             />
           </div>
         </div>
@@ -682,19 +682,25 @@ export default defineComponent({
     InputUnit,
     DragHandle,
   },
-  emits: ['close', 'update'],
   props: {
     element: {
       type: Object as PropType<NoteElement>,
       required: true,
     },
-    previousElement: Object as PropType<ScoreElement>,
-    nextElement: Object as PropType<ScoreElement>,
+    previousElement: {
+      type: Object as PropType<ScoreElement>,
+      default: undefined,
+    },
+    nextElement: {
+      type: Object as PropType<ScoreElement>,
+      default: undefined,
+    },
     pageSetup: {
       type: Object as PropType<PageSetup>,
       required: true,
     },
   },
+  emits: ['close', 'update'],
 
   data() {
     return {

--- a/src/components/TextAnnotation.vue
+++ b/src/components/TextAnnotation.vue
@@ -34,7 +34,6 @@ const ANNOTATION_LOCK_ID = 'ANNOTATION_LOCK_ID';
 
 export default defineComponent({
   components: { Ckeditor },
-  emits: ['update', 'delete'],
   props: {
     element: {
       type: Object as PropType<AnnotationElement>,
@@ -50,6 +49,7 @@ export default defineComponent({
     },
     selected: Boolean,
   },
+  emits: ['update', 'delete'],
 
   data() {
     return {
@@ -64,21 +64,6 @@ export default defineComponent({
 
       editor: InlineEditor,
     };
-  },
-
-  mounted() {
-    this.elementX = this.element.x;
-    this.elementY = this.element.y;
-    this.clampingInterval = setInterval(this.clampToPageBounds, 250);
-  },
-
-  beforeUnmount() {
-    document.removeEventListener('mouseup', this.handleMouseUp);
-    document.removeEventListener('mousemove', this.handleMouseMove);
-
-    if (this.clampingInterval != null) {
-      clearInterval(this.clampingInterval);
-    }
   },
 
   computed: {
@@ -161,6 +146,21 @@ export default defineComponent({
         },
       };
     },
+  },
+
+  mounted() {
+    this.elementX = this.element.x;
+    this.elementY = this.element.y;
+    this.clampingInterval = setInterval(this.clampToPageBounds, 250);
+  },
+
+  beforeUnmount() {
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('mousemove', this.handleMouseMove);
+
+    if (this.clampingInterval != null) {
+      clearInterval(this.clampingInterval);
+    }
   },
 
   methods: {

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -6,7 +6,7 @@
     @click="$emit('select-single')"
   >
     <span class="handle"></span>
-    <div class="text-box-multipanel-container" v-if="element.multipanel">
+    <div v-if="element.multipanel" class="text-box-multipanel-container">
       <ContentEditable
         ref="textLeft"
         class="text-box multipanel left"
@@ -15,7 +15,7 @@
         :content="contentLeft"
         :editable="editMode"
         @blur="onBlur"
-        @onEditorReady="onEditorReady"
+        @on-editor-ready="onEditorReady"
       ></ContentEditable>
       <ContentEditable
         ref="textCenter"
@@ -25,7 +25,7 @@
         :content="contentCenter"
         :editable="editMode"
         @blur="onBlur"
-        @onEditorReady="onEditorReady"
+        @on-editor-ready="onEditorReady"
       ></ContentEditable>
       <ContentEditable
         ref="textRight"
@@ -35,10 +35,10 @@
         :content="contentRight"
         :editable="editMode"
         @blur="onBlur"
-        @onEditorReady="onEditorReady"
+        @on-editor-ready="onEditorReady"
       ></ContentEditable>
     </div>
-    <div class="inline-container" v-else-if="element.inline">
+    <div v-else-if="element.inline" class="inline-container">
       <ContentEditable
         ref="text"
         class="text-box inline-top"
@@ -67,7 +67,7 @@
       :content="content"
       :editable="editMode"
       @blur="onBlur"
-      @onEditorReady="onEditorReady"
+      @on-editor-ready="onEditorReady"
     ></ContentEditable>
   </div>
 </template>
@@ -85,7 +85,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: { ContentEditable },
-  emits: ['update', 'update:height', 'select-single'],
   props: {
     element: {
       type: Object as PropType<TextBoxElement>,
@@ -103,8 +102,12 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    metadata: Object as PropType<TokenMetadata>,
+    metadata: {
+      type: Object as PropType<TokenMetadata>,
+      default: undefined,
+    },
   },
+  emits: ['update', 'update:height', 'select-single'],
 
   data() {
     return {
@@ -112,14 +115,6 @@ export default defineComponent({
       unmounting: false,
       setupResizeObserverDebounced: null as (() => void) | null,
     };
-  },
-
-  watch: {
-    'element.customHeight'(newVal) {
-      if (newVal == null) {
-        this.update();
-      }
-    },
   },
 
   computed: {
@@ -234,6 +229,14 @@ export default defineComponent({
       return {
         underline: this.element.underline,
       };
+    },
+  },
+
+  watch: {
+    'element.customHeight'(newVal) {
+      if (newVal == null) {
+        this.update();
+      }
     },
   },
 

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -16,31 +16,31 @@
         class="rich-text-editor multipanel left"
         :editor="editor"
         :model-value="contentLeft"
-        @blur="onBlur"
         :config="editorConfig"
         :disable-watchdog="true"
+        @blur="onBlur"
       />
       <ckeditor
         ref="editorCenter"
         class="rich-text-editor multipanel center"
         :editor="editor"
         :model-value="contentCenter"
-        @blur="onBlur"
-        @ready="onEditorReady"
         :config="editorConfig"
         :disable-watchdog="true"
+        @blur="onBlur"
+        @ready="onEditorReady"
       />
       <ckeditor
         ref="editorRight"
         class="rich-text-editor multipanel right"
         :editor="editor"
         :model-value="contentRight"
-        @blur="onBlur"
         :config="editorConfig"
         :disable-watchdog="true"
+        @blur="onBlur"
       />
     </div>
-    <div class="inline-container" v-else-if="element.inline">
+    <div v-else-if="element.inline" class="inline-container">
       <div class="inline-top-container" :style="textBoxTopContainerStyle">
         <div
           class="inline-top-inner-container"
@@ -52,10 +52,10 @@
             :style="textBoxStyleTop"
             :editor="editor"
             :model-value="content"
-            @blur="onBlur"
-            @ready="onEditorReadyInline"
             :config="editorConfig"
             :disable-watchdog="true"
+            @blur="onBlur"
+            @ready="onEditorReadyInline"
           />
         </div>
       </div>
@@ -66,10 +66,10 @@
           :style="textBoxStyleBottom"
           :editor="editor"
           :model-value="contentBottom"
-          @blur="onBlur"
-          @ready="onEditorReadyInlineBottom"
           :config="editorConfig"
           :disable-watchdog="true"
+          @blur="onBlur"
+          @ready="onEditorReadyInlineBottom"
         />
       </div>
     </div>
@@ -79,11 +79,11 @@
       class="rich-text-editor single scrollable"
       :editor="editor"
       :model-value="content"
-      @blur="onBlur"
-      @ready="onEditorReady"
       :config="editorConfig"
       :disable-watchdog="true"
       :style="textBoxStyle"
+      @blur="onBlur"
+      @ready="onEditorReady"
     />
     <ckeditor
       v-else
@@ -91,11 +91,11 @@
       class="rich-text-editor single"
       :editor="editor"
       :model-value="content"
-      @blur="onBlur"
-      @ready="onEditorReady"
       :config="editorConfig"
       :disable-watchdog="true"
       :style="textBoxStyle"
+      @blur="onBlur"
+      @ready="onEditorReady"
     />
   </div>
 </template>
@@ -117,7 +117,6 @@ import { withZoom } from '@/utils/withZoom';
 
 export default defineComponent({
   components: {},
-  emits: ['update', 'update:height', 'select-single'],
   props: {
     element: {
       type: Object as PropType<RichTextBoxElement>,
@@ -139,12 +138,16 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    metadata: Object as PropType<TokenMetadata>,
+    metadata: {
+      type: Object as PropType<TokenMetadata>,
+      default: undefined,
+    },
     recalc: {
       type: Boolean,
       default: false,
     },
   },
+  emits: ['update', 'update:height', 'select-single'],
 
   data() {
     return {
@@ -161,13 +164,6 @@ export default defineComponent({
       inlineTopObserver: null as ResizeObserver | null,
       debouncedPhoneHome: null as ((x: number) => void) | null,
     };
-  },
-
-  watch: {
-    'element.centerOnPage'() {
-      this.setPadding(this.getEditorInstance());
-      this.setPadding(this.getEditorInstanceBottom());
-    },
   },
 
   computed: {
@@ -360,6 +356,13 @@ export default defineComponent({
       };
 
       return style;
+    },
+  },
+
+  watch: {
+    'element.centerOnPage'() {
+      this.setPadding(this.getEditorInstance());
+      this.setPadding(this.getEditorInstanceBottom());
     },
   },
 

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -257,6 +257,12 @@ export default defineComponent({
     Vue3TabsChrome,
     SearchText,
   },
+  provide() {
+    return {
+      editorPreferences: computed(() => this.editorPreferences),
+    };
+  },
+  emits: [],
   setup() {
     return {
       audioService: inject<AudioService>(audioServiceKey, new AudioService()),
@@ -289,7 +295,6 @@ export default defineComponent({
       ipcService: inject<IIpcService>(ipcServiceKey, new IpcService()),
     };
   },
-  emits: [],
   data() {
     return {
       searchTextQuery: '',
@@ -462,11 +467,6 @@ export default defineComponent({
         onScroll: null! as () => void,
       },
       saveDebounced: null! as (markUnsavedChanges?: boolean) => void,
-    };
-  },
-  provide() {
-    return {
-      editorPreferences: computed(() => this.editorPreferences),
     };
   },
   computed: {
@@ -6199,26 +6199,26 @@ export default defineComponent({
 
 <template>
   <div class="editor">
-    <div class="loading-overlay" v-if="isLoading">
+    <div v-if="isLoading" class="loading-overlay">
       <img src="@/assets/icons/spinner.svg" />
     </div>
     <FileMenuBar v-if="showFileMenuBar" />
     <ToolbarMain
-      :entryMode="entryMode"
+      :entry-mode="entryMode"
       :zoom="zoom"
-      :zoomToFit="zoomToFit"
-      :audioState="audioService.state"
-      :audioOptions="audioOptions"
-      :playbackTime="selectedWorkspace.playbackTime"
-      :playbackBpm="selectedWorkspace.playbackBpm"
-      :currentPageNumber="currentPageNumber"
-      :pageCount="pageCount"
-      :neumeKeyboard="neumeKeyboard"
+      :zoom-to-fit="zoomToFit"
+      :audio-state="audioService.state"
+      :audio-options="audioOptions"
+      :playback-time="selectedWorkspace.playbackTime"
+      :playback-bpm="selectedWorkspace.playbackBpm"
+      :current-page-number="currentPageNumber"
+      :page-count="pageCount"
+      :neume-keyboard="neumeKeyboard"
       @update:zoom="updateZoom"
-      @update:zoomToFit="updateZoomToFit"
-      @update:audioOptionsSpeed="updateAudioOptionsSpeed"
+      @update:zoom-to-fit="updateZoomToFit"
+      @update:audio-options-speed="updateAudioOptionsSpeed"
       @add-auto-martyria="addAutoMartyria"
-      @update:entryMode="updateEntryMode"
+      @update:entry-mode="updateEntryMode"
       @toggle-page-break="togglePageBreak"
       @toggle-line-break="toggleLineBreak($event)"
       @add-tempo="addTempo"
@@ -6236,8 +6236,8 @@ export default defineComponent({
       <div class="left-panel">
         <NeumeSelector
           class="neume-selector"
-          :pageSetup="score.pageSetup"
-          :neumeKeyboard="neumeKeyboard"
+          :page-setup="score.pageSetup"
+          :neume-keyboard="neumeKeyboard"
           @select-quantitative-neume="addQuantitativeNeume"
         />
         <div
@@ -6252,7 +6252,7 @@ export default defineComponent({
         <NeumeComboSelector
           v-if="neumeComboPanelIsExpanded"
           class="neume-combo-selector"
-          :pageSetup="score.pageSetup"
+          :page-setup="score.pageSetup"
           @select-neume-combo="addNeumeCombination"
         />
       </div>
@@ -6260,16 +6260,16 @@ export default defineComponent({
       <div class="page-container">
         <!-- @vue-ignore -->
         <Vue3TabsChrome
-          class="workspace-tab-container"
           ref="tabs"
-          :tabs="tabs"
           v-model="selectedWorkspaceId"
+          class="workspace-tab-container"
+          :tabs="tabs"
           :gap="0"
           :on-close="onTabClosed"
           :render-label="renderTabLabel"
           @contextmenu="openContextMenuForTab"
         >
-          <template v-slot:after>
+          <template #after>
             <button
               class="workspace-tab-new-button"
               @click="onFileMenuNewScore"
@@ -6279,28 +6279,28 @@ export default defineComponent({
           </template></Vue3TabsChrome
         >
         <SearchText
-          ref="searchText"
           v-if="searchTextPanelIsOpen"
+          ref="searchText"
           v-model:query="searchTextQuery"
           @search="onSearchText"
           @close="searchTextPanelIsOpen = false"
         />
         <div
-          class="page-background"
           ref="page-background"
+          class="page-background"
           @scroll="throttled.onScroll"
         >
           <div
-            class="page"
-            :style="pageStyle"
+            v-for="(page, pageIndex) in filteredPages"
+            :key="`page-${pageIndex}`"
+            ref="pages"
             v-observe-visibility="{
               callback: (isVisible: boolean) =>
                 updatePageVisibility(page, isVisible),
               intersection: pageVisibilityIntersection,
             }"
-            v-for="(page, pageIndex) in filteredPages"
-            :key="`page-${pageIndex}`"
-            ref="pages"
+            class="page"
+            :style="pageStyle"
             :class="{ print: printMode }"
           >
             <template v-if="page.isVisible || printMode">
@@ -6315,21 +6315,21 @@ export default defineComponent({
                   v-if="isRichTextBoxElement(getHeaderForPageIndex(pageIndex))"
                 >
                   <TextBoxRich
-                    class="element-box"
                     :key="`element-${selectedWorkspace.id}-${getHeaderForPageIndex(pageIndex).id}-${
                       getHeaderForPageIndex(pageIndex).keyHelper
                     }`"
                     :ref="`header-${pageIndex}`"
+                    class="element-box"
                     :element="
                       getHeaderForPageIndex(pageIndex) as RichTextBoxElement
                     "
-                    :editMode="
+                    :edit-mode="
                       !printMode &&
                       getHeaderForPageIndex(pageIndex) ==
                         selectedHeaderFooterElement
                     "
                     :metadata="getTokenMetadata(pageIndex)"
-                    :pageSetup="score.pageSetup"
+                    :page-setup="score.pageSetup"
                     :fonts="fonts"
                     :selected="
                       getHeaderForPageIndex(pageIndex) ==
@@ -6358,21 +6358,21 @@ export default defineComponent({
                   v-else-if="isTextBoxElement(getHeaderForPageIndex(pageIndex))"
                 >
                   <TextBox
-                    class="element-box"
                     :key="`element-${selectedWorkspace.id}-${getHeaderForPageIndex(pageIndex).id}-${
                       getHeaderForPageIndex(pageIndex).keyHelper
                     }`"
                     :ref="`header-${pageIndex}`"
+                    class="element-box"
                     :element="
                       getHeaderForPageIndex(pageIndex) as TextBoxElement
                     "
-                    :editMode="
+                    :edit-mode="
                       !printMode &&
                       getHeaderForPageIndex(pageIndex) ==
                         selectedHeaderFooterElement
                     "
                     :metadata="getTokenMetadata(pageIndex)"
-                    :pageSetup="score.pageSetup"
+                    :page-setup="score.pageSetup"
                     :selected="
                       getHeaderForPageIndex(pageIndex) ==
                       selectedHeaderFooterElement
@@ -6408,10 +6408,10 @@ export default defineComponent({
                 ></div>
               </template>
               <div
-                class="line"
                 v-for="(line, lineIndex) in page.lines"
                 :key="`line-${pageIndex}-${lineIndex}`"
                 :ref="`line-${lineIndex}`"
+                class="line"
               >
                 <div
                   v-for="element in line.elements"
@@ -6426,17 +6426,17 @@ export default defineComponent({
                       class="neume-box"
                     >
                       <span
-                        class="section-name"
                         v-if="
                           element.sectionName != '' &&
                           element.sectionName != null
                         "
+                        class="section-name"
                         >§</span
                       >
-                      <span class="page-break" v-if="element.pageBreak"
+                      <span v-if="element.pageBreak" class="page-break"
                         ><img src="@/assets/icons/page-break.svg"
                       /></span>
-                      <span class="line-break" v-if="element.lineBreak"
+                      <span v-if="element.lineBreak" class="line-break"
                         ><img
                           v-if="element.lineBreakType === LineBreakType.Justify"
                           src="@/assets/icons/line-break-justify.svg" /><img
@@ -6453,7 +6453,7 @@ export default defineComponent({
                         ).alternateLines"
                         :key="index"
                         :element="alternateLine"
-                        :pageSetup="score.pageSetup"
+                        :page-setup="score.pageSetup"
                         :class="{
                           selectedAlternateLine:
                             selectedWorkspace.selectedAlternateLineElement ===
@@ -6469,7 +6469,7 @@ export default defineComponent({
                           .annotations"
                         :key="index"
                         :element="annotation"
-                        :pageSetup="score.pageSetup"
+                        :page-setup="score.pageSetup"
                         :fonts="fonts"
                         :selected="
                           selectedWorkspace.selectedAnnotationElement ===
@@ -6488,7 +6488,7 @@ export default defineComponent({
                       <SyllableNeumeBox
                         class="syllable-box"
                         :note="element as NoteElement"
-                        :pageSetup="score.pageSetup"
+                        :page-setup="score.pageSetup"
                         :class="[
                           {
                             selected: isSelected(element),
@@ -6504,14 +6504,14 @@ export default defineComponent({
                         :style="getLyricStyle(element as NoteElement)"
                       >
                         <ContentEditable
+                          :ref="`lyrics-${getElementIndex(element)}`"
                           class="lyrics"
                           :class="{
                             selectedLyrics: element === selectedLyrics,
                           }"
                           :content="(element as NoteElement).lyrics"
                           :editable="!lyricsLocked"
-                          whiteSpace="nowrap"
-                          :ref="`lyrics-${getElementIndex(element)}`"
+                          white-space="nowrap"
                           @click="focusLyrics(element.index)"
                           @focus="selectedLyrics = element as NoteElement"
                           @blur="updateLyrics(element as NoteElement, $event)"
@@ -6531,10 +6531,10 @@ export default defineComponent({
                             :style="getMelismaStyle(element as NoteElement)"
                           >
                             <span
-                              class="melisma-hyphen"
                               v-for="(offset, index) in (element as NoteElement)
                                 .hyphenOffsets"
                               :key="index"
+                              class="melisma-hyphen"
                               :style="
                                 getMelismaHyphenStyle(
                                   element as NoteElement,
@@ -6599,12 +6599,12 @@ export default defineComponent({
                         >
                           <span
                             class="melisma-text"
-                            v-text="(element as NoteElement).melismaText"
                             :class="{
                               selectedMelisma: element === selectedLyrics,
                             }"
                             @click="focusLyrics(element.index)"
                             @focus="selectedLyrics = element as NoteElement"
+                            v-text="(element as NoteElement).melismaText"
                           ></span>
                         </template>
                       </div>
@@ -6613,24 +6613,24 @@ export default defineComponent({
                   <template v-else-if="isMartyriaElement(element)">
                     <div class="neume-box">
                       <span
-                        class="section-name"
                         v-if="
                           element.sectionName != '' &&
                           element.sectionName != null
                         "
+                        class="section-name"
                         >§</span
                       >
-                      <span class="page-break" v-if="element.pageBreak">
+                      <span v-if="element.pageBreak" class="page-break">
                         <img src="@/assets/icons/page-break.svg"
                       /></span>
-                      <span class="line-break" v-if="element.lineBreak"
+                      <span v-if="element.lineBreak" class="line-break"
                         ><img src="@/assets/icons/line-break.svg"
                       /></span>
                       <MartyriaNeumeBox
                         :ref="`element-${getElementIndex(element)}`"
                         class="marytria-neume-box"
                         :neume="element as MartyriaElement"
-                        :pageSetup="score.pageSetup"
+                        :page-setup="score.pageSetup"
                         :class="[
                           {
                             selected: isSelected(element),
@@ -6648,23 +6648,23 @@ export default defineComponent({
                       class="neume-box"
                     >
                       <span
-                        class="section-name"
                         v-if="
                           element.sectionName != '' &&
                           element.sectionName != null
                         "
+                        class="section-name"
                         >§</span
                       >
-                      <span class="page-break" v-if="element.pageBreak">
+                      <span v-if="element.pageBreak" class="page-break">
                         <img src="@/assets/icons/page-break.svg"
                       /></span>
-                      <span class="line-break" v-if="element.lineBreak"
+                      <span v-if="element.lineBreak" class="line-break"
                         ><img src="@/assets/icons/line-break.svg"
                       /></span>
                       <TempoNeumeBox
                         class="tempo-neume-box"
                         :neume="element as TempoElement"
-                        :pageSetup="score.pageSetup"
+                        :page-setup="score.pageSetup"
                         :class="[{ selected: isSelected(element) }]"
                         @select-single="selectedElement = element"
                         @select-range="setSelectionRange(element)"
@@ -6678,17 +6678,17 @@ export default defineComponent({
                       class="neume-box"
                     >
                       <span
-                        class="section-name"
                         v-if="
                           element.sectionName != '' &&
                           element.sectionName != null
                         "
+                        class="section-name"
                         >§</span
                       >
-                      <span class="page-break" v-if="element.pageBreak">
+                      <span v-if="element.pageBreak" class="page-break">
                         <img src="@/assets/icons/page-break.svg"
                       /></span>
-                      <span class="line-break" v-if="element.lineBreak"
+                      <span v-if="element.lineBreak" class="line-break"
                         ><img src="@/assets/icons/line-break.svg"
                       /></span>
                       <EmptyNeumeBox
@@ -6702,24 +6702,24 @@ export default defineComponent({
                   </template>
                   <template v-else-if="isTextBoxElement(element)">
                     <span
-                      class="section-name-2"
                       v-if="
                         element.sectionName != '' && element.sectionName != null
                       "
+                      class="section-name-2"
                       >§</span
                     >
-                    <span class="page-break-2" v-if="element.pageBreak"
+                    <span v-if="element.pageBreak" class="page-break-2"
                       ><img src="@/assets/icons/page-break.svg"
                     /></span>
-                    <span class="line-break-2" v-if="element.lineBreak"
+                    <span v-if="element.lineBreak" class="line-break-2"
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <TextBox
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element as TextBoxElement"
-                      :editMode="true"
+                      :edit-mode="true"
                       :metadata="getTokenMetadata(pageIndex)"
-                      :pageSetup="score.pageSetup"
+                      :page-setup="score.pageSetup"
                       :selected="isSelected(element)"
                       @select-single="selectedElement = element"
                       @update="updateTextBox(element as TextBoxElement, $event)"
@@ -6730,22 +6730,22 @@ export default defineComponent({
                   </template>
                   <template v-else-if="isRichTextBoxElement(element)">
                     <span
-                      class="section-name-2"
                       v-if="
                         element.sectionName != '' && element.sectionName != null
                       "
+                      class="section-name-2"
                       >§</span
                     >
-                    <span class="page-break-2" v-if="element.pageBreak"
+                    <span v-if="element.pageBreak" class="page-break-2"
                       ><img src="@/assets/icons/page-break.svg"
                     /></span>
-                    <span class="line-break-2" v-if="element.lineBreak"
+                    <span v-if="element.lineBreak" class="line-break-2"
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <TextBoxRich
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element as RichTextBoxElement"
-                      :pageSetup="score.pageSetup"
+                      :page-setup="score.pageSetup"
                       :fonts="fonts"
                       :selected="isSelected(element)"
                       @select-single="selectedElement = element"
@@ -6762,22 +6762,22 @@ export default defineComponent({
                   </template>
                   <template v-else-if="isModeKeyElement(element)">
                     <span
-                      class="section-name-2"
                       v-if="
                         element.sectionName != '' && element.sectionName != null
                       "
+                      class="section-name-2"
                       >§</span
                     >
-                    <span class="page-break-2" v-if="element.pageBreak"
+                    <span v-if="element.pageBreak" class="page-break-2"
                       ><img src="@/assets/icons/page-break.svg"
                     /></span>
-                    <span class="line-break-2" v-if="element.lineBreak"
+                    <span v-if="element.lineBreak" class="line-break-2"
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <ModeKey
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element as ModeKeyElement"
-                      :pageSetup="score.pageSetup"
+                      :page-setup="score.pageSetup"
                       :class="[
                         {
                           selectedTextbox: isSelected(element),
@@ -6789,22 +6789,22 @@ export default defineComponent({
                   </template>
                   <template v-else-if="isDropCapElement(element)">
                     <span
-                      class="section-name"
                       v-if="
                         element.sectionName != '' && element.sectionName != null
                       "
+                      class="section-name"
                       >§</span
                     >
-                    <span class="page-break" v-if="element.pageBreak"
+                    <span v-if="element.pageBreak" class="page-break"
                       ><img src="@/assets/icons/page-break.svg"
                     /></span>
-                    <span class="line-break" v-if="element.lineBreak"
+                    <span v-if="element.lineBreak" class="line-break"
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <DropCap
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element as DropCapElement"
-                      :pageSetup="score.pageSetup"
+                      :page-setup="score.pageSetup"
                       :editable="!lyricsLocked"
                       :class="[
                         {
@@ -6818,17 +6818,17 @@ export default defineComponent({
                     />
                   </template>
                   <template v-else-if="isImageBoxElement(element)">
-                    <span class="page-break-2" v-if="element.pageBreak"
+                    <span v-if="element.pageBreak" class="page-break-2"
                       ><img src="@/assets/icons/page-break.svg"
                     /></span>
-                    <span class="line-break-2" v-if="element.lineBreak"
+                    <span v-if="element.lineBreak" class="line-break-2"
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <ImageBox
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element as ImageBoxElement"
                       :zoom="zoom"
-                      :printMode="printMode"
+                      :print-mode="printMode"
                       :class="[{ selectedImagebox: isSelected(element) }]"
                       @select-single="selectedElement = element"
                       @update:size="
@@ -6855,21 +6855,21 @@ export default defineComponent({
                   v-if="isRichTextBoxElement(getFooterForPageIndex(pageIndex))"
                 >
                   <TextBoxRich
-                    class="element-box"
                     :key="`element-${selectedWorkspace.id}-${getFooterForPageIndex(pageIndex).id}-${
                       getFooterForPageIndex(pageIndex).keyHelper
                     }`"
                     :ref="`footer-${pageIndex}`"
+                    class="element-box"
                     :element="
                       getFooterForPageIndex(pageIndex) as RichTextBoxElement
                     "
-                    :editMode="
+                    :edit-mode="
                       !printMode &&
                       getFooterForPageIndex(pageIndex) ==
                         selectedHeaderFooterElement
                     "
                     :metadata="getTokenMetadata(pageIndex)"
-                    :pageSetup="score.pageSetup"
+                    :page-setup="score.pageSetup"
                     :fonts="fonts"
                     :selected="
                       getFooterForPageIndex(pageIndex) ==
@@ -6898,21 +6898,21 @@ export default defineComponent({
                   v-else-if="isTextBoxElement(getHeaderForPageIndex(pageIndex))"
                 >
                   <TextBox
-                    class="element-box"
                     :ref="`footer-${pageIndex}`"
                     :key="`element-${selectedWorkspace.id}-${getFooterForPageIndex(pageIndex).id}-${
                       getFooterForPageIndex(pageIndex).keyHelper
                     }`"
+                    class="element-box"
                     :element="
                       getFooterForPageIndex(pageIndex) as TextBoxElement
                     "
-                    :editMode="
+                    :edit-mode="
                       !printMode &&
                       getFooterForPageIndex(pageIndex) ==
                         selectedHeaderFooterElement
                     "
                     :metadata="getTokenMetadata(pageIndex)"
-                    :pageSetup="score.pageSetup"
+                    :page-setup="score.pageSetup"
                     :selected="
                       getFooterForPageIndex(pageIndex) ==
                       selectedHeaderFooterElement
@@ -6946,9 +6946,9 @@ export default defineComponent({
       <ToolbarTextBox
         :element="selectedTextBoxElement as TextBoxElement"
         :fonts="fonts"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         @update="updateTextBox(selectedTextBoxElement, $event)"
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(
             selectedElement as TextBoxElement,
             $event,
@@ -6961,9 +6961,9 @@ export default defineComponent({
     <template v-if="selectedRichTextBoxElement != null">
       <ToolbarTextBoxRich
         :element="selectedRichTextBoxElement"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         @update="updateRichTextBox(selectedRichTextBoxElement, $event)"
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(
             selectedElement as RichTextBoxElement,
             $event,
@@ -6977,9 +6977,9 @@ export default defineComponent({
       <ToolbarDropCap
         :element="selectedElement as DropCapElement"
         :fonts="fonts"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         @update="updateDropCap(selectedElement as DropCapElement, $event)"
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(
             selectedElement as DropCapElement,
             $event,
@@ -6992,7 +6992,7 @@ export default defineComponent({
     >
       <ToolbarImageBox
         :element="selectedElement as ImageBoxElement"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         @update="updateImageBox(selectedElement as ImageBoxElement, $event)"
       />
     </template>
@@ -7001,7 +7001,7 @@ export default defineComponent({
         :element="selectedLyrics"
         :fonts="fonts"
         @update="updateNoteAndSave(selectedLyrics as NoteElement, $event)"
-        @insert:specialCharacter="insertSpecialCharacter"
+        @insert:special-character="insertSpecialCharacter"
       />
     </template>
     <template
@@ -7009,12 +7009,12 @@ export default defineComponent({
     >
       <ToolbarModeKey
         :element="selectedElement as ModeKeyElement"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         @update="updateModeKey(selectedElement as ModeKeyElement, $event)"
         @update:tempo="
           setModeKeyTempo(selectedElement as ModeKeyElement, $event)
         "
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(
             selectedElement as ModeKeyElement,
             $event,
@@ -7031,28 +7031,28 @@ export default defineComponent({
       "
     >
       <ToolbarNeume
-        :element="selectedElementForNeumeToolbar as NoteElement"
-        :pageSetup="score.pageSetup"
-        :neumeKeyboard="neumeKeyboard"
         :key="`toolbar-neume-${selectedWorkspace.id}-${selectedElement.id}-${selectedElement.keyHelper}`"
-        :innerNeume="toolbarInnerNeume"
+        :element="selectedElementForNeumeToolbar as NoteElement"
+        :page-setup="score.pageSetup"
+        :neume-keyboard="neumeKeyboard"
+        :inner-neume="toolbarInnerNeume"
         @update="
           updateNoteAndSave(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
           )
         "
-        @update:innerNeume="toolbarInnerNeume = $event"
+        @update:inner-neume="toolbarInnerNeume = $event"
         @update:accidental="
           setAccidental(selectedElementForNeumeToolbar as NoteElement, $event)
         "
-        @update:secondaryAccidental="
+        @update:secondary-accidental="
           setSecondaryAccidental(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
           )
         "
-        @update:tertiaryAccidental="
+        @update:tertiary-accidental="
           setTertiaryAccidental(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
@@ -7061,13 +7061,13 @@ export default defineComponent({
         @update:fthora="
           setFthoraNote(selectedElementForNeumeToolbar as NoteElement, $event)
         "
-        @update:secondaryFthora="
+        @update:secondary-fthora="
           setSecondaryFthora(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
           )
         "
-        @update:tertiaryFthora="
+        @update:tertiary-fthora="
           setTertiaryFthora(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
@@ -7076,7 +7076,7 @@ export default defineComponent({
         @update:gorgon="
           setGorgon(selectedElementForNeumeToolbar as NoteElement, $event)
         "
-        @update:secondaryGorgon="
+        @update:secondary-gorgon="
           setSecondaryGorgon(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
@@ -7094,13 +7094,13 @@ export default defineComponent({
             $event,
           )
         "
-        @update:measureBar="
+        @update:measure-bar="
           setMeasureBarNote(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
           )
         "
-        @update:measureNumber="
+        @update:measure-number="
           setMeasureNumber(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
@@ -7112,7 +7112,7 @@ export default defineComponent({
         @update:tie="
           setTie(selectedElementForNeumeToolbar as NoteElement, $event)
         "
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(
             selectedElementForNeumeToolbar as NoteElement,
             $event,
@@ -7126,31 +7126,31 @@ export default defineComponent({
     >
       <ToolbarMartyria
         :element="selectedElement as MartyriaElement"
-        :pageSetup="score.pageSetup"
-        :neumeKeyboard="neumeKeyboard"
+        :page-setup="score.pageSetup"
+        :neume-keyboard="neumeKeyboard"
         @update="updateMartyria(selectedElement as MartyriaElement, $event)"
         @update:fthora="
           setFthoraMartyria(selectedElement as MartyriaElement, $event)
         "
-        @update:tempoLeft="
+        @update:tempo-left="
           setMartyriaTempoLeft(selectedElement as MartyriaElement, $event)
         "
         @update:tempo="
           setMartyriaTempo(selectedElement as MartyriaElement, $event)
         "
-        @update:tempoRight="
+        @update:tempo-right="
           setMartyriaTempoRight(selectedElement as MartyriaElement, $event)
         "
-        @update:measureBar="
+        @update:measure-bar="
           setMeasureBarMartyria(selectedElement as MartyriaElement, $event)
         "
-        @update:quantitativeNeume="
+        @update:quantitative-neume="
           setMartyriaQuantitativeNeume(
             selectedElement as MartyriaElement,
             $event,
           )
         "
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(
             selectedElement as MartyriaElement,
             $event,
@@ -7161,9 +7161,9 @@ export default defineComponent({
     <template v-if="selectedElement != null && isTempoElement(selectedElement)">
       <ToolbarTempo
         :element="selectedElement as TempoElement"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         @update="updateTempo(selectedElement as TempoElement, $event)"
-        @update:sectionName="
+        @update:section-name="
           updateScoreElementSectionName(selectedElement as TempoElement, $event)
         "
       />
@@ -7174,7 +7174,7 @@ export default defineComponent({
       :locked="lyricsLocked"
       @update:locked="updateLyricsLocked"
       @update:lyrics="updateStaffLyrics"
-      @assignAcceptsLyrics="assignAcceptsLyricsFromCurrentLyrics"
+      @assign-accepts-lyrics="assignAcceptsLyricsFromCurrentLyrics"
       @close="closeLyricManager"
       @click="
         selectedElement = null;
@@ -7184,11 +7184,11 @@ export default defineComponent({
     <ModeKeyDialog
       v-if="modeKeyDialogIsOpen"
       :element="selectedElement as ModeKeyElement"
-      :pageSetup="score.pageSetup"
+      :page-setup="score.pageSetup"
       @update="
         updateModeKeyFromTemplate(selectedElement as ModeKeyElement, $event)
       "
-      @update:useOptionalDiatonicFthoras="
+      @update:use-optional-diatonic-fthoras="
         updatePageSetupUseOptionalDiatonicFthoras($event)
       "
       @close="closeModeKeyDialog"
@@ -7196,9 +7196,9 @@ export default defineComponent({
     <SyllablePositioningDialog
       v-if="syllablePositioningDialogIsOpen"
       :element="selectedElement as NoteElement"
-      :previousElement="previousElementOnLine ?? undefined"
-      :nextElement="nextElementOnLine ?? undefined"
-      :pageSetup="score.pageSetup"
+      :previous-element="previousElementOnLine ?? undefined"
+      :next-element="nextElementOnLine ?? undefined"
+      :page-setup="score.pageSetup"
       @update="updateNoteAndSave(selectedElement as NoteElement, $event)"
       @close="closeSyllablePositioningDialog"
     />
@@ -7211,13 +7211,13 @@ export default defineComponent({
     <EditorPreferencesDialog
       v-if="editorPreferencesDialogIsOpen"
       :options="editorPreferences"
-      :pageSetup="score.pageSetup"
+      :page-setup="score.pageSetup"
       @update="updateEditorPreferences"
       @close="closeEditorPreferencesDialog"
     />
     <PageSetupDialog
       v-if="pageSetupDialogIsOpen"
-      :pageSetup="score.pageSetup"
+      :page-setup="score.pageSetup"
       :fonts="fonts"
       @update="updatePageSetup($event)"
       @close="closePageSetupDialog"
@@ -7225,19 +7225,19 @@ export default defineComponent({
     <ExportDialog
       v-if="exportDialogIsOpen"
       :loading="exportInProgress"
-      :defaultFormat="exportFormat"
-      @exportAsPng="exportAsPng"
-      @exportAsMusicXml="exportAsMusicXml"
-      @exportAsLatex="exportAsLatex"
+      :default-format="exportFormat"
+      @export-as-png="exportAsPng"
+      @export-as-music-xml="exportAsMusicXml"
+      @export-as-latex="exportAsLatex"
       @close="closeExportDialog"
     />
     <template v-if="richTextBoxCalculation">
       <TextBoxRich
-        class="richTextBoxCalculation"
         v-for="element in resizableRichTextBoxElements"
         :key="element.id!"
+        class="richTextBoxCalculation"
         :element="element as RichTextBoxElement"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         :fonts="fonts"
         :recalc="true"
         @update:height="
@@ -7247,11 +7247,11 @@ export default defineComponent({
     </template>
     <template v-if="textBoxCalculation">
       <TextBox
-        class="textBoxCalculation"
         v-for="element in resizableTextBoxElements"
         :key="element.id!"
+        class="textBoxCalculation"
         :element="element as TextBoxElement"
-        :pageSetup="score.pageSetup"
+        :page-setup="score.pageSetup"
         :fonts="fonts"
         @update:height="updateTextBoxHeight(element as TextBoxElement, $event)"
       />

--- a/src/components/ToolbarDropCap.vue
+++ b/src/components/ToolbarDropCap.vue
@@ -31,8 +31,8 @@
       <InputFontSize
         class="drop-caps-input"
         :max="500"
-        :modelValue="element.fontSize"
-        @update:modelValue="
+        :model-value="element.fontSize"
+        @update:model-value="
           $emit('update', {
             fontSize: $event,
           } as Partial<DropCapElement>)
@@ -45,10 +45,10 @@
         :nullable="true"
         :min="0"
         :step="0.1"
-        :modelValue="element.lineHeight"
+        :model-value="element.lineHeight"
         :precision="2"
         placeholder="auto"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', {
             lineHeight: $event,
           } as Partial<DropCapElement>)
@@ -56,8 +56,8 @@
       />
       <span class="space"></span>
       <ColorPicker
-        :modelValue="element.color"
-        @update:modelValue="
+        :model-value="element.color"
+        @update:model-value="
           $emit('update', {
             color: $event,
           } as Partial<DropCapElement>)
@@ -89,8 +89,8 @@
       <span class="space"></span>
       <label class="right-space">{{ $t('toolbar:common.outline') }}</label>
       <InputStrokeWidth
-        :modelValue="element.strokeWidth"
-        @update:modelValue="
+        :model-value="element.strokeWidth"
+        @update:model-value="
           $emit('update', {
             strokeWidth: $event,
           } as Partial<DropCapElement>)
@@ -104,9 +104,9 @@
         :min="1"
         :max="10"
         :step="1"
-        :modelValue="element.lineSpan"
+        :model-value="element.lineSpan"
         :precision="0"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', {
             lineSpan: $event,
           } as Partial<DropCapElement>)
@@ -122,10 +122,10 @@
       :min="4"
       :max="maxWidth"
       :step="0.5"
-      :modelValue="element.customWidth"
+      :model-value="element.customWidth"
       :precision="1"
       placeholder="auto"
-      @update:modelValue="
+      @update:model-value="
         $emit('update', {
           customWidth: $event,
         } as Partial<DropCapElement>)
@@ -159,7 +159,6 @@ import { Unit } from '@/utils/Unit';
 
 export default defineComponent({
   components: { ColorPicker, InputFontSize, InputStrokeWidth, InputUnit },
-  emits: ['update', 'update:sectionName'],
   props: {
     element: {
       type: Object as PropType<DropCapElement>,
@@ -174,6 +173,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update', 'update:sectionName'],
 
   data() {
     return {};

--- a/src/components/ToolbarImageBox.vue
+++ b/src/components/ToolbarImageBox.vue
@@ -39,13 +39,13 @@
     <div style="display: flex; align-items: center">
       <label class="right-space">{{ $t('toolbar:imageBox.width') }}</label>
       <InputUnit
-        :modelValue="element.imageWidth"
-        @update:modelValue="onChangeWidth($event)"
+        :model-value="element.imageWidth"
         unit="unitless"
         :min="10"
         :max="pageSetup.pageWidth"
         :step="1"
         :precision="0"
+        @update:model-value="onChangeWidth($event)"
       />
     </div>
 
@@ -54,13 +54,13 @@
     <div style="display: flex; align-items: center">
       <label class="right-space">{{ $t('toolbar:imageBox.height') }}</label>
       <InputUnit
-        :modelValue="element.imageHeight"
-        @update:modelValue="onChangeHeight($event)"
+        :model-value="element.imageHeight"
         unit="unitless"
         :min="10"
         :max="pageSetup.pageHeight"
         :step="1"
         :precision="0"
+        @update:model-value="onChangeHeight($event)"
       />
     </div>
     <template v-if="!element.inline">
@@ -127,7 +127,6 @@ import InputUnit from './InputUnit.vue';
 
 export default defineComponent({
   components: { InputUnit },
-  emits: ['update'],
   props: {
     element: {
       type: Object as PropType<ImageBoxElement>,
@@ -138,6 +137,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update'],
 
   data() {
     return {

--- a/src/components/ToolbarLyrics.vue
+++ b/src/components/ToolbarLyrics.vue
@@ -30,8 +30,8 @@
       <span class="space"></span>
       <InputFontSize
         class="lyrics-input"
-        :modelValue="element.lyricsFontSize"
-        @update:modelValue="
+        :model-value="element.lyricsFontSize"
+        @update:model-value="
           $emit('update', {
             lyricsFontSize: $event,
           } as Partial<NoteElement>)
@@ -39,8 +39,8 @@
       />
       <span class="space"></span>
       <ColorPicker
-        :modelValue="element.lyricsColor"
-        @update:modelValue="
+        :model-value="element.lyricsColor"
+        @update:model-value="
           $emit('update', {
             lyricsColor: $event,
           } as Partial<NoteElement>)
@@ -83,8 +83,8 @@
       <span class="space"></span>
       <label class="right-space">{{ $t('toolbar:common.outline') }}</label>
       <InputStrokeWidth
-        :modelValue="element.lyricsStrokeWidth"
-        @update:modelValue="
+        :model-value="element.lyricsStrokeWidth"
+        @update:model-value="
           $emit('update', {
             lyricsStrokeWidth: $event,
           } as Partial<NoteElement>)
@@ -156,7 +156,6 @@ const specialCharacters = [
 
 export default defineComponent({
   components: { ColorPicker, InputFontSize, InputStrokeWidth },
-  emits: ['insert:specialCharacter', 'update'],
   props: {
     element: {
       type: Object as PropType<NoteElement>,
@@ -167,6 +166,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['insert:specialCharacter', 'update'],
 
   data() {
     return {

--- a/src/components/ToolbarMain.vue
+++ b/src/components/ToolbarMain.vue
@@ -2,22 +2,22 @@
   <div class="main-toolbar">
     <button
       class="entry-mode-btn"
-      @click="$emit('update:entryMode', EntryMode.Auto)"
       :class="{ on: entryMode === EntryMode.Auto }"
+      @click="$emit('update:entryMode', EntryMode.Auto)"
     >
       {{ $t('toolbar:main.auto') }}
     </button>
     <button
       class="entry-mode-btn"
-      @click="$emit('update:entryMode', EntryMode.Insert)"
       :class="{ on: entryMode === EntryMode.Insert }"
+      @click="$emit('update:entryMode', EntryMode.Insert)"
     >
       {{ $t('toolbar:main.insert') }}
     </button>
     <button
       class="entry-mode-btn"
-      @click="$emit('update:entryMode', EntryMode.Edit)"
       :class="{ on: entryMode === EntryMode.Edit }"
+      @click="$emit('update:entryMode', EntryMode.Edit)"
     >
       {{ $t('toolbar:main.single') }}
     </button>
@@ -34,7 +34,7 @@
       direction="down"
       :options="tempoOptions"
       :title="tempoTooltip"
-      imgSize="28px"
+      img-size="28px"
       @select="$emit('add-tempo', $event)"
     />
     <span class="space"></span>
@@ -115,7 +115,7 @@
       <img src="@/assets/icons/delete.svg" width="24" height="24" />
     </button>
     <span class="space"></span>
-    <div class="zoom-container" @focusout="showZoomMenu = false" tabindex="-1">
+    <div class="zoom-container" tabindex="-1" @focusout="showZoomMenu = false">
       <input
         class="zoom"
         :value="zoomDisplay"
@@ -124,7 +124,7 @@
       <span class="zoom-arrow" @click="showZoomMenu = !showZoomMenu"
         >&#x25BE;</span
       >
-      <div class="zoom-menu" v-if="showZoomMenu">
+      <div v-if="showZoomMenu" class="zoom-menu">
         <div class="zoom-menu-item" @click="updateZoom('Fit')">
           {{ $t('toolbar:main.fit') }}
         </div>
@@ -189,9 +189,9 @@
         :max="300"
         :step="1"
         :precision="0"
-        :modelValue="audioOptions.speed"
+        :model-value="audioOptions.speed"
         :disabled="audioState === AudioState.Playing"
-        @update:modelValue="$emit('update:audioOptionsSpeed', $event)"
+        @update:model-value="$emit('update:audioOptionsSpeed', $event)"
       />
       <span>%</span>
     </div>
@@ -253,24 +253,6 @@ const tempoOptions: ButtonWithMenuOption[] = [
 
 export default defineComponent({
   components: { ButtonWithMenu, InputUnit },
-  emits: [
-    'add-auto-martyria',
-    'add-drop-cap',
-    'add-image',
-    'add-mode-key',
-    'add-tempo',
-    'add-text-box',
-    'add-text-box-rich',
-    'delete-selected-element',
-    'open-playback-settings',
-    'play-audio',
-    'toggle-line-break',
-    'toggle-page-break',
-    'update:audioOptionsSpeed',
-    'update:entryMode',
-    'update:zoom',
-    'update:zoomToFit',
-  ],
   props: {
     entryMode: {
       type: String as PropType<EntryMode>,
@@ -313,6 +295,24 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: [
+    'add-auto-martyria',
+    'add-drop-cap',
+    'add-image',
+    'add-mode-key',
+    'add-tempo',
+    'add-text-box',
+    'add-text-box-rich',
+    'delete-selected-element',
+    'open-playback-settings',
+    'play-audio',
+    'toggle-line-break',
+    'toggle-page-break',
+    'update:audioOptionsSpeed',
+    'update:entryMode',
+    'update:zoom',
+    'update:zoomToFit',
+  ],
 
   data() {
     return {

--- a/src/components/ToolbarMartyria.vue
+++ b/src/components/ToolbarMartyria.vue
@@ -244,8 +244,8 @@
           element.tempoLeft == null &&
           element.tempoRight == null
         "
-        :modelValue="element.bpm"
-        @update:modelValue="
+        :model-value="element.bpm"
+        @update:model-value="
           $emit('update', {
             bpm: $event,
           } as Partial<MartyriaElement>)
@@ -264,8 +264,8 @@
         :max="spaceAfterMax"
         :step="0.5"
         :precision="2"
-        :modelValue="element.verticalOffset"
-        @update:modelValue="
+        :model-value="element.verticalOffset"
+        @update:model-value="
           $emit('update', {
             verticalOffset: $event,
           } as Partial<MartyriaElement>)
@@ -282,8 +282,8 @@
         :max="spaceAfterMax"
         :step="0.5"
         :precision="2"
-        :modelValue="element.spaceAfter"
-        @update:modelValue="
+        :model-value="element.spaceAfter"
+        @update:model-value="
           $emit('update', {
             spaceAfter: $event,
           } as Partial<MartyriaElement>)
@@ -686,16 +686,6 @@ function getDisplayName(neume: Neume) {
 
 export default defineComponent({
   components: { InputUnit, InputBpm, ButtonWithMenu },
-  emits: [
-    'update',
-    'update:fthora',
-    'update:measureBar',
-    'update:quantitativeNeume',
-    'update:sectionName',
-    'update:tempoLeft',
-    'update:tempo',
-    'update:tempoRight',
-  ],
   props: {
     element: {
       type: Object as PropType<MartyriaElement>,
@@ -710,6 +700,16 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: [
+    'update',
+    'update:fthora',
+    'update:measureBar',
+    'update:quantitativeNeume',
+    'update:sectionName',
+    'update:tempoLeft',
+    'update:tempo',
+    'update:tempoRight',
+  ],
 
   data() {
     return {

--- a/src/components/ToolbarModeKey.vue
+++ b/src/components/ToolbarModeKey.vue
@@ -18,15 +18,15 @@
     <template v-if="!element.useDefaultStyle">
       <label class="right-space">{{ $t('toolbar:modeKey.size') }}</label>
       <InputFontSize
-        :modelValue="element.fontSize"
-        @update:modelValue="
+        :model-value="element.fontSize"
+        @update:model-value="
           $emit('update', { fontSize: $event } as Partial<ModeKeyElement>)
         "
       />
       <span class="space"></span>
       <ColorPicker
-        :modelValue="element.color"
-        @update:modelValue="
+        :model-value="element.color"
+        @update:model-value="
           $emit('update', { color: $event } as Partial<ModeKeyElement>)
         "
       />
@@ -87,8 +87,8 @@
     <template v-if="!element.useDefaultStyle">
       <label class="right-space">{{ $t('toolbar:common.outline') }}</label>
       <InputStrokeWidth
-        :modelValue="element.strokeWidth"
-        @update:modelValue="
+        :model-value="element.strokeWidth"
+        @update:model-value="
           $emit('update', { strokeWidth: $event } as Partial<ModeKeyElement>)
         "
       />
@@ -105,8 +105,8 @@
         :max="heightAdjustmentMax"
         :step="0.5"
         :precision="2"
-        :modelValue="element.heightAdjustment"
-        @update:modelValue="
+        :model-value="element.heightAdjustment"
+        @update:model-value="
           $emit('update', {
             heightAdjustment: $event,
           } as Partial<ModeKeyElement>)
@@ -142,8 +142,8 @@
 
     <label class="right-space">{{ $t('toolbar:common.bpm') }}</label>
     <InputBpm
-      :modelValue="element.bpm"
-      @update:modelValue="
+      :model-value="element.bpm"
+      @update:model-value="
         $emit('update', { bpm: $event } as Partial<ModeKeyElement>)
       "
     />
@@ -158,9 +158,9 @@
         :min="0"
         :max="maxHeight"
         :step="0.5"
-        :modelValue="element.marginTop"
+        :model-value="element.marginTop"
         :precision="1"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { marginTop: $event } as Partial<ModeKeyElement>)
         "
       />
@@ -174,9 +174,9 @@
         :min="0"
         :max="maxHeight"
         :step="0.5"
-        :modelValue="element.marginBottom"
+        :model-value="element.marginBottom"
         :precision="1"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { marginBottom: $event } as Partial<ModeKeyElement>)
         "
       />
@@ -318,12 +318,6 @@ export default defineComponent({
     InputStrokeWidth,
     ButtonWithMenu,
   },
-  emits: [
-    'open-mode-key-dialog',
-    'update',
-    'update:sectionName',
-    'update:tempo',
-  ],
   props: {
     element: {
       type: Object as PropType<ModeKeyElement>,
@@ -334,6 +328,12 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: [
+    'open-mode-key-dialog',
+    'update',
+    'update:sectionName',
+    'update:tempo',
+  ],
 
   data() {
     return {

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -1,37 +1,37 @@
 <template>
   <div class="neume-toolbar">
-    <div class="row" v-if="secondaryNeume">
+    <div v-if="secondaryNeume" class="row">
       <span>{{ $t('toolbar:neume.neumeSelect') }}</span>
       <span class="space"></span>
       <button
         v-if="tertiaryNeume"
         class="btnNeumeSelect"
-        @click="$emit('update:innerNeume', 'Tertiary')"
         :class="{ selected: innerNeume === 'Tertiary' }"
+        @click="$emit('update:innerNeume', 'Tertiary')"
       >
         <Neume
           :neume="tertiaryNeume"
-          :fontFamily="pageSetup.neumeDefaultFontFamily"
+          :font-family="pageSetup.neumeDefaultFontFamily"
         />
       </button>
       <button
-        @click="$emit('update:innerNeume', 'Secondary')"
         class="btnNeumeSelect"
         :class="{ selected: innerNeume === 'Secondary' }"
+        @click="$emit('update:innerNeume', 'Secondary')"
       >
         <Neume
           :neume="secondaryNeume"
-          :fontFamily="pageSetup.neumeDefaultFontFamily"
+          :font-family="pageSetup.neumeDefaultFontFamily"
         />
       </button>
       <button
-        @click="$emit('update:innerNeume', 'Primary')"
         class="btnNeumeSelect"
         :class="{ selected: innerNeume === 'Primary' }"
+        @click="$emit('update:innerNeume', 'Primary')"
       >
         <Neume
           :neume="primaryNeume!"
-          :fontFamily="pageSetup.neumeDefaultFontFamily"
+          :font-family="pageSetup.neumeDefaultFontFamily"
         />
       </button>
     </div>
@@ -417,8 +417,8 @@
         :max="spaceAfterMax"
         :step="0.5"
         :precision="2"
-        :modelValue="element.spaceAfter"
-        @update:modelValue="$emit('update', { spaceAfter: $event })"
+        :model-value="element.spaceAfter"
+        @update:model-value="$emit('update', { spaceAfter: $event })"
       />
       <span class="space"></span>
 
@@ -992,6 +992,24 @@ function getDisplayName(neume: Neume) {
 
 export default defineComponent({
   components: { InputUnit, ButtonWithMenu, Neume: NeumeVue },
+  props: {
+    element: {
+      type: Object as PropType<NoteElement>,
+      required: true,
+    },
+    pageSetup: {
+      type: Object as PropType<PageSetup>,
+      required: true,
+    },
+    innerNeume: {
+      type: String,
+      required: true,
+    },
+    neumeKeyboard: {
+      type: Object as PropType<NeumeKeyboard>,
+      required: true,
+    },
+  },
   emits: [
     'update',
     'open-syllable-positioning-dialog',
@@ -1013,24 +1031,6 @@ export default defineComponent({
     'update:tie',
     'update:time',
   ],
-  props: {
-    element: {
-      type: Object as PropType<NoteElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    innerNeume: {
-      type: String,
-      required: true,
-    },
-    neumeKeyboard: {
-      type: Object as PropType<NeumeKeyboard>,
-      required: true,
-    },
-  },
 
   data() {
     return {

--- a/src/components/ToolbarTempo.vue
+++ b/src/components/ToolbarTempo.vue
@@ -4,8 +4,8 @@
       <div class="form-group">
         <label class="right-space">{{ $t('toolbar:common.bpm') }}</label>
         <InputBpm
-          :modelValue="element.bpm"
-          @update:modelValue="
+          :model-value="element.bpm"
+          @update:model-value="
             $emit('update', { bpm: $event } as Partial<TempoElement>)
           "
         />
@@ -21,8 +21,8 @@
           :max="spaceAfterMax"
           :step="0.5"
           :precision="2"
-          :modelValue="element.spaceAfter"
-          @update:modelValue="
+          :model-value="element.spaceAfter"
+          @update:model-value="
             $emit('update', { spaceAfter: $event } as Partial<TempoElement>)
           "
         />
@@ -59,7 +59,6 @@ import InputUnit from './InputUnit.vue';
 
 export default defineComponent({
   components: { InputUnit, InputBpm },
-  emits: ['update', 'update:sectionName'],
   props: {
     element: {
       type: Object as PropType<TempoElement>,
@@ -70,6 +69,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update', 'update:sectionName'],
 
   data() {
     return {};

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -35,8 +35,8 @@
       <span class="space"></span>
       <InputFontSize
         class="drop-caps-input"
-        :modelValue="element.fontSize"
-        @update:modelValue="
+        :model-value="element.fontSize"
+        @update:model-value="
           $emit('update', { fontSize: $event } as Partial<TextBoxElement>)
         "
       />
@@ -47,17 +47,17 @@
         :nullable="true"
         :min="0"
         :step="0.1"
-        :modelValue="element.lineHeight"
+        :model-value="element.lineHeight"
         :precision="2"
         placeholder="normal"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { lineHeight: $event } as Partial<TextBoxElement>)
         "
       />
       <span class="space"></span>
       <ColorPicker
-        :modelValue="element.color"
-        @update:modelValue="
+        :model-value="element.color"
+        @update:model-value="
           $emit('update', { color: $event } as Partial<TextBoxElement>)
         "
       />
@@ -149,8 +149,8 @@
       <span class="space" />
       <label class="right-space">{{ $t('toolbar:common.outline') }}</label>
       <InputStrokeWidth
-        :modelValue="element.strokeWidth"
-        @update:modelValue="
+        :model-value="element.strokeWidth"
+        @update:model-value="
           $emit('update', { strokeWidth: $event } as Partial<TextBoxElement>)
         "
       />
@@ -200,10 +200,10 @@
           :min="0.5"
           :max="maxWidth"
           :step="0.5"
-          :modelValue="element.customHeight"
+          :model-value="element.customHeight"
           :precision="1"
           placeholder="auto"
-          @update:modelValue="
+          @update:model-value="
             $emit('update', { customHeight: $event } as Partial<TextBoxElement>)
           "
         />
@@ -219,10 +219,10 @@
         :min="0.5"
         :max="maxWidth"
         :step="0.5"
-        :modelValue="element.customWidth"
+        :model-value="element.customWidth"
         :precision="1"
         placeholder="auto"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { customWidth: $event } as Partial<TextBoxElement>)
         "
       />
@@ -249,9 +249,9 @@
         :min="-maxHeight"
         :max="maxHeight"
         :step="0.5"
-        :modelValue="element.marginTop"
+        :model-value="element.marginTop"
         :precision="1"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { marginTop: $event } as Partial<TextBoxElement>)
         "
       />
@@ -265,9 +265,9 @@
         :min="0"
         :max="maxHeight"
         :step="0.5"
-        :modelValue="element.marginBottom"
+        :model-value="element.marginBottom"
         :precision="1"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { marginBottom: $event } as Partial<TextBoxElement>)
         "
       />
@@ -299,12 +299,6 @@ import { Unit } from '@/utils/Unit';
 
 export default defineComponent({
   components: { ColorPicker, InputFontSize, InputUnit, InputStrokeWidth },
-  emits: [
-    'insert:gorthmikon',
-    'insert:pelastikon',
-    'update',
-    'update:sectionName',
-  ],
   props: {
     element: {
       type: Object as PropType<TextBoxElement>,
@@ -319,6 +313,12 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: [
+    'insert:gorthmikon',
+    'insert:pelastikon',
+    'update',
+    'update:sectionName',
+  ],
 
   data() {
     return {

--- a/src/components/ToolbarTextBoxRich.vue
+++ b/src/components/ToolbarTextBoxRich.vue
@@ -26,10 +26,10 @@
           :min="0.5"
           :max="maxWidth"
           :step="0.5"
-          :modelValue="element.customWidth"
+          :model-value="element.customWidth"
           :precision="1"
           placeholder="fill"
-          @update:modelValue="
+          @update:model-value="
             $emit('update', {
               customWidth: $event,
             } as Partial<RichTextBoxElement>)
@@ -47,9 +47,9 @@
           :min="-maxHeight"
           :max="maxHeight"
           :step="0.5"
-          :modelValue="element.offsetYTop"
+          :model-value="element.offsetYTop"
           :precision="1"
-          @update:modelValue="
+          @update:model-value="
             $emit('update', {
               offsetYTop: $event,
             } as Partial<RichTextBoxElement>)
@@ -67,9 +67,9 @@
           :min="-maxHeight"
           :max="maxHeight"
           :step="0.5"
-          :modelValue="element.offsetYBottom"
+          :model-value="element.offsetYBottom"
           :precision="1"
-          @update:modelValue="
+          @update:model-value="
             $emit('update', {
               offsetYBottom: $event,
             } as Partial<RichTextBoxElement>)
@@ -102,9 +102,9 @@
         :min="0"
         :max="maxHeight"
         :step="0.5"
-        :modelValue="element.marginTop"
+        :model-value="element.marginTop"
         :precision="1"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', { marginTop: $event } as Partial<RichTextBoxElement>)
         "
       />
@@ -118,9 +118,9 @@
         :min="0"
         :max="maxHeight"
         :step="0.5"
-        :modelValue="element.marginBottom"
+        :model-value="element.marginBottom"
         :precision="1"
-        @update:modelValue="
+        @update:model-value="
           $emit('update', {
             marginBottom: $event,
           } as Partial<RichTextBoxElement>)
@@ -199,8 +199,8 @@
       <div class="form-group">
         <label class="right-space">{{ $t('toolbar:common.bpm') }}</label>
         <InputBpm
-          :modelValue="element.modeChangeBpm"
-          @update:modelValue="
+          :model-value="element.modeChangeBpm"
+          @update:model-value="
             $emit('update', {
               modeChangeBpm: $event,
             } as Partial<RichTextBoxElement>)
@@ -389,7 +389,6 @@ function getScaleDisplayName(scale: Scale) {
 
 export default defineComponent({
   components: { InputBpm, InputUnit },
-  emits: ['update', 'update:sectionName'],
   props: {
     element: {
       type: Object as PropType<RichTextBoxElement>,
@@ -400,6 +399,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['update', 'update:sectionName'],
 
   data() {
     return {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,7 +10,7 @@ import TheEditor from '@/components/TheEditor.vue';
 
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
-  name: 'home',
+  name: 'Home',
   components: {
     TheEditor,
   },


### PR DESCRIPTION
Switches the Vue ESLint preset from `flat/essential` to `flat/recommended` in `eslint.config.mjs`:

- **`vue/attributes-order`**: `v-if` (and other structural directives) now come before other attributes: `<div class="..." v-if="x">` - `<div v-if="x" class="...">`.
- **`vue/attribute-hyphenation`**: kebab-case for attribute bindings in templates: `:pageSetup` - `:page-setup`, `:alternateLine` - `:alternate-line`.
- **`vue/order-in-components`**: Options API keys reordered to the canonical sequence: `components` - `inject` - `props` - `emits` - `data` - `computed` - lifecycle hooks - `methods`.
- **`vue/component-definition-name-casing`**: `name: 'home'` - `name: 'Home'` in `views/Home.vue`.
- **`vue/require-default-prop`**: optional props now declare `default: undefined` instead of `required: false`.