### PR TITLE
Localize CKEditor UI language

### DIFF
--- a/src/components/TextAnnotation.vue
+++ b/src/components/TextAnnotation.vue
@@ -8,6 +8,7 @@
     @dblclick="handleDoubleClick"
   >
     <ckeditor
+      :key="editorLanguage"
       ref="editor"
       class="rich-text-editor"
       :editor="editor"
@@ -47,6 +48,10 @@ export default defineComponent({
     fonts: {
       type: Array as PropType<string[]>,
       required: true,
+    },
+    editorLanguage: {
+      type: String,
+      default: 'en',
     },
     selected: Boolean,
   },
@@ -117,6 +122,9 @@ export default defineComponent({
         // language: {
         //   content: this.element.rtl ? 'ar' : 'en',
         // },
+        language: {
+          ui: this.editorLanguage,
+        },
         licenseKey: 'GPL',
         insertNeume: {
           neumeDefaultFontFamily: this.pageSetup.neumeDefaultFontFamily,
@@ -146,6 +154,15 @@ export default defineComponent({
           shouldNotGroupWhenFull: true,
         },
       };
+    },
+  },
+
+  watch: {
+    editorLanguage: {
+      handler() {
+        this.persistEditorData();
+      },
+      flush: 'pre',
     },
   },
 
@@ -182,20 +199,27 @@ export default defineComponent({
       editor.ui.focusTracker.on('change:isFocused', (evt, name, isFocused) => {
         if (!isFocused) {
           editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
-
-          const text = editor.getData();
-
-          if (text.trim() === '') {
-            this.$emit('delete');
-          } else if (this.element.text !== text) {
-            this.$emit('update', { text });
-          }
+          this.persistEditorData(editor);
         }
       });
 
       const toolbarEl = editor.ui.view.toolbar.element;
       if (toolbarEl) {
         toolbarEl.style.maxWidth = '400px';
+      }
+    },
+
+    persistEditorData(editor?: InlineEditor) {
+      const text = (editor ?? this.getEditorInstance())?.getData();
+
+      if (text == null) {
+        return;
+      }
+
+      if (text.trim() === '') {
+        this.$emit('delete');
+      } else if (this.element.text !== text) {
+        this.$emit('update', { text });
       }
     },
 

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -13,6 +13,7 @@
       :style="multipanelContainerStyle"
     >
       <ckeditor
+        :key="`left-${editorLanguage}`"
         ref="editorLeft"
         class="rich-text-editor multipanel left"
         :editor="editor"
@@ -22,6 +23,7 @@
         @blur="onBlur"
       />
       <ckeditor
+        :key="`center-${editorLanguage}`"
         ref="editorCenter"
         class="rich-text-editor multipanel center"
         :editor="editor"
@@ -32,6 +34,7 @@
         @ready="onEditorReady"
       />
       <ckeditor
+        :key="`right-${editorLanguage}`"
         ref="editorRight"
         class="rich-text-editor multipanel right"
         :editor="editor"
@@ -48,6 +51,7 @@
           :style="textBoxTopInnerContainerStyle"
         >
           <ckeditor
+            :key="`inline-top-${editorLanguage}`"
             ref="editor"
             class="rich-text-editor inline-top"
             :style="textBoxStyleTop"
@@ -62,6 +66,7 @@
       </div>
       <div class="inline-bottom-container" :style="textBoxBottomContainerStyle">
         <ckeditor
+          :key="`inline-bottom-${editorLanguage}`"
           ref="editorBottom"
           class="rich-text-editor inline-bottom"
           :style="textBoxStyleBottom"
@@ -76,6 +81,7 @@
     </div>
     <ckeditor
       v-else-if="element.scrollable"
+      :key="`scrollable-${editorLanguage}`"
       ref="editor"
       class="rich-text-editor single scrollable"
       :editor="editor"
@@ -88,6 +94,7 @@
     />
     <ckeditor
       v-else
+      :key="`single-${editorLanguage}`"
       ref="editor"
       class="rich-text-editor single"
       :editor="editor"
@@ -147,6 +154,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    editorLanguage: {
+      type: String,
+      default: 'en',
+    },
   },
   emits: ['update', 'update:height', 'select-single'],
 
@@ -201,6 +212,7 @@ export default defineComponent({
           options: ['default', ...fontSizeOptions],
         },
         language: {
+          ui: this.editorLanguage,
           content: this.element.rtl ? 'ar' : 'en',
         },
         licenseKey: 'GPL',
@@ -364,6 +376,12 @@ export default defineComponent({
     'element.centerOnPage'() {
       this.setPadding(this.getEditorInstance());
       this.setPadding(this.getEditorInstanceBottom());
+    },
+    editorLanguage: {
+      handler() {
+        this.update();
+      },
+      flush: 'pre',
     },
   },
 

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -489,6 +489,15 @@ export default defineComponent({
       return this.score.pageSetup.melkiteRtl;
     },
 
+    ckeditorLanguage() {
+      return (
+        resolveLanguagePreference(
+          this.editorPreferences.language,
+          navigator.language,
+        ) ?? 'en'
+      );
+    },
+
     selectedWorkspace: {
       get() {
         return this.selectedWorkspaceValue as Workspace;
@@ -6377,6 +6386,7 @@ export default defineComponent({
                     :metadata="getTokenMetadata(pageIndex)"
                     :page-setup="score.pageSetup"
                     :fonts="fonts"
+                    :editor-language="ckeditorLanguage"
                     :selected="
                       getHeaderForPageIndex(pageIndex) ==
                       selectedHeaderFooterElement
@@ -6517,6 +6527,7 @@ export default defineComponent({
                         :element="annotation"
                         :page-setup="score.pageSetup"
                         :fonts="fonts"
+                        :editor-language="ckeditorLanguage"
                         :selected="
                           selectedWorkspace.selectedAnnotationElement ===
                           annotation
@@ -6794,6 +6805,7 @@ export default defineComponent({
                       :element="element as RichTextBoxElement"
                       :page-setup="score.pageSetup"
                       :fonts="fonts"
+                      :editor-language="ckeditorLanguage"
                       :selected="isSelected(element)"
                       @select-single="selectedElement = element"
                       @update="
@@ -6928,6 +6940,7 @@ export default defineComponent({
                     :metadata="getTokenMetadata(pageIndex)"
                     :page-setup="score.pageSetup"
                     :fonts="fonts"
+                    :editor-language="ckeditorLanguage"
                     :selected="
                       getFooterForPageIndex(pageIndex) ==
                       selectedHeaderFooterElement
@@ -7296,6 +7309,7 @@ export default defineComponent({
         :element="element as RichTextBoxElement"
         :page-setup="score.pageSetup"
         :fonts="fonts"
+        :editor-language="ckeditorLanguage"
         :recalc="true"
         @update:height="
           updateRichTextBoxHeight(element as RichTextBoxElement, $event)

--- a/src/customEditor.ts
+++ b/src/customEditor.ts
@@ -40,6 +40,9 @@ import {
   Underline,
   Undo,
 } from 'ckeditor5';
+import elTranslations from 'ckeditor5/translations/el.js';
+import idTranslations from 'ckeditor5/translations/id.js';
+import roTranslations from 'ckeditor5/translations/ro.js';
 
 import InsertNeume from './ckeditor-plugins/insertneume/insertneume';
 
@@ -129,7 +132,11 @@ InlineEditor.defaultConfig = {
     ],
     shouldNotGroupWhenFull: true,
   },
-  language: 'en',
+  language: {
+    ui: 'en',
+    content: 'en',
+  },
+  translations: [elTranslations, idTranslations, roTranslations],
   image: {
     toolbar: [
       'imageTextAlternative',


### PR DESCRIPTION
The CKEditor 5 rich-text editors used for text boxes and annotations always rendered their UI (toolbar tooltips, menus, dialogs) in English, regardless of the user's chosen application language. This change makes the editor UI follow the app's language preference.

- **Bundle CKEditor translation packs** (`src/customEditor.ts`): import and register the `el`, `id`, and `ro` translation packs via the `translations` config array. English is built in and needs no pack -- together these cover every language the app supports (`el`, `en`, `id`, `ro`). The `defaultConfig.language` is split into explicit `ui`/`content` keys.
- **Resolve the editor UI language** (`src/components/TheEditor.vue`): add a `ckeditorLanguage` computed property that derives the UI language from the user's preference (`resolveLanguagePreference(editorPreferences.language, navigator.language)`), falling back to `en`. It is threaded down to all `<TextBoxRich>` and `<Annotation>` instances via a new `editor-language` prop.
- **Apply the language per editor** (`src/components/TextBoxRich.vue`, `src/components/TextAnnotation.vue`): accept the `editorLanguage` prop and pass it as `language.ui` in the per-instance editor config. Because CKEditor fixes its UI language at construction time, each `<ckeditor>` element is given a `:key` derived from `editorLanguage` so it remounts when the preference changes.

## Testing

Switched the application language to Greek, Indonesian, and Romanian and confirmed the rich-text editor toolbar/tooltips appeared in that language.