### PR TITLE
refactor: Consolidate i18next initialization

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -14,7 +14,6 @@ import {
 import { autoUpdater } from 'electron-updater';
 import { promises as fs } from 'fs';
 import i18next from 'i18next';
-import Pseudo from 'i18next-pseudo';
 import { imageSizeFromFile } from 'image-size/fromFile';
 import JSZip from 'jszip';
 import mimetypes from 'mime-types';
@@ -23,12 +22,7 @@ import { debounce } from 'throttle-debounce';
 
 import { PageSize } from '@/models/PageSetup';
 
-import {
-  defaultNS,
-  resolveLanguagePreference,
-  resources,
-  supportedLngs,
-} from '../../src/i18n';
+import { initializeI18n, resolveLanguagePreference } from '../../src/i18n';
 import {
   CloseWorkspacesArgs,
   CloseWorkspacesDisposition,
@@ -2104,28 +2098,9 @@ app.on('ready', async () => {
   // is honored when we initialize i18next and build the native menu.
   await loadStore();
 
-  i18next
-    .use(
-      new Pseudo({
-        enabled:
-          'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
-          import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true',
-        languageToPseudo: 'en-US',
-      }),
-    )
-    .init({
-      debug:
-        'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
-        import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true',
-      lng: resolveLanguagePreference(store.language, app.getLocale()),
-      fallbackLng: 'en',
-      supportedLngs,
-      nonExplicitSupportedLngs: true,
-      ns: Object.keys(resources['en']),
-      postProcess: ['pseudo'],
-      defaultNS,
-      resources,
-    });
+  await initializeI18n({
+    lng: resolveLanguagePreference(store.language, app.getLocale()),
+  });
 
   if (!win) {
     createWindow();

--- a/src/components/EditorPreferencesDialog.vue
+++ b/src/components/EditorPreferencesDialog.vue
@@ -69,6 +69,7 @@ import { defineComponent, PropType } from 'vue';
 
 import ModalDialog from '@/components/ModalDialog.vue';
 import Neume from '@/components/NeumeGlyph.vue';
+import { supportedLocales } from '@/i18n';
 import { ButtonMenuMode, EditorPreferences } from '@/models/EditorPreferences';
 import { TempoSign } from '@/models/Neumes';
 import { PageSetup } from '@/models/PageSetup';
@@ -84,15 +85,6 @@ const tempoSigns = [
   TempoSign.Quick,
   TempoSign.Quicker,
   TempoSign.VeryQuick,
-];
-
-// Language names are shown in their native script so users can find their
-// language even when the surrounding UI is in a language they don't read.
-const supportedLocales = [
-  { code: 'el', name: 'Ελληνικά' },
-  { code: 'en', name: 'English' },
-  { code: 'id', name: 'Bahasa Indonesia' },
-  { code: 'ro', name: 'Română' },
 ];
 
 export default defineComponent({

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,3 +1,11 @@
+import i18next, {
+  type InitOptions,
+  type Module,
+  type Newable,
+  type NewableModule,
+} from 'i18next';
+import Pseudo from 'i18next-pseudo';
+
 import el from './el';
 import en from './en';
 import id from './id';
@@ -5,6 +13,20 @@ import ro from './ro';
 
 export const supportedLngs = ['el', 'en', 'id', 'ro'] as const;
 export type SupportedLanguage = (typeof supportedLngs)[number];
+
+const supportedLanguageNames: Record<SupportedLanguage, string> = {
+  el: 'Ελληνικά',
+  en: 'English',
+  id: 'Bahasa Indonesia',
+  ro: 'Română',
+};
+
+// Language names are shown in their native script so users can find their
+// language even when the surrounding UI is in a language they don't read.
+export const supportedLocales = supportedLngs.map((code) => ({
+  code,
+  name: supportedLanguageNames[code],
+}));
 
 const supportedLanguageSet = new Set<string>(supportedLngs);
 
@@ -44,4 +66,54 @@ export function resolveLanguagePreference(
     resolveSupportedLanguage(languagePreference) ??
     resolveSupportedLanguage(systemLanguage)
   );
+}
+
+type I18nPlugin = Module | NewableModule<Module> | Newable<Module>;
+
+type InitializeI18nOptions = {
+  lng?: string;
+  plugins?: I18nPlugin[];
+  detection?: InitOptions['detection'];
+};
+
+function isPseudoLocalizationEnabled() {
+  return (
+    'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
+    import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true'
+  );
+}
+
+export function initializeI18n({
+  lng,
+  plugins = [],
+  detection,
+}: InitializeI18nOptions = {}) {
+  const pseudoLocalizationEnabled = isPseudoLocalizationEnabled();
+
+  for (const plugin of plugins) {
+    i18next.use(plugin);
+  }
+
+  return i18next
+    .use(
+      new Pseudo({
+        enabled: pseudoLocalizationEnabled,
+        languageToPseudo: 'en-US',
+      }),
+    )
+    .init({
+      debug: pseudoLocalizationEnabled,
+      lng,
+      detection,
+      fallbackLng: 'en',
+      supportedLngs,
+      nonExplicitSupportedLngs: true,
+      interpolation: {
+        escapeValue: false,
+      },
+      ns: Object.keys(resources['en']),
+      postProcess: ['pseudo'],
+      defaultNS,
+      resources,
+    });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,18 +3,12 @@ import './registerServiceWorker';
 import { CkeditorPlugin } from '@ckeditor/ckeditor5-vue';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import Pseudo from 'i18next-pseudo';
 import I18NextVue from 'i18next-vue';
 import { createApp } from 'vue';
 import VueObserveVisibility from 'vue3-observe-visibility';
 
 import App from './App.vue';
-import {
-  defaultNS,
-  resolveLanguagePreference,
-  resources,
-  supportedLngs,
-} from './i18n';
+import { initializeI18n, resolveLanguagePreference } from './i18n';
 import {
   audioServiceKey,
   ipcServiceKey,
@@ -67,35 +61,13 @@ function readSavedLanguage(): string | undefined {
 
 const savedLanguage = readSavedLanguage();
 
-i18next
-  .use(LanguageDetector)
-  .use(
-    new Pseudo({
-      enabled:
-        'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
-        import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true',
-      languageToPseudo: 'en-US',
-    }),
-  )
-  .init({
-    debug:
-      'VITE_PSEUDOLOCALIZATION' in import.meta.env &&
-      import.meta.env['VITE_PSEUDOLOCALIZATION'] === 'true',
-    lng: savedLanguage,
-    detection: {
-      order: ['querystring', 'navigator'],
-    },
-    fallbackLng: 'en',
-    supportedLngs,
-    nonExplicitSupportedLngs: true,
-    interpolation: {
-      escapeValue: false,
-    },
-    ns: Object.keys(resources['en']),
-    postProcess: ['pseudo'],
-    defaultNS,
-    resources,
-  });
+initializeI18n({
+  lng: savedLanguage,
+  plugins: [LanguageDetector],
+  detection: {
+    order: ['querystring', 'navigator'],
+  },
+});
 
 const app = createApp(App);
 app.use(VueObserveVisibility);


### PR DESCRIPTION
Extract the duplicated i18next setup in the Electron main process and the renderer entry point into a shared `initializeI18n` function in `src/i18n`. Also move the `supportedLocales` list into `src/i18n` so it derives from `supportedLngs`.

The Electron main process now passes `interpolation.escapeValue: false`, which it did not before. This has no observable effect today since no native menu strings use interpolation.