### PR TITLE
chore: More build cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {
+        "electron-updater": "^6.8.3",
         "i18next": "^26.0.8",
         "i18next-pseudo": "^2.2.1",
         "image-size": "^2.0.2",
@@ -35,7 +36,6 @@
         "ckeditor5": "^48.0.1",
         "electron": "^42.0.1",
         "electron-builder": "^26.8.1",
-        "electron-updater": "^6.8.3",
         "eslint": "^10.3.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-simple-import-sort": "^13.0.0",
@@ -6443,7 +6443,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -6887,7 +6886,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -7595,7 +7593,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8177,7 +8174,6 @@
       "version": "6.8.3",
       "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
       "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "builder-util-runtime": "9.5.1",
@@ -8194,7 +8190,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -8209,7 +8204,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -8222,7 +8216,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8235,7 +8228,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -9556,7 +9548,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -10898,7 +10889,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11015,7 +11005,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/leven": {
@@ -11383,7 +11372,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
@@ -11391,7 +11379,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -12584,7 +12571,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
@@ -14143,7 +14129,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -15020,7 +15005,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "test:dev": "vitest",
     "coverage": "vitest run --coverage",
     "web:dev": "vite --mode web",
-    "web:build": "vite build --mode web"
+    "web:build": "vue-tsc --noEmit && vite build --mode web"
   },
   "main": "dist-electron/main/index.js",
   "dependencies": {
+    "electron-updater": "^6.8.3",
     "i18next": "^26.0.8",
     "i18next-pseudo": "^2.2.1",
     "image-size": "^2.0.2",
@@ -57,7 +58,6 @@
     "ckeditor5": "^48.0.1",
     "electron": "^42.0.1",
     "electron-builder": "^26.8.1",
-    "electron-updater": "^6.8.3",
     "eslint": "^10.3.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^13.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "src/**/*.vue"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts"
+    "node_modules"
   ]
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -12,13 +12,16 @@ import pkg from './package.json';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
-  rmSync('dist-electron', { recursive: true, force: true });
-
   const isServe = command === 'serve';
   const isBuild = command === 'build';
   const sourcemap = isServe || !!process.env.VSCODE_DEBUG;
 
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
+  const isElectron = process.env.VITE_IS_ELECTRON === 'true';
+
+  if (isElectron) {
+    rmSync('dist-electron', { recursive: true, force: true });
+  }
 
   return {
     resolve: {
@@ -27,10 +30,10 @@ export default defineConfig(({ command, mode }) => {
       },
     },
     define: {
-      APP_VERSION: JSON.stringify(process.env.npm_package_version),
+      APP_VERSION: JSON.stringify(pkg.version),
     },
     plugins: [
-      mode === 'web'
+      !isElectron
         ? VitePWA({
             registerType: null, // We'll inject the service worker ourselves
             workbox: {
@@ -109,7 +112,7 @@ export default defineConfig(({ command, mode }) => {
           overrideConfigFile: 'eslint.config.mjs',
         },
       }),
-      !mode.includes('web')
+      isElectron
         ? electron([
             {
               // Main-Process entry file of the Electron App.


### PR DESCRIPTION
## package.json

- Moved `electron-updater` from `devDependencies` to `dependencies`. It is imported by `electron/main/index.ts` and the electron build externalizes `pkg.dependencies`, so it must be a runtime dependency for electron-builder to ship it in the packaged app.
- Added `vue-tsc --noEmit` to the `web:build` script so the web build is type-checked, matching the type-check coverage the electron `build`/`release` scripts already had.

## vite.config.mjs

- Introduced `isElectron = process.env.VITE_IS_ELECTRON === 'true'`, derived from the env var that's already loaded from `.env` (electron) and `.env.web` (web). This unifies build-time platform detection with the runtime detection already in `src/utils/isElectron.ts`, so build and runtime share a single source of truth.
- Gated the `rmSync('dist-electron', ...)` cleanup on `isElectron`. Web builds no longer wipe an unrelated output directory.
- Replaced `!mode.includes('web')` and `mode === 'web'` with `isElectron` / `!isElectron` for the electron and PWA plugins respectively, so both plugin checks use the same flag.
- Changed `APP_VERSION` from `process.env.npm_package_version` to `pkg.version`. The `pkg` import was already available, and the new form works regardless of how Vite is invoked (npm script, direct binary, IDE, VS Code debug).