### PR TITLE
fix: Move electron-builder output out of the asar input directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn-error.log*
 #Electron-builder output
 /dist
 /dist-electron
+/release

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 .vscode
 dist
 dist-electron
+release
 docs/.vitepress/cache
 node_modules
 package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To create a release build, type:
 npm run build
 ```
 
-The build artifacts are found in `dist/`. For Windows, the installer will be called `Neanes Setup [version].exe`. The raw files can be found in `dist/win_unpacked`.
+The build artifacts are found in `release/`. For Windows, the installer will be called `Neanes Setup [version].exe`. The raw files can be found in `release/win-unpacked`.
 
 ### Development
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,6 +1,9 @@
 {
   "appId": "com.danielgarthur.neanes",
   "files": ["dist-electron", "dist"],
+  "directories": {
+    "output": "release"
+  },
   "productName": "Neanes",
   "copyright": "Copyright © 2021 danielgarthur",
   "publish": ["github"],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,12 @@ import pluginVue from 'eslint-plugin-vue';
 
 export default [
   {
-    ignores: ['dist/**/*', 'dist-electron/**/*', '**/.vitepress/cache/**/*'],
+    ignores: [
+      'dist/**/*',
+      'dist-electron/**/*',
+      'release/**/*',
+      '**/.vitepress/cache/**/*',
+    ],
   },
   ...pluginVue.configs['flat/recommended'],
   ...vueTsEslintConfig({


### PR DESCRIPTION
Fixes #2141