### PR TITLE
feat: Add language switcher to Preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Neanes (pronounced neh-ah-ness) is a free and open source scorewriter for notati
 - Rapid entry of neumes and lyrics
 - Automatic alignment of supporting neumes (i.e. fthoras, accidentals, klasmas, gorgons, et al)
 - Automatic calculation of martyria
+- Multilingual lyric entry and user interface
 - [Optimal line breaking](notes/knuth_plass.md) for beautifully even spacing across every line, just like TeX and Adobe InDesign
 - Print or export to PDF
 - Export to HTML using [ByzHtml](https://danielgarthur.github.io/byzhtml) web components

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ features:
     details: Point and click to add neumes and see how they will appear on the page.
   - title: Rapid Entry of Neumes and Lyrics
     details: Neumes and lyrics are automatically aligned and martyria are automatically calculated.
+  - title: Multilingual Support
+    details: Write lyrics in any language, and switch the user interface language at any time from Preferences.
   - title: Advanced Typography
     details: Optimal line breaking produces beautifully even spacing across every line, just like TeX and Adobe InDesign.
   - title: Print or Export to PDF

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -23,7 +23,12 @@ import { debounce } from 'throttle-debounce';
 
 import { PageSize } from '@/models/PageSetup';
 
-import { defaultNS, resources } from '../../src/i18n';
+import {
+  defaultNS,
+  resolveLanguagePreference,
+  resources,
+  supportedLngs,
+} from '../../src/i18n';
 import {
   CloseWorkspacesArgs,
   CloseWorkspacesDisposition,
@@ -119,6 +124,7 @@ interface Store {
   recentFiles: string[];
   windowState: WindowState;
   lastDirectory?: string;
+  language?: string;
 }
 
 const defaultWindowState: WindowState = {
@@ -1780,6 +1786,15 @@ app.setAboutPanelOptions({
   applicationVersion: app.getVersion(),
 });
 
+ipcMain.on(IpcRendererChannels.SetLanguage, async (event, language: string) => {
+  store.language = language || undefined;
+  await saveStore();
+  await i18next.changeLanguage(
+    resolveLanguagePreference(store.language, app.getLocale()),
+  );
+  createMenu();
+});
+
 ipcMain.on(IpcRendererChannels.SetCanUndo, async (event, data) => {
   Menu.getApplicationMenu()!.getMenuItemById('undo')!.enabled = data;
 });
@@ -2083,6 +2098,10 @@ app.on('activate', () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', async () => {
+  // Load the persisted store first so the user's chosen language (if any)
+  // is honored when we initialize i18next and build the native menu.
+  await loadStore();
+
   i18next
     .use(
       new Pseudo({
@@ -2096,8 +2115,10 @@ app.on('ready', async () => {
       debug:
         'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
         import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true',
-      lng: app.getLocale(),
+      lng: resolveLanguagePreference(store.language, app.getLocale()),
       fallbackLng: 'en',
+      supportedLngs,
+      nonExplicitSupportedLngs: true,
       ns: Object.keys(resources['en']),
       postProcess: ['pseudo'],
       defaultNS,

--- a/src/components/EditorPreferencesDialog.vue
+++ b/src/components/EditorPreferencesDialog.vue
@@ -4,6 +4,23 @@
       <div class="header">{{ $t('dialog:preferences.root') }}</div>
       <div class="pane-container">
         <div class="subheader">
+          {{ $t('dialog:preferences.language') }}
+        </div>
+        <div class="form-group">
+          <select v-model="form.language">
+            <option value="">
+              {{ $t('dialog:preferences.languageSystemDefault') }}
+            </option>
+            <option
+              v-for="locale in supportedLocales"
+              :key="locale.code"
+              :value="locale.code"
+            >
+              {{ locale.name }}
+            </option>
+          </select>
+        </div>
+        <div class="subheader">
           {{ $t('dialog:preferences.menuInteraction') }}
         </div>
         <div class="form-group">
@@ -69,6 +86,15 @@ const tempoSigns = [
   TempoSign.VeryQuick,
 ];
 
+// Language names are shown in their native script so users can find their
+// language even when the surrounding UI is in a language they don't read.
+const supportedLocales = [
+  { code: 'el', name: 'Ελληνικά' },
+  { code: 'en', name: 'English' },
+  { code: 'id', name: 'Bahasa Indonesia' },
+  { code: 'ro', name: 'Română' },
+];
+
 export default defineComponent({
   components: { ModalDialog, Neume, InputBpm },
   props: {
@@ -87,6 +113,7 @@ export default defineComponent({
     return {
       form: new EditorPreferences(),
       tempoSigns,
+      supportedLocales,
       ButtonMenuMode,
     };
   },

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -2,6 +2,7 @@
 import 'vue3-tabs-chrome/dist/vue3-tabs-chrome.css';
 
 import { getFontEmbedCSS, toPng } from 'html-to-image';
+import i18next from 'i18next';
 import { debounce, throttle } from 'throttle-debounce';
 import {
   computed,
@@ -52,6 +53,7 @@ import ToolbarTempo from '@/components/ToolbarTempo.vue';
 import ToolbarTextBox from '@/components/ToolbarTextBox.vue';
 import ToolbarTextBoxRich from '@/components/ToolbarTextBoxRich.vue';
 import { EventBus } from '@/eventBus';
+import { resolveLanguagePreference } from '@/i18n';
 import {
   audioServiceKey,
   ipcServiceKey,
@@ -1694,9 +1696,19 @@ export default defineComponent({
     },
 
     updateEditorPreferences(form: EditorPreferences) {
+      const languageChanged = this.editorPreferences.language !== form.language;
+
       Object.assign(this.editorPreferences, form);
 
       this.saveEditorPreferences();
+
+      if (languageChanged) {
+        // An empty string means "fall back to the auto-detected locale".
+        i18next.changeLanguage(
+          resolveLanguagePreference(form.language, navigator.language),
+        );
+        EventBus.$emit(IpcRendererChannels.SetLanguage, form.language);
+      }
 
       this.editorPreferencesDialogIsOpen = false;
     },

--- a/src/i18n/el/dialog.json
+++ b/src/i18n/el/dialog.json
@@ -1,1 +1,6 @@
-{}
+{
+  "preferences": {
+    "language": "Γλώσσα",
+    "languageSystemDefault": "Προεπιλογή συστήματος"
+  }
+}

--- a/src/i18n/en/dialog.json
+++ b/src/i18n/en/dialog.json
@@ -201,6 +201,8 @@
   },
   "preferences": {
     "root": "Preferences",
+    "language": "Language",
+    "languageSystemDefault": "System default",
     "menuInteraction": "Menu Interaction",
     "menuInteractionHold": "Press and hold to select",
     "menuInteractionClick": "Click to open menu",

--- a/src/i18n/id/dialog.json
+++ b/src/i18n/id/dialog.json
@@ -201,6 +201,8 @@
   },
   "preferences": {
     "root": "Preferensi",
+    "language": "Bahasa",
+    "languageSystemDefault": "Bawaan sistem",
     "menuInteraction": "Interaksi Menu",
     "menuInteractionHold": "Tekan dan tahan untuk memilih",
     "menuInteractionClick": "Klik untuk membuka menu",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,6 +3,11 @@ import en from './en';
 import id from './id';
 import ro from './ro';
 
+export const supportedLngs = ['el', 'en', 'id', 'ro'] as const;
+export type SupportedLanguage = (typeof supportedLngs)[number];
+
+const supportedLanguageSet = new Set<string>(supportedLngs);
+
 export const defaultNS = 'model';
 export const resources = {
   el,
@@ -10,3 +15,33 @@ export const resources = {
   id,
   ro,
 } as const;
+
+function resolveSupportedLanguage(language: string | null | undefined) {
+  const normalized = language?.trim().toLowerCase();
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (supportedLanguageSet.has(normalized)) {
+    return normalized as SupportedLanguage;
+  }
+
+  const baseLanguage = normalized.replace('_', '-').split('-')[0];
+
+  if (supportedLanguageSet.has(baseLanguage)) {
+    return baseLanguage as SupportedLanguage;
+  }
+
+  return undefined;
+}
+
+export function resolveLanguagePreference(
+  languagePreference: string | null | undefined,
+  systemLanguage?: string | null,
+) {
+  return (
+    resolveSupportedLanguage(languagePreference) ??
+    resolveSupportedLanguage(systemLanguage)
+  );
+}

--- a/src/i18n/ro/dialog.json
+++ b/src/i18n/ro/dialog.json
@@ -199,6 +199,8 @@
   },
   "preferences": {
     "root": "Preferințe",
+    "language": "Limbă",
+    "languageSystemDefault": "Implicit (sistem)",
     "menuInteraction": "Interacțiune meniu",
     "menuInteractionHold": "Apasă și menține pentru a selecta",
     "menuInteractionClick": "Click pentru a deschide meniul",

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -81,6 +81,8 @@ export enum IpcRendererChannels {
   OpenContextMenuForTab = 'OpenContextMenuForTab',
 
   Paste = 'Paste',
+
+  SetLanguage = 'SetLanguage',
 }
 
 export interface FileMenuOpenScoreArgs {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,12 @@ import { createApp } from 'vue';
 import VueObserveVisibility from 'vue3-observe-visibility';
 
 import App from './App.vue';
-import { defaultNS, resources } from './i18n';
+import {
+  defaultNS,
+  resolveLanguagePreference,
+  resources,
+  supportedLngs,
+} from './i18n';
 import {
   audioServiceKey,
   ipcServiceKey,
@@ -45,6 +50,23 @@ if (isElectron()) {
   initalizeBrowserIpcListeners();
 }
 
+// Read the user's saved language override before i18next initializes so we
+// don't render a flash of auto-detected UI before swapping to the chosen one.
+function readSavedLanguage(): string | undefined {
+  try {
+    const raw = localStorage.getItem('editorPreferences');
+    if (raw == null) {
+      return undefined;
+    }
+    const parsed = JSON.parse(raw);
+    return resolveLanguagePreference(parsed?.language);
+  } catch {
+    return undefined;
+  }
+}
+
+const savedLanguage = readSavedLanguage();
+
 i18next
   .use(LanguageDetector)
   .use(
@@ -59,10 +81,13 @@ i18next
     debug:
       'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
       import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true',
+    lng: savedLanguage,
     detection: {
       order: ['querystring', 'navigator'],
     },
     fallbackLng: 'en',
+    supportedLngs,
+    nonExplicitSupportedLngs: true,
     interpolation: {
       escapeValue: false,
     },

--- a/src/models/EditorPreferences.ts
+++ b/src/models/EditorPreferences.ts
@@ -9,11 +9,14 @@ export enum ButtonMenuMode {
 export interface IEditorPreferences {
   tempoDefaults: { [key in TempoSign]?: number };
   buttonMenuMode: ButtonMenuMode;
+  // Empty string means "follow the system / browser locale".
+  language: string;
 }
 
 export class EditorPreferences implements IEditorPreferences {
   tempoDefaults: { [key in TempoSign]?: number };
   buttonMenuMode = ButtonMenuMode.Hold;
+  language = '';
 
   constructor() {
     this.tempoDefaults = {


### PR DESCRIPTION
Users can now override the auto-detected UI language from Preferences. The choice persists across restarts and applies live to both the renderer UI and the native Electron menu: no restart required. Tested in both the web app and Electron.