### PR TITLE
fix: Page break adds an extra page

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1196,6 +1196,10 @@ export class LayoutService {
           pages.push(page);
           currentPageHeightPx = lastLineHeightPx;
 
+          if (lastElementWasPageBreak) {
+            lastElementWasPageBreak = false;
+          }
+
           // Recalculate the height of the headers/footers of the new page
           ({ extraHeaderHeightPx, extraFooterHeightPx } =
             this.getExtraHeaderFooterHeight(score, pageSetup, pages.length));
@@ -3052,9 +3056,16 @@ export class LayoutService {
 
         let firstElementOnNextLine: ScoreElement | null = null;
 
-        if (lineIndex + 1 < page.lines.length) {
+        if (
+          lineIndex + 1 < page.lines.length &&
+          page.lines[lineIndex + 1].elements.length > 0
+        ) {
           firstElementOnNextLine = page.lines[lineIndex + 1].elements[0];
-        } else if (pageIndex + 1 < pages.length) {
+        } else if (
+          pageIndex + 1 < pages.length &&
+          pages[pageIndex + 1].lines.length > 0 &&
+          pages[pageIndex + 1].lines[0].elements.length > 0
+        ) {
           firstElementOnNextLine = pages[pageIndex + 1].lines[0].elements[0];
         }
 

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1196,9 +1196,7 @@ export class LayoutService {
           pages.push(page);
           currentPageHeightPx = lastLineHeightPx;
 
-          if (lastElementWasPageBreak) {
-            lastElementWasPageBreak = false;
-          }
+          lastElementWasPageBreak = false;
 
           // Recalculate the height of the headers/footers of the new page
           ({ extraHeaderHeightPx, extraFooterHeightPx } =

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1196,6 +1196,11 @@ export class LayoutService {
           pages.push(page);
           currentPageHeightPx = lastLineHeightPx;
 
+          // Consume the page-break trigger. Subsequent positioned items
+          // belonging to the same break (glues, penalties without an
+          // associated element) hit the `continue` below and skip the
+          // `lastElementWasPageBreak` update, so without this reset the
+          // flag re-fires this branch and leaves an empty page behind.
           lastElementWasPageBreak = false;
 
           // Recalculate the height of the headers/footers of the new page
@@ -1547,7 +1552,15 @@ export class LayoutService {
         previousLyricsEndPx -
         workspace.neumesEndPx +
         pageSetup.neumeDefaultSpacing;
-      this.addAnonymousBox(adjustment, workspace);
+
+      // A zero-width spacer would only add a box to pendingParagraph without
+      // advancing neumesEndPx. The immediately-following addBox call already
+      // supplies the box that anchors any later glue as a legal breakpoint,
+      // so the spacer is redundant when adjustment is 0. This mirrors the
+      // martyria bar-transfer call site, which is also guarded by > 0.
+      if (adjustment > 0) {
+        this.addAnonymousBox(adjustment, workspace);
+      }
     }
 
     workspace.lyricsEndPx =


### PR DESCRIPTION
## Problem and Reproduction Steps

- Create a new score. 
- Delete the text box and mode key for simplicity. 
- Add a single oligon. 
- Put a page break on the oligon. 
- No page is added.

There is an error in the console related to out of bounds access to an array. If this is fixed, then instead of two pages, three pages are shown. The first page contains the oligon. The second nothing. The third page contains the empty element.