### PR TITLE
Migrate Vue components from Options API to Composition API

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,58 +7,38 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 
-export default defineComponent({
-  components: {},
-  props: {},
-  emits: [],
+const registration = ref<ServiceWorkerRegistration | null>(null);
+const updateExists = ref(false);
 
-  data() {
-    return {
-      registration: null as ServiceWorkerRegistration | null,
-      updateExists: false,
-    };
-  },
+if (navigator.serviceWorker) {
+  document.addEventListener('swUpdated', onUpdateAvailable as EventListener, {
+    once: true,
+  });
 
-  computed: {},
+  let refreshing = false;
 
-  created() {
-    if (navigator.serviceWorker) {
-      document.addEventListener(
-        'swUpdated',
-        this.onUpdateAvailable as EventListener,
-        {
-          once: true,
-        },
-      );
-
-      let refreshing = false;
-
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        if (!refreshing) {
-          window.location.reload();
-          refreshing = true;
-        }
-      });
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!refreshing) {
+      window.location.reload();
+      refreshing = true;
     }
-  },
+  });
+}
 
-  methods: {
-    onUpdateAvailable(event: CustomEvent) {
-      this.registration = event.detail;
-      this.updateExists = true;
-    },
+function onUpdateAvailable(event: CustomEvent) {
+  registration.value = event.detail;
+  updateExists.value = true;
+}
 
-    refreshApp() {
-      this.updateExists = false;
-      if (this.registration && this.registration.waiting) {
-        this.registration.waiting.postMessage({ type: 'SKIP_WAITING' });
-      }
-    },
-  },
-});
+function refreshApp() {
+  updateExists.value = false;
+  if (registration.value?.waiting) {
+    registration.value.waiting.postMessage({ type: 'SKIP_WAITING' });
+  }
+}
 </script>
 
 <style>

--- a/src/components/AlternateLine.vue
+++ b/src/components/AlternateLine.vue
@@ -17,8 +17,15 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  PropType,
+  ref,
+  useTemplateRef,
+} from 'vue';
 
 import {
   AlternateLineElement,
@@ -30,173 +37,154 @@ import { withZoom } from '@/utils/withZoom';
 
 import NeumeBoxSyllable from './NeumeBoxSyllable.vue';
 
-export default defineComponent({
-  components: { NeumeBoxSyllable },
-  props: {
-    element: {
-      type: Object as PropType<AlternateLineElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const emit = defineEmits(['update']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<AlternateLineElement>,
+    required: true,
   },
-  emits: ['update'],
-
-  data() {
-    return {
-      offsetX: 0,
-      offsetY: 0,
-      elementX: 0,
-      elementY: 0,
-
-      zoom: 1,
-      ElementType,
-
-      NoteElement,
-
-      clampingInterval: null as ReturnType<typeof setTimeout> | null,
-    };
-  },
-
-  computed: {
-    style() {
-      return {
-        left: withZoom(this.elementX),
-        top: withZoom(this.elementY),
-        minHeight: withZoom(this.pageSetup.alternateLineDefaultFontSize),
-      };
-    },
-  },
-
-  mounted() {
-    this.elementX = this.element.x;
-    this.elementY = this.element.y;
-    this.clampingInterval = setInterval(this.clampToPageBounds, 250);
-  },
-
-  beforeUnmount() {
-    document.removeEventListener('mouseup', this.handleMouseUp);
-    document.removeEventListener('mousemove', this.handleMouseMove);
-
-    if (this.clampingInterval != null) {
-      clearInterval(this.clampingInterval);
-    }
-  },
-
-  methods: {
-    handleMouseDown(e: MouseEvent) {
-      // We only calculate zoom once when the mouse is pressed down
-      // to avoid recalculating it on every mouse move
-      this.zoom = Number(
-        getComputedStyle(this.$refs.container as HTMLElement).getPropertyValue(
-          '--zoom',
-        ),
-      );
-
-      const draggedEl = this.$refs.container as HTMLElement;
-      const rect = draggedEl.getBoundingClientRect();
-
-      // Calculate the offset of the mouse click relative to the element
-      this.offsetX = e.clientX - rect.left;
-      this.offsetY = e.clientY - rect.top;
-
-      document.addEventListener('mouseup', this.handleMouseUp);
-      document.addEventListener('mousemove', this.handleMouseMove);
-    },
-
-    handleMouseMove(e: MouseEvent) {
-      e.preventDefault();
-
-      const draggedEl = this.$refs.container as HTMLElement;
-      const pageEl = draggedEl.closest('.page') as HTMLElement;
-      if (!draggedEl || !pageEl) {
-        console.warn('Could not find dragged element or page element');
-        return;
-      }
-
-      const elRect = draggedEl.getBoundingClientRect();
-      const pageRect = pageEl.getBoundingClientRect();
-
-      const elWidth = elRect.width;
-      const elHeight = elRect.height;
-
-      // Compute desired top-left corner of element in viewport space
-      const desiredLeft = e.clientX - this.offsetX;
-      const desiredTop = e.clientY - this.offsetY;
-
-      // Clamp those values to page bounds
-      const clampedLeft = Math.max(
-        pageRect.left,
-        Math.min(desiredLeft, pageRect.right - elWidth),
-      );
-      const clampedTop = Math.max(
-        pageRect.top,
-        Math.min(desiredTop, pageRect.bottom - elHeight),
-      );
-
-      // Convert clamped screen coords into coordinates relative to the element's offsetParent
-      const offsetParent = draggedEl.offsetParent as HTMLElement;
-      const parentRect = offsetParent.getBoundingClientRect();
-
-      const newX = clampedLeft - parentRect.left;
-      const newY = clampedTop - parentRect.top;
-
-      this.elementX = newX / this.zoom;
-      this.elementY = newY / this.zoom;
-    },
-
-    handleMouseUp() {
-      this.$emit('update', { x: this.elementX, y: this.elementY });
-
-      document.removeEventListener('mouseup', this.handleMouseUp);
-      document.removeEventListener('mousemove', this.handleMouseMove);
-    },
-
-    clampToPageBounds() {
-      const el = this.$refs.container as HTMLElement;
-
-      if (!el) {
-        return;
-      }
-
-      const pageEl = el.closest('.page') as HTMLElement;
-      const offsetParent = el.offsetParent as HTMLElement;
-
-      if (!pageEl || !offsetParent) {
-        return;
-      }
-
-      const zoom = Number(
-        getComputedStyle(this.$refs.container as HTMLElement).getPropertyValue(
-          '--zoom',
-        ),
-      );
-
-      const elRect = el.getBoundingClientRect();
-      const pageRect = pageEl.getBoundingClientRect();
-      const parentRect = offsetParent.getBoundingClientRect();
-
-      const elWidth = elRect.width;
-      const elHeight = elRect.height;
-
-      // Current position relative to offset parent
-      const currentX = this.elementX * zoom;
-      const currentY = this.elementY * zoom;
-
-      // Convert .page bounds into offsetParent-relative coordinates
-      const minX = pageRect.left - parentRect.left;
-      const minY = pageRect.top - parentRect.top;
-      const maxX = pageRect.right - parentRect.left - elWidth;
-      const maxY = pageRect.bottom - parentRect.top - elHeight;
-
-      // Clamp
-      this.elementX = Math.max(minX, Math.min(currentX, maxX)) / zoom;
-      this.elementY = Math.max(minY, Math.min(currentY, maxY)) / zoom;
-    },
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
 });
+
+const container = useTemplateRef<HTMLElement>('container');
+const offsetX = ref(0);
+const offsetY = ref(0);
+const elementX = ref(0);
+const elementY = ref(0);
+const zoom = ref(1);
+const clampingInterval = ref<ReturnType<typeof setTimeout> | null>(null);
+
+const style = computed(() => {
+  return {
+    left: withZoom(elementX.value),
+    top: withZoom(elementY.value),
+    minHeight: withZoom(props.pageSetup.alternateLineDefaultFontSize),
+  };
+});
+
+onMounted(() => {
+  elementX.value = props.element.x;
+  elementY.value = props.element.y;
+  clampingInterval.value = setInterval(clampToPageBounds, 250);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mouseup', handleMouseUp);
+  document.removeEventListener('mousemove', handleMouseMove);
+
+  if (clampingInterval.value != null) {
+    clearInterval(clampingInterval.value);
+  }
+});
+
+function handleMouseDown(e: MouseEvent) {
+  // We only calculate zoom once when the mouse is pressed down
+  // to avoid recalculating it on every mouse move
+  zoom.value = Number(
+    getComputedStyle(container.value!).getPropertyValue('--zoom'),
+  );
+
+  const draggedEl = container.value!;
+  const rect = draggedEl.getBoundingClientRect();
+
+  // Calculate the offset of the mouse click relative to the element
+  offsetX.value = e.clientX - rect.left;
+  offsetY.value = e.clientY - rect.top;
+
+  document.addEventListener('mouseup', handleMouseUp);
+  document.addEventListener('mousemove', handleMouseMove);
+}
+
+function handleMouseMove(e: MouseEvent) {
+  e.preventDefault();
+
+  const draggedEl = container.value!;
+  const pageEl = draggedEl.closest('.page') as HTMLElement;
+  if (!draggedEl || !pageEl) {
+    console.warn('Could not find dragged element or page element');
+    return;
+  }
+
+  const elRect = draggedEl.getBoundingClientRect();
+  const pageRect = pageEl.getBoundingClientRect();
+
+  const elWidth = elRect.width;
+  const elHeight = elRect.height;
+
+  // Compute desired top-left corner of element in viewport space
+  const desiredLeft = e.clientX - offsetX.value;
+  const desiredTop = e.clientY - offsetY.value;
+
+  // Clamp those values to page bounds
+  const clampedLeft = Math.max(
+    pageRect.left,
+    Math.min(desiredLeft, pageRect.right - elWidth),
+  );
+  const clampedTop = Math.max(
+    pageRect.top,
+    Math.min(desiredTop, pageRect.bottom - elHeight),
+  );
+
+  // Convert clamped screen coords into coordinates relative to the element's offsetParent
+  const offsetParent = draggedEl.offsetParent as HTMLElement;
+  const parentRect = offsetParent.getBoundingClientRect();
+
+  const newX = clampedLeft - parentRect.left;
+  const newY = clampedTop - parentRect.top;
+
+  elementX.value = newX / zoom.value;
+  elementY.value = newY / zoom.value;
+}
+
+function handleMouseUp() {
+  emit('update', { x: elementX.value, y: elementY.value });
+
+  document.removeEventListener('mouseup', handleMouseUp);
+  document.removeEventListener('mousemove', handleMouseMove);
+}
+
+function clampToPageBounds() {
+  const el = container.value;
+
+  if (!el) {
+    return;
+  }
+
+  const pageEl = el.closest('.page') as HTMLElement;
+  const offsetParent = el.offsetParent as HTMLElement;
+
+  if (!pageEl || !offsetParent) {
+    return;
+  }
+
+  const zoom = Number(
+    getComputedStyle(container.value!).getPropertyValue('--zoom'),
+  );
+
+  const elRect = el.getBoundingClientRect();
+  const pageRect = pageEl.getBoundingClientRect();
+  const parentRect = offsetParent.getBoundingClientRect();
+
+  const elWidth = elRect.width;
+  const elHeight = elRect.height;
+
+  // Current position relative to offset parent
+  const currentX = elementX.value * zoom;
+  const currentY = elementY.value * zoom;
+
+  // Convert .page bounds into offsetParent-relative coordinates
+  const minX = pageRect.left - parentRect.left;
+  const minY = pageRect.top - parentRect.top;
+  const maxX = pageRect.right - parentRect.left - elWidth;
+  const maxY = pageRect.bottom - parentRect.top - elHeight;
+
+  // Clamp
+  elementX.value = Math.max(minX, Math.min(currentX, maxX)) / zoom;
+  elementY.value = Math.max(minY, Math.min(currentY, maxY)) / zoom;
+}
 </script>
 
 <style scoped>

--- a/src/components/ButtonWithMenu.types.ts
+++ b/src/components/ButtonWithMenu.types.ts
@@ -1,0 +1,7 @@
+import { Neume } from '@/models/Neumes';
+
+export interface ButtonWithMenuOption {
+  icon?: string;
+  text?: string;
+  neume: Neume | Neume[];
+}

--- a/src/components/ButtonWithMenu.vue
+++ b/src/components/ButtonWithMenu.vue
@@ -35,147 +35,149 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
-
-import { ButtonMenuMode, EditorPreferences } from '@/models/EditorPreferences';
-import { Neume } from '@/models/Neumes';
-
 export interface ButtonWithMenuOption {
   icon?: string;
   text?: string;
-  neume: Neume | Neume[];
+  neume: import('@/models/Neumes').Neume | import('@/models/Neumes').Neume[];
 }
+</script>
 
-export default defineComponent({
-  components: {},
-  inject: ['editorPreferences'],
-  props: {
-    direction: {
-      type: String as PropType<'up' | 'down'>,
-      default: 'up',
-    },
-    options: {
-      type: Array as PropType<ButtonWithMenuOption[]>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    fontFamily: {
-      type: String,
-      default: 'Neanes',
-    },
-    imgSize: {
-      type: String,
-      default: undefined,
-    },
+<script setup lang="ts">
+import {
+  computed,
+  inject,
+  onBeforeUnmount,
+  onMounted,
+  PropType,
+  ref,
+  StyleValue,
+  useTemplateRef,
+} from 'vue';
+
+import { editorPreferencesKey } from '@/injectionKeys';
+import { ButtonMenuMode } from '@/models/EditorPreferences';
+import { Neume } from '@/models/Neumes';
+
+const emit = defineEmits(['select']);
+const props = defineProps({
+  direction: {
+    type: String as PropType<'up' | 'down'>,
+    default: 'up',
   },
-  emits: ['select'],
-
-  data() {
-    return {
-      showMenu: false,
-      selectedOption: null as Neume | Neume[] | null,
-    };
+  options: {
+    type: Array as PropType<ButtonWithMenuOption[]>,
+    required: true,
   },
-
-  computed: {
-    menuMode() {
-      return (this.editorPreferences as EditorPreferences).buttonMenuMode;
-    },
-    mainIcon() {
-      return this.direction === 'up'
-        ? this.options.at(-1)!.icon
-        : this.options[0].icon;
-    },
-
-    mainText() {
-      return this.direction === 'up'
-        ? this.options.at(-1)!.text
-        : this.options[0].text;
-    },
-
-    textStyle() {
-      return {
-        fontFamily: this.fontFamily,
-      } as StyleValue;
-    },
-
-    imgStyle() {
-      return {
-        height: this.imgSize ?? undefined,
-        width: this.imgSize ?? undefined,
-      } as StyleValue;
-    },
+  disabled: {
+    type: Boolean,
+    default: false,
   },
-
-  mounted() {
-    window.addEventListener('pointerdown', this.handleGlobalPointerDown);
+  fontFamily: {
+    type: String,
+    default: 'Neanes',
   },
-
-  beforeUnmount() {
-    window.removeEventListener('mouseup', this.onMouseUp);
-    window.removeEventListener('pointerdown', this.handleGlobalPointerDown);
-  },
-
-  methods: {
-    getKey(option: ButtonWithMenuOption) {
-      return Array.isArray(option.neume) ? option.neume[0] : option.neume;
-    },
-
-    handleMouseDown() {
-      if (this.disabled) {
-        return;
-      }
-
-      this.showMenu = true;
-
-      if (this.menuMode === ButtonMenuMode.Hold) {
-        window.addEventListener('mouseup', this.onMouseUp);
-      }
-    },
-
-    handleMouseEnter(selectedOption: Neume | Neume[]) {
-      if (this.menuMode === ButtonMenuMode.Hold) {
-        this.selectedOption = selectedOption;
-      }
-    },
-
-    handleMouseLeave() {
-      if (this.menuMode === ButtonMenuMode.Hold) {
-        this.selectedOption = null;
-      }
-    },
-
-    handleGlobalPointerDown(e: MouseEvent) {
-      if (
-        this.menuMode === ButtonMenuMode.Click &&
-        !(this.$refs.menu as HTMLElement).contains(e.target as Node)
-      ) {
-        this.showMenu = false;
-      }
-    },
-
-    handleChoiceClick(selectedOption: Neume | Neume[]) {
-      if (this.menuMode === ButtonMenuMode.Click) {
-        this.$emit('select', selectedOption);
-
-        this.showMenu = false;
-      }
-    },
-
-    onMouseUp() {
-      if (this.selectedOption) {
-        this.$emit('select', this.selectedOption);
-      }
-
-      this.showMenu = false;
-
-      window.removeEventListener('mouseup', this.onMouseUp);
-    },
+  imgSize: {
+    type: String,
+    default: undefined,
   },
 });
+
+const editorPreferences = inject(editorPreferencesKey)!;
+
+const menu = useTemplateRef<HTMLElement>('menu');
+const showMenu = ref(false);
+const selectedOption = ref<Neume | Neume[] | null>(null);
+
+const menuMode = computed(() => editorPreferences.value.buttonMenuMode);
+
+const mainIcon = computed(() => {
+  return props.direction === 'up'
+    ? props.options.at(-1)!.icon
+    : props.options[0].icon;
+});
+
+const mainText = computed(() => {
+  return props.direction === 'up'
+    ? props.options.at(-1)!.text
+    : props.options[0].text;
+});
+
+const textStyle = computed(() => {
+  return {
+    fontFamily: props.fontFamily,
+  } as StyleValue;
+});
+
+const imgStyle = computed(() => {
+  return {
+    height: props.imgSize ?? undefined,
+    width: props.imgSize ?? undefined,
+  } as StyleValue;
+});
+
+onMounted(() => {
+  window.addEventListener('pointerdown', handleGlobalPointerDown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('mouseup', onMouseUp);
+  window.removeEventListener('pointerdown', handleGlobalPointerDown);
+});
+
+function getKey(option: ButtonWithMenuOption) {
+  return Array.isArray(option.neume) ? option.neume[0] : option.neume;
+}
+
+function handleMouseDown() {
+  if (props.disabled) {
+    return;
+  }
+
+  showMenu.value = true;
+
+  if (menuMode.value === ButtonMenuMode.Hold) {
+    window.addEventListener('mouseup', onMouseUp);
+  }
+}
+
+function handleMouseEnter(option: Neume | Neume[]) {
+  if (menuMode.value === ButtonMenuMode.Hold) {
+    selectedOption.value = option;
+  }
+}
+
+function handleMouseLeave() {
+  if (menuMode.value === ButtonMenuMode.Hold) {
+    selectedOption.value = null;
+  }
+}
+
+function handleGlobalPointerDown(e: MouseEvent) {
+  if (
+    menuMode.value === ButtonMenuMode.Click &&
+    !menu.value?.contains(e.target as Node)
+  ) {
+    showMenu.value = false;
+  }
+}
+
+function handleChoiceClick(option: Neume | Neume[]) {
+  if (menuMode.value === ButtonMenuMode.Click) {
+    emit('select', option);
+
+    showMenu.value = false;
+  }
+}
+
+function onMouseUp() {
+  if (selectedOption.value) {
+    emit('select', selectedOption.value);
+  }
+
+  showMenu.value = false;
+
+  window.removeEventListener('mouseup', onMouseUp);
+}
 </script>
 
 <style scoped>

--- a/src/components/ButtonWithMenu.vue
+++ b/src/components/ButtonWithMenu.vue
@@ -34,14 +34,6 @@
   </div>
 </template>
 
-<script lang="ts">
-export interface ButtonWithMenuOption {
-  icon?: string;
-  text?: string;
-  neume: import('@/models/Neumes').Neume | import('@/models/Neumes').Neume[];
-}
-</script>
-
 <script setup lang="ts">
 import {
   computed,
@@ -57,6 +49,8 @@ import {
 import { editorPreferencesKey } from '@/injectionKeys';
 import { ButtonMenuMode } from '@/models/EditorPreferences';
 import { Neume } from '@/models/Neumes';
+
+import type { ButtonWithMenuOption } from './ButtonWithMenu.types';
 
 const emit = defineEmits(['select']);
 const props = defineProps({

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -17,113 +17,94 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { Sketch } from '@ckpack/vue-color';
-import { defineComponent, StyleValue } from 'vue';
+import { computed, ref, StyleValue, useTemplateRef, watch } from 'vue';
 
 interface Color {
   hex: string;
 }
 
-export default defineComponent({
-  components: { Sketch },
-  props: {
-    modelValue: {
-      type: String,
-      required: true,
-    },
-    historyKey: {
-      type: String,
-      default: 'colorPicker_presetColors',
-    },
+const emit = defineEmits(['update:modelValue']);
+const props = defineProps({
+  modelValue: {
+    type: String,
+    required: true,
   },
-  emits: ['update:modelValue'],
-
-  data() {
-    return {
-      isOpen: false,
-
-      presetColors: [] as string[],
-
-      popupPositionTop: 0,
-
-      maxHistorySize: 8,
-
-      color: '#000000',
-    };
-  },
-
-  computed: {
-    swatch() {
-      return this.$refs.swatch as HTMLElement;
-    },
-
-    colorStyle() {
-      return {
-        backgroundColor: this.color,
-      } as StyleValue;
-    },
-
-    popupStyle() {
-      return {
-        top: `${this.popupPositionTop}px`,
-      } as StyleValue;
-    },
-  },
-
-  watch: {
-    modelValue(newValue: string) {
-      this.color = newValue;
-    },
-  },
-
-  created() {
-    this.color = this.modelValue;
-  },
-
-  methods: {
-    open() {
-      this.presetColors = JSON.parse(
-        localStorage.getItem(this.historyKey)!,
-      ) || ['#000000', '#800000', '#FF0000'];
-
-      // Fist, try to position the popup underneath the swatch
-      this.popupPositionTop =
-        this.swatch.getBoundingClientRect().top + this.swatch.offsetHeight;
-
-      // If the popover goes off the bottom of the screen, position above the swatch
-      const popoverHeightPx = 260;
-
-      if (this.popupPositionTop + popoverHeightPx > window.innerHeight) {
-        this.popupPositionTop -= popoverHeightPx + this.swatch.offsetHeight;
-      }
-
-      this.isOpen = true;
-    },
-
-    onColorChanged(color: Color) {
-      this.color = color.hex;
-    },
-
-    close() {
-      const index = this.presetColors.indexOf(this.color);
-
-      if (index >= 0) {
-        this.presetColors.splice(index, 1);
-      }
-
-      this.presetColors.unshift(this.color);
-      this.presetColors = this.presetColors.slice(0, this.maxHistorySize);
-      localStorage.setItem(this.historyKey, JSON.stringify(this.presetColors));
-
-      this.isOpen = false;
-
-      if (this.color !== this.modelValue) {
-        this.$emit('update:modelValue', this.color);
-      }
-    },
+  historyKey: {
+    type: String,
+    default: 'colorPicker_presetColors',
   },
 });
+
+const swatch = useTemplateRef<HTMLElement>('swatch');
+const isOpen = ref(false);
+const presetColors = ref<string[]>([]);
+const popupPositionTop = ref(0);
+const maxHistorySize = 8;
+const color = ref(props.modelValue);
+
+const colorStyle = computed(() => {
+  return {
+    backgroundColor: color.value,
+  } as StyleValue;
+});
+
+const popupStyle = computed(() => {
+  return {
+    top: `${popupPositionTop.value}px`,
+  } as StyleValue;
+});
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    color.value = newValue;
+  },
+);
+
+function open() {
+  presetColors.value = JSON.parse(localStorage.getItem(props.historyKey)!) || [
+    '#000000',
+    '#800000',
+    '#FF0000',
+  ];
+
+  // Fist, try to position the popup underneath the swatch
+  popupPositionTop.value =
+    swatch.value!.getBoundingClientRect().top + swatch.value!.offsetHeight;
+
+  // If the popover goes off the bottom of the screen, position above the swatch
+  const popoverHeightPx = 260;
+
+  if (popupPositionTop.value + popoverHeightPx > window.innerHeight) {
+    popupPositionTop.value -= popoverHeightPx + swatch.value!.offsetHeight;
+  }
+
+  isOpen.value = true;
+}
+
+function onColorChanged(colorValue: Color) {
+  color.value = colorValue.hex;
+}
+
+function close() {
+  const index = presetColors.value.indexOf(color.value);
+
+  if (index >= 0) {
+    presetColors.value.splice(index, 1);
+  }
+
+  presetColors.value.unshift(color.value);
+  presetColors.value = presetColors.value.slice(0, maxHistorySize);
+  localStorage.setItem(props.historyKey, JSON.stringify(presetColors.value));
+
+  isOpen.value = false;
+
+  if (color.value !== props.modelValue) {
+    emit('update:modelValue', color.value);
+  }
+}
 </script>
 
 <style scoped>

--- a/src/components/ContentEditable.vue
+++ b/src/components/ContentEditable.vue
@@ -13,98 +13,96 @@
   <!-- eslint-enable vue/no-v-html -->
 </template>
 
-<script lang="ts">
-import { defineComponent, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, onMounted, StyleValue, useTemplateRef } from 'vue';
 
-export default defineComponent({
-  components: {},
-  props: {
-    content: {
-      type: String,
-      required: true,
-    },
-    selectAllOnFocus: {
-      type: Boolean,
-      default: true,
-    },
-    editable: {
-      type: Boolean,
-      default: true,
-    },
-    plaintextOnly: {
-      type: Boolean,
-      default: true,
-    },
-    whiteSpace: {
-      type: String,
-      default: 'break-spaces',
-    },
+const emit = defineEmits(['click', 'focus', 'blur', 'onEditorReady']);
+const props = defineProps({
+  content: {
+    type: String,
+    required: true,
   },
-  emits: ['click', 'focus', 'blur', 'onEditorReady'],
-
-  data() {
-    return {};
+  selectAllOnFocus: {
+    type: Boolean,
+    default: true,
   },
-
-  computed: {
-    contentEditable() {
-      return this.editable
-        ? this.plaintextOnly
-          ? 'plaintext-only'
-          : 'true'
-        : 'false';
-    },
-
-    htmlElement() {
-      return this.$refs.span as HTMLElement;
-    },
-
-    style() {
-      return {
-        whiteSpace: this.whiteSpace,
-      } as StyleValue;
-    },
+  editable: {
+    type: Boolean,
+    default: true,
   },
-
-  mounted() {
-    this.$emit('onEditorReady');
+  plaintextOnly: {
+    type: Boolean,
+    default: true,
   },
-
-  methods: {
-    getInnerText() {
-      return this.htmlElement.innerText;
-    },
-
-    getContent() {
-      return this.escapeHtml(this.htmlElement.innerText);
-    },
-
-    onBlur() {
-      this.$emit('blur', this.getContent());
-    },
-
-    focus(selectAll: boolean) {
-      this.htmlElement.focus();
-
-      if (selectAll) {
-        document.execCommand('selectAll', false);
-      }
-    },
-
-    blur() {
-      this.htmlElement.blur();
-    },
-
-    setInnerText(text: string) {
-      this.htmlElement.innerText = text;
-    },
-
-    escapeHtml(text: string) {
-      const p = document.createElement('p');
-      p.appendChild(document.createTextNode(text));
-      return p.innerHTML;
-    },
+  whiteSpace: {
+    type: String,
+    default: 'break-spaces',
   },
+});
+
+const span = useTemplateRef<HTMLElement>('span');
+
+const contentEditable = computed(() => {
+  return props.editable
+    ? props.plaintextOnly
+      ? 'plaintext-only'
+      : 'true'
+    : 'false';
+});
+
+const htmlElement = computed(() => span.value!);
+
+const style = computed(() => {
+  return {
+    whiteSpace: props.whiteSpace,
+  } as StyleValue;
+});
+
+onMounted(() => {
+  emit('onEditorReady');
+});
+
+function getInnerText() {
+  return htmlElement.value.innerText;
+}
+
+function getContent() {
+  return escapeHtml(htmlElement.value.innerText);
+}
+
+function onBlur() {
+  emit('blur', getContent());
+}
+
+function focus(selectAll: boolean) {
+  htmlElement.value.focus();
+
+  if (selectAll) {
+    document.execCommand('selectAll', false);
+  }
+}
+
+function blur() {
+  htmlElement.value.blur();
+}
+
+function setInnerText(text: string) {
+  htmlElement.value.innerText = text;
+}
+
+function escapeHtml(text: string) {
+  const p = document.createElement('p');
+  p.appendChild(document.createTextNode(text));
+  return p.innerHTML;
+}
+
+defineExpose({
+  blur,
+  focus,
+  getContent,
+  getInnerText,
+  htmlElement,
+  setInnerText,
 });
 </script>
 

--- a/src/components/DragHandle.vue
+++ b/src/components/DragHandle.vue
@@ -2,8 +2,8 @@
   <span class="handle" :style="handleStyle" @mousedown="handleMouseDown" />
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, onBeforeUnmount, PropType, ref, StyleValue } from 'vue';
 
 import { NoteElement, ScoreElementOffset } from '@/models/Element';
 import { Neume, VocalExpressionNeume } from '@/models/Neumes';
@@ -11,145 +11,124 @@ import { fontService } from '@/services/FontService';
 import { NeumeMappingService } from '@/services/NeumeMappingService';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: {},
-  props: {
-    x: {
-      type: [Number, null],
-      required: true,
-    },
-    y: {
-      type: [Number, null],
-      required: true,
-    },
-    fontSize: {
-      type: Number,
-      required: true,
-    },
-    zoom: {
-      type: Number,
-      default: 1,
-    },
-    note: {
-      type: Object as PropType<NoteElement>,
-      required: true,
-    },
-    mark: {
-      type: String as PropType<Neume>,
-      required: true,
-    },
-    height: {
-      type: Number,
-      default: 8,
-    },
-    width: {
-      type: Number,
-      default: 8,
-    },
-    fontFamily: {
-      type: String,
-      required: true,
-    },
+const emit = defineEmits(['update']);
+const props = defineProps({
+  x: {
+    type: [Number, null],
+    required: true,
   },
-  emits: ['update'],
-
-  data() {
-    return {
-      startX: 0,
-      startY: 0,
-
-      offset: { x: 0, y: 0 } as ScoreElementOffset,
-    };
+  y: {
+    type: [Number, null],
+    required: true,
   },
-
-  computed: {
-    handleStyle() {
-      const left = this.offset.x + (this.x ?? 0);
-      const top = this.offset.y + (this.y ?? 0);
-
-      return {
-        position: 'absolute',
-        left: `calc(${left}em - ${(this.zoom * this.width) / 2}px)`,
-        top: `calc(${top}em - ${(this.zoom * this.height) / 2}px)`,
-        fontSize: withZoom(this.fontSize),
-        height: withZoom(this.height),
-        width: withZoom(this.width),
-      } as StyleValue;
-    },
+  fontSize: {
+    type: Number,
+    required: true,
   },
-
-  created() {
-    this.offset = this.getOffset(this.mark);
+  zoom: {
+    type: Number,
+    default: 1,
   },
-
-  beforeUnmount() {
-    document.removeEventListener('mouseup', this.handleMouseUp);
-    document.removeEventListener('mousemove', this.handleMouseMove);
+  note: {
+    type: Object as PropType<NoteElement>,
+    required: true,
   },
-
-  methods: {
-    handleMouseDown(e: MouseEvent) {
-      e.preventDefault();
-
-      this.startX = e.clientX - (this.x ?? 0) * this.fontSize * this.zoom;
-      this.startY = e.clientY - (this.y ?? 0) * this.fontSize * this.zoom;
-
-      document.addEventListener('mouseup', this.handleMouseUp);
-      document.addEventListener('mousemove', this.handleMouseMove);
-    },
-
-    handleMouseMove(e: MouseEvent) {
-      e.preventDefault();
-
-      const x = (e.clientX - this.startX) / this.fontSize / this.zoom;
-      const y = (e.clientY - this.startY) / this.fontSize / this.zoom;
-
-      this.$emit('update', { x, y });
-    },
-
-    handleMouseUp() {
-      document.removeEventListener('mouseup', this.handleMouseUp);
-      document.removeEventListener('mousemove', this.handleMouseMove);
-    },
-    getOffset(neume: Neume) {
-      const mark = this.getMapping(neume).glyphName;
-      const base = this.getMapping(this.note.quantitativeNeume).glyphName;
-
-      const offset = fontService.getMarkAnchorOffset(
-        this.fontFamily,
-        base,
-        mark,
-      );
-
-      // Shift offset for vareia
-      if (this.note.vareia) {
-        const vareiaGlyphName = this.getMapping(
-          VocalExpressionNeume.Vareia,
-        ).glyphName;
-
-        const vareiaWidth = fontService.getAdvanceWidth(
-          this.fontFamily,
-          vareiaGlyphName,
-        );
-        offset.x += vareiaWidth;
-      }
-
-      // Shift offset for measure bar
-      if (this.note.measureBarLeft) {
-        const glyphName = this.getMapping(this.note.measureBarLeft).glyphName;
-
-        const width = fontService.getAdvanceWidth(this.fontFamily, glyphName);
-        offset.x += width;
-      }
-
-      return offset;
-    },
-
-    getMapping(neume: Neume) {
-      return NeumeMappingService.getMapping(neume);
-    },
+  mark: {
+    type: String as PropType<Neume>,
+    required: true,
+  },
+  height: {
+    type: Number,
+    default: 8,
+  },
+  width: {
+    type: Number,
+    default: 8,
+  },
+  fontFamily: {
+    type: String,
+    required: true,
   },
 });
+
+const startX = ref(0);
+const startY = ref(0);
+const offset = ref<ScoreElementOffset>(getOffset(props.mark));
+
+const handleStyle = computed(() => {
+  const left = offset.value.x + (props.x ?? 0);
+  const top = offset.value.y + (props.y ?? 0);
+
+  return {
+    position: 'absolute',
+    left: `calc(${left}em - ${(props.zoom * props.width) / 2}px)`,
+    top: `calc(${top}em - ${(props.zoom * props.height) / 2}px)`,
+    fontSize: withZoom(props.fontSize),
+    height: withZoom(props.height),
+    width: withZoom(props.width),
+  } as StyleValue;
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mouseup', handleMouseUp);
+  document.removeEventListener('mousemove', handleMouseMove);
+});
+
+function handleMouseDown(e: MouseEvent) {
+  e.preventDefault();
+
+  startX.value = e.clientX - (props.x ?? 0) * props.fontSize * props.zoom;
+  startY.value = e.clientY - (props.y ?? 0) * props.fontSize * props.zoom;
+
+  document.addEventListener('mouseup', handleMouseUp);
+  document.addEventListener('mousemove', handleMouseMove);
+}
+
+function handleMouseMove(e: MouseEvent) {
+  e.preventDefault();
+
+  const x = (e.clientX - startX.value) / props.fontSize / props.zoom;
+  const y = (e.clientY - startY.value) / props.fontSize / props.zoom;
+
+  emit('update', { x, y });
+}
+
+function handleMouseUp() {
+  document.removeEventListener('mouseup', handleMouseUp);
+  document.removeEventListener('mousemove', handleMouseMove);
+}
+
+function getOffset(neume: Neume) {
+  const mark = getMapping(neume).glyphName;
+  const base = getMapping(props.note.quantitativeNeume).glyphName;
+
+  const offset = fontService.getMarkAnchorOffset(props.fontFamily, base, mark);
+
+  // Shift offset for vareia
+  if (props.note.vareia) {
+    const vareiaGlyphName = getMapping(VocalExpressionNeume.Vareia).glyphName;
+
+    const vareiaWidth = fontService.getAdvanceWidth(
+      props.fontFamily,
+      vareiaGlyphName,
+    );
+    offset.x += vareiaWidth;
+  }
+
+  // Shift offset for measure bar
+  if (props.note.measureBarLeft) {
+    const glyphName = getMapping(props.note.measureBarLeft).glyphName;
+
+    const width = fontService.getAdvanceWidth(props.fontFamily, glyphName);
+    offset.x += width;
+  }
+
+  return offset;
+}
+
+function getMapping(neume: Neume) {
+  return NeumeMappingService.getMapping(neume);
+}
 </script>
 
 <style scoped>

--- a/src/components/DropCap.vue
+++ b/src/components/DropCap.vue
@@ -18,8 +18,9 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, PropType, StyleValue, useTemplateRef } from 'vue';
+import { ComponentExposed } from 'vue-component-type-helpers';
 
 import ContentEditable from '@/components/ContentEditable.vue';
 import { DropCapElement } from '@/models/Element';
@@ -27,72 +28,66 @@ import { PageSetup } from '@/models/PageSetup';
 import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { ContentEditable },
-  props: {
-    element: {
-      type: Object as PropType<DropCapElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    editable: {
-      type: Boolean,
-      required: true,
-    },
+const emit = defineEmits(['update:content', 'select-single']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<DropCapElement>,
+    required: true,
   },
-  emits: ['update:content', 'select-single'],
-
-  data() {
-    return {};
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    htmlElement() {
-      return this.$refs.container as HTMLElement;
-    },
-
-    textElement() {
-      return this.$refs.text as InstanceType<typeof ContentEditable>;
-    },
-
-    style() {
-      const style = {
-        color: this.element.computedColor,
-        fontFamily: getFontFamilyWithFallback(this.element.computedFontFamily),
-        fontSize: withZoom(this.element.computedFontSize),
-        fontWeight: this.element.computedFontWeight,
-        fontStyle: this.element.computedFontStyle,
-        lineHeight: `${this.element.computedLineHeight ?? 'normal'}`,
-        webkitTextStrokeWidth: withZoom(this.element.computedStrokeWidth),
-      } as StyleValue;
-
-      return style;
-    },
+  editable: {
+    type: Boolean,
+    required: true,
   },
+});
 
-  methods: {
-    focus() {
-      if (this.editable) {
-        this.textElement.focus(true);
-      }
-    },
+const container = useTemplateRef<HTMLElement>('container');
+const text = useTemplateRef<ComponentExposed<typeof ContentEditable>>('text');
 
-    blur() {
-      this.textElement.blur();
-    },
+const htmlElement = computed(() => container.value!);
+const textElement = computed(() => text.value!);
 
-    updateContent(content: string) {
-      // Nothing actually changed, so do nothing
-      if (this.element.content === content) {
-        return;
-      }
+const style = computed(() => {
+  const style = {
+    color: props.element.computedColor,
+    fontFamily: getFontFamilyWithFallback(props.element.computedFontFamily),
+    fontSize: withZoom(props.element.computedFontSize),
+    fontWeight: props.element.computedFontWeight,
+    fontStyle: props.element.computedFontStyle,
+    lineHeight: `${props.element.computedLineHeight ?? 'normal'}`,
+    webkitTextStrokeWidth: withZoom(props.element.computedStrokeWidth),
+  } as StyleValue;
 
-      this.$emit('update:content', content);
-    },
-  },
+  return style;
+});
+
+function focus() {
+  if (props.editable) {
+    textElement.value.focus(true);
+  }
+}
+
+function blur() {
+  textElement.value.blur();
+}
+
+function updateContent(content: string) {
+  // Nothing actually changed, so do nothing
+  if (props.element.content === content) {
+    return;
+  }
+
+  emit('update:content', content);
+}
+
+defineExpose({
+  blur,
+  focus,
+  htmlElement,
+  textElement,
 });
 </script>
 

--- a/src/components/EditorPreferencesDialog.vue
+++ b/src/components/EditorPreferencesDialog.vue
@@ -99,8 +99,8 @@
   </ModalDialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, PropType, ref } from 'vue';
 
 import ModalDialog from '@/components/ModalDialog.vue';
 import Neume from '@/components/NeumeGlyph.vue';
@@ -111,6 +111,19 @@ import { PageSetup } from '@/models/PageSetup';
 
 import InputBpm from './InputBpm.vue';
 
+const emit = defineEmits(['close', 'update']);
+const props = defineProps({
+  options: {
+    type: Object as PropType<EditorPreferences>,
+    required: true,
+  },
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
+  },
+});
+
+const form = ref(new EditorPreferences());
 const tempoSigns = [
   TempoSign.VerySlow,
   TempoSign.Slower,
@@ -122,57 +135,29 @@ const tempoSigns = [
   TempoSign.VeryQuick,
 ];
 
-export default defineComponent({
-  components: { ModalDialog, Neume, InputBpm },
-  props: {
-    options: {
-      type: Object as PropType<EditorPreferences>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-  },
-  emits: ['close', 'update'],
+onMounted(() => {
+  form.value = JSON.parse(JSON.stringify(props.options));
 
-  data() {
-    return {
-      form: new EditorPreferences(),
-      tempoSigns,
-      supportedLocales,
-      ButtonMenuMode,
-    };
-  },
-
-  computed: {},
-
-  mounted() {
-    this.form = JSON.parse(JSON.stringify(this.options));
-
-    window.addEventListener('keydown', this.onKeyDown);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  methods: {
-    onKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        this.$emit('close');
-      }
-    },
-
-    onTempoChanged(neume: TempoSign, bpm: number) {
-      this.form.tempoDefaults[neume] = bpm;
-    },
-
-    resetToSystemDefaults() {
-      this.form = new EditorPreferences();
-    },
-  },
+  window.addEventListener('keydown', onKeyDown);
 });
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+});
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.code === 'Escape') {
+    emit('close');
+  }
+}
+
+function onTempoChanged(neume: TempoSign, bpm: number) {
+  form.value.tempoDefaults[neume] = bpm;
+}
+
+function resetToSystemDefaults() {
+  form.value = new EditorPreferences();
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ExportDialog.types.ts
+++ b/src/components/ExportDialog.types.ts
@@ -1,0 +1,27 @@
+import { LatexExporterOptions } from '@/services/integration/LatexExporter';
+import { MusicXmlExporterOptions } from '@/services/integration/MusicXmlExporter';
+
+export enum ExportFormat {
+  HTML = 'HTML',
+  PDF = 'PDF',
+  PNG = 'PNG',
+  SVG = 'SVG',
+  MusicXml = 'MusicXml',
+  Latex = 'Latex',
+}
+
+export interface ExportAsPngSettings {
+  dpi: number;
+  openFolder: boolean;
+  transparentBackground: boolean;
+}
+
+export interface ExportAsMusicXmlSettings {
+  options: MusicXmlExporterOptions;
+  openFolder: boolean;
+  compressed: boolean;
+}
+
+export interface ExportAsLatexSettings {
+  options: LatexExporterOptions;
+}

--- a/src/components/ExportDialog.vue
+++ b/src/components/ExportDialog.vue
@@ -164,10 +164,6 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
-
-import InputUnit from '@/components/InputUnit.vue';
-import ModalDialog from '@/components/ModalDialog.vue';
 import { LatexExporterOptions } from '@/services/integration/LatexExporter';
 import { MusicXmlExporterOptions } from '@/services/integration/MusicXmlExporter';
 
@@ -195,100 +191,91 @@ export interface ExportAsMusicXmlSettings {
 export interface ExportAsLatexSettings {
   options: LatexExporterOptions;
 }
+</script>
 
-export default defineComponent({
-  components: { ModalDialog, InputUnit },
-  props: {
-    defaultFormat: {
-      type: String as PropType<ExportFormat>,
-      required: true,
-    },
-    loading: {
-      type: Boolean,
-      required: true,
-    },
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, PropType, ref } from 'vue';
+
+import InputUnit from '@/components/InputUnit.vue';
+import ModalDialog from '@/components/ModalDialog.vue';
+
+const emit = defineEmits([
+  'close',
+  'exportAsLatex',
+  'exportAsMusicXml',
+  'exportAsPng',
+  'exportAsSvg',
+]);
+const props = defineProps({
+  defaultFormat: {
+    type: String as PropType<ExportFormat>,
+    required: true,
   },
-  emits: [
-    'close',
-    'exportAsLatex',
-    'exportAsMusicXml',
-    'exportAsPng',
-    'exportAsSvg',
-  ],
-
-  data() {
-    return {
-      format: ExportFormat.PNG,
-      dpi: 300,
-      transparentBackground: false,
-      openFolder: true,
-
-      musicXmlOptions: new MusicXmlExporterOptions(),
-      latexOptions: new LatexExporterOptions(),
-
-      ExportFormat,
-    };
-  },
-
-  computed: {
-    exportFormatIsImage() {
-      return (
-        this.format === ExportFormat.PNG || this.format === ExportFormat.SVG
-      );
-    },
-  },
-
-  mounted() {
-    if (this.defaultFormat != null) {
-      this.format = this.defaultFormat;
-    }
-
-    window.addEventListener('keydown', this.onKeyDown);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  methods: {
-    onKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        this.close();
-      }
-    },
-
-    round(value: number) {
-      return Math.round(value);
-    },
-
-    doExport() {
-      if (this.format === ExportFormat.PNG) {
-        const { dpi, openFolder, transparentBackground } = this;
-        this.$emit('exportAsPng', {
-          dpi,
-          openFolder,
-          transparentBackground,
-        } as ExportAsPngSettings);
-      } else if (this.format === ExportFormat.SVG) {
-        this.$emit('exportAsSvg', this.openFolder);
-      } else if (this.format === ExportFormat.MusicXml) {
-        this.$emit('exportAsMusicXml', {
-          options: this.musicXmlOptions,
-          compressed: false,
-          openFolder: this.openFolder,
-        } as ExportAsMusicXmlSettings);
-      } else if (this.format === ExportFormat.Latex) {
-        this.$emit('exportAsLatex', {
-          options: this.latexOptions,
-        } as ExportAsLatexSettings);
-      }
-    },
-
-    close() {
-      this.$emit('close');
-    },
+  loading: {
+    type: Boolean,
+    required: true,
   },
 });
+
+const format = ref(ExportFormat.PNG);
+const dpi = ref(300);
+const transparentBackground = ref(false);
+const openFolder = ref(true);
+
+const musicXmlOptions = ref(new MusicXmlExporterOptions());
+const latexOptions = ref(new LatexExporterOptions());
+
+const exportFormatIsImage = computed(() => {
+  return format.value === ExportFormat.PNG || format.value === ExportFormat.SVG;
+});
+
+onMounted(() => {
+  if (props.defaultFormat != null) {
+    format.value = props.defaultFormat;
+  }
+
+  window.addEventListener('keydown', onKeyDown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+});
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.code === 'Escape') {
+    close();
+  }
+}
+
+function round(value: number) {
+  return Math.round(value);
+}
+
+function doExport() {
+  if (format.value === ExportFormat.PNG) {
+    emit('exportAsPng', {
+      dpi: dpi.value,
+      openFolder: openFolder.value,
+      transparentBackground: transparentBackground.value,
+    } as ExportAsPngSettings);
+  } else if (format.value === ExportFormat.SVG) {
+    emit('exportAsSvg', openFolder.value);
+  } else if (format.value === ExportFormat.MusicXml) {
+    emit('exportAsMusicXml', {
+      options: musicXmlOptions.value,
+      compressed: false,
+      openFolder: openFolder.value,
+    } as ExportAsMusicXmlSettings);
+  } else if (format.value === ExportFormat.Latex) {
+    emit('exportAsLatex', {
+      options: latexOptions.value,
+    } as ExportAsLatexSettings);
+  }
+}
+
+function close() {
+  emit('close');
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ExportDialog.vue
+++ b/src/components/ExportDialog.vue
@@ -163,41 +163,20 @@
   </ModalDialog>
 </template>
 
-<script lang="ts">
-import { LatexExporterOptions } from '@/services/integration/LatexExporter';
-import { MusicXmlExporterOptions } from '@/services/integration/MusicXmlExporter';
-
-export enum ExportFormat {
-  HTML = 'HTML',
-  PDF = 'PDF',
-  PNG = 'PNG',
-  SVG = 'SVG',
-  MusicXml = 'MusicXml',
-  Latex = 'Latex',
-}
-
-export interface ExportAsPngSettings {
-  dpi: number;
-  openFolder: boolean;
-  transparentBackground: boolean;
-}
-
-export interface ExportAsMusicXmlSettings {
-  options: MusicXmlExporterOptions;
-  openFolder: boolean;
-  compressed: boolean;
-}
-
-export interface ExportAsLatexSettings {
-  options: LatexExporterOptions;
-}
-</script>
-
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, PropType, ref } from 'vue';
 
 import InputUnit from '@/components/InputUnit.vue';
 import ModalDialog from '@/components/ModalDialog.vue';
+import { LatexExporterOptions } from '@/services/integration/LatexExporter';
+import { MusicXmlExporterOptions } from '@/services/integration/MusicXmlExporter';
+
+import type {
+  ExportAsLatexSettings,
+  ExportAsMusicXmlSettings,
+  ExportAsPngSettings,
+} from './ExportDialog.types';
+import { ExportFormat } from './ExportDialog.types';
 
 const emit = defineEmits([
   'close',

--- a/src/components/FileMenuBar.vue
+++ b/src/components/FileMenuBar.vue
@@ -202,9 +202,9 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import JSZip from 'jszip';
-import { defineComponent } from 'vue';
+import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue';
 
 import FileMenuBarItem from '@/components/FileMenuBarItem.vue';
 import FileMenuItem from '@/components/FileMenuItem.vue';
@@ -219,349 +219,330 @@ import {
   IpcRendererChannels,
 } from '@/ipc/ipcChannels';
 
-export default defineComponent({
-  components: { FileMenuBarItem, FileMenuItem },
-  props: {},
-  emits: [],
+const fileSelector = useTemplateRef<HTMLInputElement>('file');
+const imageFileSelector = useTemplateRef<HTMLInputElement>('imagefile');
 
-  data() {
-    return {
-      isMenuOpen: false,
-      selectedMenu: '',
-      accept: '.byz,.byzx',
-      acceptImage: '.bmp,.jpg,.jpeg,.jpe,.png,.gif,.svg,.webp,.ico',
-      isChrome: (window as any).chrome != null,
-    };
-  },
+const isMenuOpen = ref(false);
+const selectedMenu = ref('');
+const accept = '.byz,.byzx';
+const acceptImage = '.bmp,.jpg,.jpeg,.jpe,.png,.gif,.svg,.webp,.ico';
+const isChrome = (window as any).chrome != null;
 
-  computed: {
-    fileSelector() {
-      return this.$refs.file as HTMLInputElement;
-    },
+onMounted(() => {
+  // If using the browser, then we need to hook into the key down
+  // to listen for Ctrl+O for open, Ctrl+S for save, etc.
+  window.addEventListener('keydown', onKeyDown);
 
-    imageFileSelector() {
-      return this.$refs.imagefile as HTMLInputElement;
-    },
-  },
-
-  mounted() {
-    // If using the browser, then we need to hook into the key down
-    // to listen for Ctrl+O for oven, Ctrl+S for save, etc.
-    window.addEventListener('keydown', this.onKeyDown);
-
-    EventBus.$on(IpcRendererChannels.OpenImageDialog, this.onClickAddImage);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-    EventBus.$off(IpcRendererChannels.OpenImageDialog, this.onClickAddImage);
-  },
-
-  methods: {
-    onKeyDown(event: KeyboardEvent) {
-      if (event.ctrlKey || event.metaKey) {
-        if (event.code === 'KeyO') {
-          this.onClickOpen();
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyS') {
-          this.onClickSave();
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyN') {
-          // Note: this doesn't actually work in Chrome.
-          // Chrome prevents you from capturing Ctrl+N.
-          this.onClickNew();
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyD') {
-          if (event.shiftKey) {
-            this.onClickAddDropCapAfter();
-          } else {
-            this.onClickAddDropCapBefore();
-          }
-          event.preventDefault();
-          return;
-        } else if (event.shiftKey && event.code === 'KeyP') {
-          this.onClickPageSetup();
-          event.preventDefault();
-          return;
-        } else if (event.code === 'Comma') {
-          this.onClickPreferences();
-          event.preventDefault();
-          return;
-        }
-      }
-    },
-
-    toggleMenu() {
-      this.isMenuOpen = !this.isMenuOpen;
-    },
-
-    onClickNew() {
-      EventBus.$emit(IpcMainChannels.FileMenuNewScore);
-      this.isMenuOpen = false;
-    },
-
-    onClickOpen() {
-      this.fileSelector.click();
-      this.isMenuOpen = false;
-    },
-
-    onClickSave() {
-      EventBus.$emit(IpcMainChannels.FileMenuSaveAs);
-      this.isMenuOpen = false;
-    },
-
-    onClickExportAsHtml() {
-      EventBus.$emit(IpcMainChannels.FileMenuExportAsHtml);
-      this.isMenuOpen = false;
-    },
-
-    onClickExportAsMusicXml() {
-      EventBus.$emit(IpcMainChannels.FileMenuExportAsMusicXml);
-      this.isMenuOpen = false;
-    },
-
-    onClickExportAsLatex() {
-      EventBus.$emit(IpcMainChannels.FileMenuExportAsLatex);
-      this.isMenuOpen = false;
-    },
-
-    onClickPageSetup() {
-      EventBus.$emit(IpcMainChannels.FileMenuPageSetup);
-      this.isMenuOpen = false;
-    },
-
-    onClickClose() {
-      EventBus.$emit(IpcMainChannels.CloseWorkspaces, {
-        disposition: CloseWorkspacesDisposition.SELF,
-      } as CloseWorkspacesArgs);
-      this.isMenuOpen = false;
-    },
-
-    onClickCloseOthers() {
-      EventBus.$emit(IpcMainChannels.CloseWorkspaces, {
-        disposition: CloseWorkspacesDisposition.OTHERS,
-      } as CloseWorkspacesArgs);
-      this.isMenuOpen = false;
-    },
-
-    async onSelectFile() {
-      const files = this.fileSelector.files!;
-
-      if (files.length > 0) {
-        const file = files[0];
-
-        if (file.name.endsWith('.byz')) {
-          const zip = await JSZip.loadAsync(file);
-          const data = await zip.file(/\.(byzx)$/)[0].async('text');
-
-          EventBus.$emit(IpcMainChannels.FileMenuOpenScore, {
-            data,
-            filePath: file.name,
-            success: true,
-          } as FileMenuOpenScoreArgs);
-
-          // Reset the selector so that if the user selects
-          // the same file twice, it will load
-          this.fileSelector.value = '';
-        } else {
-          const reader = new FileReader();
-
-          reader.onload = () => {
-            EventBus.$emit(IpcMainChannels.FileMenuOpenScore, {
-              data: reader.result as string,
-              filePath: file.name,
-              success: true,
-            } as FileMenuOpenScoreArgs);
-
-            // Reset the selector so that if the user selects
-            // the same file twice, it will load
-            this.fileSelector.value = '';
-          };
-
-          reader.readAsText(file);
-        }
-      }
-    },
-
-    async onSelectImageFile() {
-      const files = this.imageFileSelector.files!;
-
-      if (files.length > 0) {
-        const file = files[0];
-
-        const reader = new FileReader();
-
-        reader.onload = () => {
-          const data = reader.result as string;
-
-          // Create an instance of Image to determine the
-          // original image's height and width
-          const image = new Image();
-
-          image.onload = () => {
-            EventBus.$emit(IpcMainChannels.FileMenuInsertImage, {
-              data,
-              imageHeight: image.height,
-              imageWidth: image.width,
-              filePath: file.name,
-              success: true,
-            } as FileMenuOpenImageArgs);
-          };
-
-          image.src = data;
-
-          // Reset the selector so that if the user selects
-          // the same file twice, it will load
-          this.imageFileSelector.value = '';
-        };
-
-        reader.readAsDataURL(file);
-      }
-    },
-
-    onClickCut() {
-      EventBus.$emit(IpcMainChannels.FileMenuCut);
-      this.isMenuOpen = false;
-    },
-
-    onClickCopy() {
-      EventBus.$emit(IpcMainChannels.FileMenuCopy);
-      this.isMenuOpen = false;
-    },
-
-    onClickCopyAsHtml() {
-      EventBus.$emit(IpcMainChannels.FileMenuCopyAsHtml);
-      this.isMenuOpen = false;
-    },
-
-    onClickCopyFormat() {
-      EventBus.$emit(IpcMainChannels.FileMenuCopyFormat);
-      this.isMenuOpen = false;
-    },
-
-    onClickPaste() {
-      EventBus.$emit(IpcMainChannels.FileMenuPaste);
-      this.isMenuOpen = false;
-    },
-
-    onClickPasteWithLyrics() {
-      EventBus.$emit(IpcMainChannels.FileMenuPasteWithLyrics);
-      this.isMenuOpen = false;
-    },
-
-    onClickPasteFormat() {
-      EventBus.$emit(IpcMainChannels.FileMenuPasteFormat);
-      this.isMenuOpen = false;
-    },
-
-    onClickFind() {
-      EventBus.$emit(IpcMainChannels.FileMenuFind);
-      this.isMenuOpen = false;
-    },
-
-    onClickLyrics() {
-      EventBus.$emit(IpcMainChannels.FileMenuLyrics);
-      this.isMenuOpen = false;
-    },
-
-    onClickPreferences() {
-      EventBus.$emit(IpcMainChannels.FileMenuPreferences);
-      this.isMenuOpen = false;
-    },
-
-    onClickUndo() {
-      EventBus.$emit(IpcMainChannels.FileMenuUndo);
-      this.isMenuOpen = false;
-    },
-
-    onClickRedo() {
-      EventBus.$emit(IpcMainChannels.FileMenuRedo);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddTextBox() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertTextBox, {
-        inline: false,
-      } as FileMenuInsertTextboxArgs);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddRichTextBox() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertRichTextBox);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddInlineTextBox() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertTextBox, {
-        inline: true,
-      } as FileMenuInsertTextboxArgs);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddModeKey() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertModeKey);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddAlternateLine() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertAlternateLine);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddAnnotation() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertAnnotation);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddDropCapBefore() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertDropCapBefore);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddDropCapAfter() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertDropCapAfter);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddImage() {
-      this.imageFileSelector.click();
-      this.isMenuOpen = false;
-    },
-
-    onClickAddHeader() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertHeader);
-      this.isMenuOpen = false;
-    },
-
-    onClickAddFooter() {
-      EventBus.$emit(IpcMainChannels.FileMenuInsertFooter);
-      this.isMenuOpen = false;
-    },
-
-    onClickAbout() {
-      alert(`Neanes\nVersion: ${APP_VERSION}`);
-      this.isMenuOpen = false;
-    },
-
-    onClickGuide() {
-      window.open(import.meta.env.VITE_GUIDE_URL, '_blank');
-      this.isMenuOpen = false;
-    },
-
-    onClickRequestFeature() {
-      window.open(import.meta.env.VITE_ISSUES_URL, '_blank');
-      this.isMenuOpen = false;
-    },
-
-    onClickReportIssue() {
-      window.open(import.meta.env.VITE_ISSUES_URL, '_blank');
-      this.isMenuOpen = false;
-    },
-  },
+  EventBus.$on(IpcRendererChannels.OpenImageDialog, onClickAddImage);
 });
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+  EventBus.$off(IpcRendererChannels.OpenImageDialog, onClickAddImage);
+});
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.ctrlKey || event.metaKey) {
+    if (event.code === 'KeyO') {
+      onClickOpen();
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyS') {
+      onClickSave();
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyN') {
+      // Note: this doesn't actually work in Chrome.
+      // Chrome prevents you from capturing Ctrl+N.
+      onClickNew();
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyD') {
+      if (event.shiftKey) {
+        onClickAddDropCapAfter();
+      } else {
+        onClickAddDropCapBefore();
+      }
+      event.preventDefault();
+      return;
+    } else if (event.shiftKey && event.code === 'KeyP') {
+      onClickPageSetup();
+      event.preventDefault();
+      return;
+    } else if (event.code === 'Comma') {
+      onClickPreferences();
+      event.preventDefault();
+      return;
+    }
+  }
+}
+
+function toggleMenu() {
+  isMenuOpen.value = !isMenuOpen.value;
+}
+
+function onClickNew() {
+  EventBus.$emit(IpcMainChannels.FileMenuNewScore);
+  isMenuOpen.value = false;
+}
+
+function onClickOpen() {
+  fileSelector.value!.click();
+  isMenuOpen.value = false;
+}
+
+function onClickSave() {
+  EventBus.$emit(IpcMainChannels.FileMenuSaveAs);
+  isMenuOpen.value = false;
+}
+
+function onClickExportAsHtml() {
+  EventBus.$emit(IpcMainChannels.FileMenuExportAsHtml);
+  isMenuOpen.value = false;
+}
+
+function onClickExportAsMusicXml() {
+  EventBus.$emit(IpcMainChannels.FileMenuExportAsMusicXml);
+  isMenuOpen.value = false;
+}
+
+function onClickExportAsLatex() {
+  EventBus.$emit(IpcMainChannels.FileMenuExportAsLatex);
+  isMenuOpen.value = false;
+}
+
+function onClickPageSetup() {
+  EventBus.$emit(IpcMainChannels.FileMenuPageSetup);
+  isMenuOpen.value = false;
+}
+
+function onClickClose() {
+  EventBus.$emit(IpcMainChannels.CloseWorkspaces, {
+    disposition: CloseWorkspacesDisposition.SELF,
+  } as CloseWorkspacesArgs);
+  isMenuOpen.value = false;
+}
+
+function onClickCloseOthers() {
+  EventBus.$emit(IpcMainChannels.CloseWorkspaces, {
+    disposition: CloseWorkspacesDisposition.OTHERS,
+  } as CloseWorkspacesArgs);
+  isMenuOpen.value = false;
+}
+
+async function onSelectFile() {
+  const files = fileSelector.value!.files!;
+
+  if (files.length > 0) {
+    const file = files[0];
+
+    if (file.name.endsWith('.byz')) {
+      const zip = await JSZip.loadAsync(file);
+      const data = await zip.file(/\.(byzx)$/)[0].async('text');
+
+      EventBus.$emit(IpcMainChannels.FileMenuOpenScore, {
+        data,
+        filePath: file.name,
+        success: true,
+      } as FileMenuOpenScoreArgs);
+
+      // Reset the selector so that if the user selects
+      // the same file twice, it will load
+      fileSelector.value!.value = '';
+    } else {
+      const reader = new FileReader();
+
+      reader.onload = () => {
+        EventBus.$emit(IpcMainChannels.FileMenuOpenScore, {
+          data: reader.result as string,
+          filePath: file.name,
+          success: true,
+        } as FileMenuOpenScoreArgs);
+
+        // Reset the selector so that if the user selects
+        // the same file twice, it will load
+        fileSelector.value!.value = '';
+      };
+
+      reader.readAsText(file);
+    }
+  }
+}
+
+async function onSelectImageFile() {
+  const files = imageFileSelector.value!.files!;
+
+  if (files.length > 0) {
+    const file = files[0];
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const data = reader.result as string;
+
+      // Create an instance of Image to determine the
+      // original image's height and width
+      const image = new Image();
+
+      image.onload = () => {
+        EventBus.$emit(IpcMainChannels.FileMenuInsertImage, {
+          data,
+          imageHeight: image.height,
+          imageWidth: image.width,
+          filePath: file.name,
+          success: true,
+        } as FileMenuOpenImageArgs);
+      };
+
+      image.src = data;
+
+      // Reset the selector so that if the user selects
+      // the same file twice, it will load
+      imageFileSelector.value!.value = '';
+    };
+
+    reader.readAsDataURL(file);
+  }
+}
+
+function onClickCut() {
+  EventBus.$emit(IpcMainChannels.FileMenuCut);
+  isMenuOpen.value = false;
+}
+
+function onClickCopy() {
+  EventBus.$emit(IpcMainChannels.FileMenuCopy);
+  isMenuOpen.value = false;
+}
+
+function onClickCopyAsHtml() {
+  EventBus.$emit(IpcMainChannels.FileMenuCopyAsHtml);
+  isMenuOpen.value = false;
+}
+
+function onClickCopyFormat() {
+  EventBus.$emit(IpcMainChannels.FileMenuCopyFormat);
+  isMenuOpen.value = false;
+}
+
+function onClickPaste() {
+  EventBus.$emit(IpcMainChannels.FileMenuPaste);
+  isMenuOpen.value = false;
+}
+
+function onClickPasteWithLyrics() {
+  EventBus.$emit(IpcMainChannels.FileMenuPasteWithLyrics);
+  isMenuOpen.value = false;
+}
+
+function onClickPasteFormat() {
+  EventBus.$emit(IpcMainChannels.FileMenuPasteFormat);
+  isMenuOpen.value = false;
+}
+
+function onClickFind() {
+  EventBus.$emit(IpcMainChannels.FileMenuFind);
+  isMenuOpen.value = false;
+}
+
+function onClickLyrics() {
+  EventBus.$emit(IpcMainChannels.FileMenuLyrics);
+  isMenuOpen.value = false;
+}
+
+function onClickPreferences() {
+  EventBus.$emit(IpcMainChannels.FileMenuPreferences);
+  isMenuOpen.value = false;
+}
+
+function onClickUndo() {
+  EventBus.$emit(IpcMainChannels.FileMenuUndo);
+  isMenuOpen.value = false;
+}
+
+function onClickRedo() {
+  EventBus.$emit(IpcMainChannels.FileMenuRedo);
+  isMenuOpen.value = false;
+}
+
+function onClickAddTextBox() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertTextBox, {
+    inline: false,
+  } as FileMenuInsertTextboxArgs);
+  isMenuOpen.value = false;
+}
+
+function onClickAddRichTextBox() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertRichTextBox);
+  isMenuOpen.value = false;
+}
+
+function onClickAddInlineTextBox() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertTextBox, {
+    inline: true,
+  } as FileMenuInsertTextboxArgs);
+  isMenuOpen.value = false;
+}
+
+function onClickAddModeKey() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertModeKey);
+  isMenuOpen.value = false;
+}
+
+function onClickAddAlternateLine() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertAlternateLine);
+  isMenuOpen.value = false;
+}
+
+function onClickAddAnnotation() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertAnnotation);
+  isMenuOpen.value = false;
+}
+
+function onClickAddDropCapBefore() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertDropCapBefore);
+  isMenuOpen.value = false;
+}
+
+function onClickAddDropCapAfter() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertDropCapAfter);
+  isMenuOpen.value = false;
+}
+
+function onClickAddImage() {
+  imageFileSelector.value!.click();
+  isMenuOpen.value = false;
+}
+
+function onClickAddHeader() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertHeader);
+  isMenuOpen.value = false;
+}
+
+function onClickAddFooter() {
+  EventBus.$emit(IpcMainChannels.FileMenuInsertFooter);
+  isMenuOpen.value = false;
+}
+
+function onClickAbout() {
+  alert(`Neanes\nVersion: ${APP_VERSION}`);
+  isMenuOpen.value = false;
+}
+
+function onClickGuide() {
+  window.open(import.meta.env.VITE_GUIDE_URL, '_blank');
+  isMenuOpen.value = false;
+}
+
+function onClickRequestFeature() {
+  window.open(import.meta.env.VITE_ISSUES_URL, '_blank');
+  isMenuOpen.value = false;
+}
+
+function onClickReportIssue() {
+  window.open(import.meta.env.VITE_ISSUES_URL, '_blank');
+  isMenuOpen.value = false;
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/FileMenuBarItem.vue
+++ b/src/components/FileMenuBarItem.vue
@@ -11,30 +11,17 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: {},
-  props: {
-    label: {
-      type: String,
-      required: true,
-    },
-    isOpen: {
-      type: Boolean,
-      required: true,
-    },
+<script setup lang="ts">
+defineEmits(['click', 'mouseenter']);
+defineProps({
+  label: {
+    type: String,
+    required: true,
   },
-  emits: ['click', 'mouseenter'],
-
-  data() {
-    return {};
+  isOpen: {
+    type: Boolean,
+    required: true,
   },
-
-  computed: {},
-
-  methods: {},
 });
 </script>
 

--- a/src/components/FileMenuItem.vue
+++ b/src/components/FileMenuItem.vue
@@ -4,26 +4,13 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: {},
-  props: {
-    label: {
-      type: String,
-      required: true,
-    },
+<script setup lang="ts">
+defineEmits(['click']);
+defineProps({
+  label: {
+    type: String,
+    required: true,
   },
-  emits: ['click'],
-
-  data() {
-    return {};
-  },
-
-  computed: {},
-
-  methods: {},
 });
 </script>
 

--- a/src/components/ImageBox.vue
+++ b/src/components/ImageBox.vue
@@ -28,101 +28,91 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import 'vue-draggable-resizable/style.css';
 
-import { defineComponent, PropType, StyleValue } from 'vue';
+import { computed, PropType, ref, StyleValue, watch } from 'vue';
 import VueDraggableResizable from 'vue-draggable-resizable';
 
 import { ImageBoxElement } from '@/models/Element';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { VueDraggableResizable },
-  props: {
-    element: {
-      type: Object as PropType<ImageBoxElement>,
-      required: true,
-    },
-    zoom: {
-      type: Number,
-      required: true,
-    },
-    printMode: {
-      type: Boolean,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<ImageBoxElement>,
+    required: true,
   },
-  emits: ['update:size', 'select-single'],
-
-  data() {
-    return {
-      imageWidth: 0,
-      imageHeight: 0,
-    };
+  zoom: {
+    type: Number,
+    required: true,
   },
-
-  computed: {
-    imageWidthZoomed() {
-      return this.imageWidth * this.zoom;
-    },
-
-    imageHeightZoomed() {
-      return this.imageHeight * this.zoom;
-    },
-
-    containerStyle() {
-      const style = {
-        justifyContent: this.element.alignment,
-        width: withZoom(this.element.width),
-        height: withZoom(this.imageHeight),
-      } as Partial<CSSStyleDeclaration>;
-
-      if (this.element.inline) {
-        style.border = 'none';
-      }
-
-      return style as StyleValue;
-    },
-
-    imageStyle() {
-      const style: any = {
-        width: withZoom(this.imageWidth),
-        height: withZoom(this.imageHeight),
-      };
-
-      return style;
-    },
-  },
-
-  watch: {
-    'element.imageWidth'(newValue: number) {
-      this.imageWidth = newValue;
-    },
-    'element.imageHeight'(newValue: number) {
-      this.imageHeight = newValue;
-    },
-  },
-
-  created() {
-    this.imageWidth = this.element.imageWidth;
-    this.imageHeight = this.element.imageHeight;
-  },
-
-  methods: {
-    onResize(x: number, y: number, width: number, height: number) {
-      this.imageWidth = width / this.zoom;
-      this.imageHeight = height / this.zoom;
-    },
-
-    onResizeStop(left: number, top: number, width: number, height: number) {
-      this.$emit('update:size', {
-        width: width / this.zoom,
-        height: height / this.zoom,
-      });
-    },
+  printMode: {
+    type: Boolean,
+    required: true,
   },
 });
+
+const emit = defineEmits(['update:size', 'select-single']);
+
+const imageWidth = ref(props.element.imageWidth);
+const imageHeight = ref(props.element.imageHeight);
+
+const imageWidthZoomed = computed(() => imageWidth.value * props.zoom);
+const imageHeightZoomed = computed(() => imageHeight.value * props.zoom);
+
+const containerStyle = computed(() => {
+  const style = {
+    justifyContent: props.element.alignment,
+    width: withZoom(props.element.width),
+    height: withZoom(imageHeight.value),
+  } as Partial<CSSStyleDeclaration>;
+
+  if (props.element.inline) {
+    style.border = 'none';
+  }
+
+  return style as StyleValue;
+});
+
+const imageStyle = computed(() => {
+  const style: any = {
+    width: withZoom(imageWidth.value),
+    height: withZoom(imageHeight.value),
+  };
+
+  return style;
+});
+
+watch(
+  () => props.element.imageWidth,
+  (newValue) => {
+    imageWidth.value = newValue;
+  },
+);
+
+watch(
+  () => props.element.imageHeight,
+  (newValue) => {
+    imageHeight.value = newValue;
+  },
+);
+
+function onResize(x: number, y: number, width: number, height: number) {
+  imageWidth.value = width / props.zoom;
+  imageHeight.value = height / props.zoom;
+}
+
+function onResizeStop(
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+) {
+  emit('update:size', {
+    width: width / props.zoom,
+    height: height / props.zoom,
+  });
+}
 </script>
 
 <style scoped>

--- a/src/components/InputBpm.vue
+++ b/src/components/InputBpm.vue
@@ -11,37 +11,24 @@
   />
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
+<script setup lang="ts">
 import InputUnit from '@/components/InputUnit.vue';
 
-export default defineComponent({
-  components: { InputUnit },
-  props: {
-    modelValue: {
-      type: Number,
-      required: true,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
+defineEmits(['update:modelValue']);
+defineProps({
+  modelValue: {
+    type: Number,
+    required: true,
   },
-  emits: ['update:modelValue'],
-
-  data() {
-    return {};
-  },
-
-  computed: {},
-
-  methods: {
-    round(value: number) {
-      return Math.round(value);
-    },
+  disabled: {
+    type: Boolean,
+    default: false,
   },
 });
+
+function round(value: number) {
+  return Math.round(value);
+}
 </script>
 
 <style scoped></style>

--- a/src/components/InputFontSize.vue
+++ b/src/components/InputFontSize.vue
@@ -10,37 +10,24 @@
   />
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
+<script setup lang="ts">
 import InputUnit from '@/components/InputUnit.vue';
 
-export default defineComponent({
-  components: { InputUnit },
-  props: {
-    modelValue: {
-      type: Number,
-      required: true,
-    },
-    max: {
-      type: Number,
-      default: 100,
-    },
+defineEmits(['update:modelValue']);
+defineProps({
+  modelValue: {
+    type: Number,
+    required: true,
   },
-  emits: ['update:modelValue'],
-
-  data() {
-    return {};
-  },
-
-  computed: {},
-
-  methods: {
-    round(value: number) {
-      return Math.round(value * 2) / 2;
-    },
+  max: {
+    type: Number,
+    default: 100,
   },
 });
+
+function round(value: number) {
+  return Math.round(value * 2) / 2;
+}
 </script>
 
 <style scoped></style>

--- a/src/components/InputStrokeWidth.vue
+++ b/src/components/InputStrokeWidth.vue
@@ -10,36 +10,19 @@
   />
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
+<script setup lang="ts">
 import InputUnit from '@/components/InputUnit.vue';
 
 const strokeWidthMax = 5;
 const strokeWidthStep = 0.1;
 const strokeWidthPrecision = 2;
 
-export default defineComponent({
-  components: { InputUnit },
-  props: {
-    modelValue: {
-      type: Number,
-      required: true,
-    },
+defineEmits(['update:modelValue']);
+defineProps({
+  modelValue: {
+    type: Number,
+    required: true,
   },
-  emits: ['update:modelValue'],
-
-  data() {
-    return {
-      strokeWidthMax,
-      strokeWidthStep,
-      strokeWidthPrecision,
-    };
-  },
-
-  computed: {},
-
-  methods: {},
 });
 </script>
 

--- a/src/components/InputUnit.types.ts
+++ b/src/components/InputUnit.types.ts
@@ -1,0 +1,8 @@
+export type UnitOfMeasure =
+  | 'pc'
+  | 'pt'
+  | 'in'
+  | 'cm'
+  | 'mm'
+  | 'percent'
+  | 'unitless';

--- a/src/components/InputUnit.vue
+++ b/src/components/InputUnit.vue
@@ -11,20 +11,10 @@
   />
 </template>
 
-<script lang="ts">
-export type UnitOfMeasure =
-  | 'pc'
-  | 'pt'
-  | 'in'
-  | 'cm'
-  | 'mm'
-  | 'percent'
-  | 'unitless';
-</script>
-
 <script setup lang="ts">
 import { computed, PropType, useTemplateRef } from 'vue';
 
+import type { UnitOfMeasure } from '@/components/InputUnit.types';
 import { Unit } from '@/utils/Unit';
 
 const emit = defineEmits(['update:modelValue']);
@@ -115,12 +105,12 @@ function emitValue(v: number | null) {
   }
 }
 
-function onChange(input: string) {
-  if (input.trim() === '' && props.nullable) {
+function onChange(value: string) {
+  if (value.trim() === '' && props.nullable) {
     return emitValue(null);
   }
 
-  let newValue = parseFloat(input);
+  let newValue = parseFloat(value);
 
   if (isNaN(newValue)) {
     newValue = props.defaultValue;

--- a/src/components/InputUnit.vue
+++ b/src/components/InputUnit.vue
@@ -12,10 +12,6 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
-
-import { Unit } from '@/utils/Unit';
-
 export type UnitOfMeasure =
   | 'pc'
   | 'pt'
@@ -24,183 +20,176 @@ export type UnitOfMeasure =
   | 'mm'
   | 'percent'
   | 'unitless';
+</script>
 
-export default defineComponent({
-  components: {},
-  props: {
-    modelValue: {
-      type: [Number, null],
-      required: true,
-    },
-    unit: {
-      type: String as PropType<UnitOfMeasure>,
-      required: true,
-    },
-    nullable: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * The minimum value allowed, in display units.
-     */
-    min: {
-      type: Number,
-      default: undefined,
-    },
-    /**
-     * The maximum value allowed, in display units.
-     */
-    max: {
-      type: Number,
-      default: undefined,
-    },
-    /**
-     * The step size, in display units.
-     */
-    step: {
-      type: Number,
-      default: undefined,
-    },
-    /**
-     * The number of decimal places that will be displayed.
-     */
-    precision: {
-      type: Number,
-      default: undefined,
-    },
-    /**
-     * The default value if the value is cleared
-     */
-    defaultValue: {
-      type: Number,
-      default: 0,
-    },
-    /**
-     * Whether the input is disabled
-     */
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * A special rounding function applied to the display value
-     * before it is converted to the stored value.
-     */
-    round: {
-      type: Function as PropType<(x: number) => number>,
-      default: undefined,
-    },
+<script setup lang="ts">
+import { computed, PropType, useTemplateRef } from 'vue';
+
+import { Unit } from '@/utils/Unit';
+
+const emit = defineEmits(['update:modelValue']);
+const props = defineProps({
+  modelValue: {
+    type: [Number, null],
+    required: true,
   },
-  emits: ['update:modelValue'],
-
-  data() {
-    return {};
+  unit: {
+    type: String as PropType<UnitOfMeasure>,
+    required: true,
   },
-
-  computed: {
-    htmlElement() {
-      return this.$refs.input as HTMLInputElement;
-    },
-
-    displayValue() {
-      const convertedValue = this.toDisplay(this.modelValue);
-
-      if (convertedValue == null) {
-        return this.nullable ? '' : this.defaultValue.toString();
-      }
-
-      return this.precision != null
-        ? convertedValue.toFixed(this.precision)
-        : convertedValue.toString();
-    },
+  nullable: {
+    type: Boolean,
+    default: false,
   },
-
-  methods: {
-    emitValue(v: number | null) {
-      if (this.modelValue !== v) {
-        this.$emit('update:modelValue', v);
-      } else {
-        this.htmlElement.value = this.displayValue;
-      }
-    },
-
-    onChange(input: string) {
-      if (input.trim() === '' && this.nullable) {
-        return this.emitValue(null);
-      }
-
-      let newValue = parseFloat(input);
-
-      if (isNaN(newValue)) {
-        newValue = this.defaultValue;
-      }
-
-      if (this.round != null) {
-        newValue = this.round(newValue);
-      }
-
-      let storageValue = this.toStorage(newValue);
-
-      if (this.min != null) {
-        storageValue = Math.max(this.toStorage(this.min), storageValue);
-      }
-
-      if (this.max != null) {
-        storageValue = Math.min(this.toStorage(this.max), storageValue);
-      }
-
-      this.emitValue(storageValue);
-    },
-
-    toStorage(value: number) {
-      switch (this.unit) {
-        case 'pc':
-          return Unit.fromPc(value);
-        case 'pt':
-          return Unit.fromPt(value);
-        case 'in':
-          return Unit.fromInch(value);
-        case 'cm':
-          return Unit.fromCm(value);
-        case 'mm':
-          return Unit.fromMm(value);
-        case 'percent':
-          return Unit.fromPercent(value);
-        case 'unitless':
-          return value;
-        default:
-          console.error(`Unsupported unit ${this.unit}`);
-          return value;
-      }
-    },
-
-    toDisplay(value: number | null) {
-      if (value == null) {
-        return null;
-      }
-
-      switch (this.unit) {
-        case 'pc':
-          return Unit.toPc(value);
-        case 'pt':
-          return Unit.toPt(value);
-        case 'in':
-          return Unit.toInch(value);
-        case 'cm':
-          return Unit.toCm(value);
-        case 'mm':
-          return Unit.toMm(value);
-        case 'percent':
-          return Unit.toPercent(value);
-        case 'unitless':
-          return value;
-        default:
-          console.error(`Unsupported unit ${this.unit}`);
-          return value;
-      }
-    },
+  /**
+   * The minimum value allowed, in display units.
+   */
+  min: {
+    type: Number,
+    default: undefined,
+  },
+  /**
+   * The maximum value allowed, in display units.
+   */
+  max: {
+    type: Number,
+    default: undefined,
+  },
+  /**
+   * The step size, in display units.
+   */
+  step: {
+    type: Number,
+    default: undefined,
+  },
+  /**
+   * The number of decimal places that will be displayed.
+   */
+  precision: {
+    type: Number,
+    default: undefined,
+  },
+  /**
+   * The default value if the value is cleared
+   */
+  defaultValue: {
+    type: Number,
+    default: 0,
+  },
+  /**
+   * Whether the input is disabled
+   */
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * A special rounding function applied to the display value
+   * before it is converted to the stored value.
+   */
+  round: {
+    type: Function as PropType<(x: number) => number>,
+    default: undefined,
   },
 });
+
+const input = useTemplateRef<HTMLInputElement>('input');
+
+const displayValue = computed(() => {
+  const convertedValue = toDisplay(props.modelValue);
+
+  if (convertedValue == null) {
+    return props.nullable ? '' : props.defaultValue.toString();
+  }
+
+  return props.precision != null
+    ? convertedValue.toFixed(props.precision)
+    : convertedValue.toString();
+});
+
+function emitValue(v: number | null) {
+  if (props.modelValue !== v) {
+    emit('update:modelValue', v);
+  } else {
+    input.value!.value = displayValue.value;
+  }
+}
+
+function onChange(input: string) {
+  if (input.trim() === '' && props.nullable) {
+    return emitValue(null);
+  }
+
+  let newValue = parseFloat(input);
+
+  if (isNaN(newValue)) {
+    newValue = props.defaultValue;
+  }
+
+  if (props.round != null) {
+    newValue = props.round(newValue);
+  }
+
+  let storageValue = toStorage(newValue);
+
+  if (props.min != null) {
+    storageValue = Math.max(toStorage(props.min), storageValue);
+  }
+
+  if (props.max != null) {
+    storageValue = Math.min(toStorage(props.max), storageValue);
+  }
+
+  emitValue(storageValue);
+}
+
+function toStorage(value: number) {
+  switch (props.unit) {
+    case 'pc':
+      return Unit.fromPc(value);
+    case 'pt':
+      return Unit.fromPt(value);
+    case 'in':
+      return Unit.fromInch(value);
+    case 'cm':
+      return Unit.fromCm(value);
+    case 'mm':
+      return Unit.fromMm(value);
+    case 'percent':
+      return Unit.fromPercent(value);
+    case 'unitless':
+      return value;
+    default:
+      console.error(`Unsupported unit ${props.unit}`);
+      return value;
+  }
+}
+
+function toDisplay(value: number | null) {
+  if (value == null) {
+    return null;
+  }
+
+  switch (props.unit) {
+    case 'pc':
+      return Unit.toPc(value);
+    case 'pt':
+      return Unit.toPt(value);
+    case 'in':
+      return Unit.toInch(value);
+    case 'cm':
+      return Unit.toCm(value);
+    case 'mm':
+      return Unit.toMm(value);
+    case 'percent':
+      return Unit.toPercent(value);
+    case 'unitless':
+      return value;
+    default:
+      console.error(`Unsupported unit ${props.unit}`);
+      return value;
+  }
+}
 </script>
 
 <style scoped></style>

--- a/src/components/ModeKey.vue
+++ b/src/components/ModeKey.vue
@@ -63,8 +63,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, PropType, StyleValue } from 'vue';
 
 import Neume from '@/components/NeumeGlyph.vue';
 import { ModeKeyElement } from '@/models/Element';
@@ -72,69 +72,54 @@ import { ModeSign } from '@/models/Neumes';
 import { PageSetup } from '@/models/PageSetup';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { Neume },
-  props: {
-    element: {
-      type: Object as PropType<ModeKeyElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+defineEmits(['select-single']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<ModeKeyElement>,
+    required: true,
   },
-  emits: ['select-single'],
-
-  data() {
-    return {
-      ModeSign,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
+});
 
-  computed: {
-    style() {
-      return {
-        color: this.element.computedColor,
-        fontFamily: this.element.computedFontFamily,
-        fontSize: withZoom(this.element.computedFontSize),
-        textAlign: this.element.alignment,
-        width: withZoom(this.element.width),
-        height: withZoom(this.element.height),
-        webkitTextStrokeWidth: withZoom(this.element.computedStrokeWidth),
-      } as StyleValue;
-    },
+const style = computed(() => {
+  return {
+    color: props.element.computedColor,
+    fontFamily: props.element.computedFontFamily,
+    fontSize: withZoom(props.element.computedFontSize),
+    textAlign: props.element.alignment,
+    width: withZoom(props.element.width),
+    height: withZoom(props.element.height),
+    webkitTextStrokeWidth: withZoom(props.element.computedStrokeWidth),
+  } as StyleValue;
+});
 
-    tempoStyle() {
-      // TODO figure out a way to remove the hard-coded -.45em
-      // maybe put it in the font metadata json?
-      const style = {
-        color: this.pageSetup.tempoDefaultColor,
-        webkitTextStrokeWidth: withZoom(this.pageSetup.tempoDefaultStrokeWidth),
-        top: '-0.45em',
-        marginLeft: withZoom(8),
-      } as StyleValue;
+const tempoStyle = computed(() => {
+  // TODO figure out a way to remove the hard-coded -.45em
+  // maybe put it in the font metadata json?
+  const style = {
+    color: props.pageSetup.tempoDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.tempoDefaultStrokeWidth),
+    top: '-0.45em',
+    marginLeft: withZoom(8),
+  } as StyleValue;
 
-      return style;
-    },
+  return style;
+});
 
-    ambitusStyle() {
-      // TODO figure out a way to remove the hard-coded -.45em
-      // maybe put it in the font metadata json?
-      const style = {
-        color: this.pageSetup.martyriaDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.martyriaDefaultStrokeWidth,
-        ),
-        position: 'relative',
-        top: '-0.45em',
-      } as StyleValue;
+const ambitusStyle = computed(() => {
+  // TODO figure out a way to remove the hard-coded -.45em
+  // maybe put it in the font metadata json?
+  const style = {
+    color: props.pageSetup.martyriaDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.martyriaDefaultStrokeWidth),
+    position: 'relative',
+    top: '-0.45em',
+  } as StyleValue;
 
-      return style;
-    },
-  },
-
-  methods: {},
+  return style;
 });
 </script>
 

--- a/src/components/ModeKeyDialog.vue
+++ b/src/components/ModeKeyDialog.vue
@@ -110,8 +110,8 @@
   </ModalDialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, onBeforeUnmount, PropType, ref } from 'vue';
 
 import ModalDialog from '@/components/ModalDialog.vue';
 import ModeKey from '@/components/ModeKey.vue';
@@ -120,90 +120,81 @@ import { modeKeyTemplates } from '@/models/ModeKeys';
 import { PageSetup } from '@/models/PageSetup';
 import { TextMeasurementService } from '@/services/TextMeasurementService';
 
-export default defineComponent({
-  components: { ModalDialog, ModeKey },
-  props: {
-    element: {
-      type: Object as PropType<ModeKeyElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const emit = defineEmits([
+  'close',
+  'update',
+  'update:useOptionalDiatonicFthoras',
+]);
+const props = defineProps({
+  element: {
+    type: Object as PropType<ModeKeyElement>,
+    required: true,
   },
-  emits: ['close', 'update', 'update:useOptionalDiatonicFthoras'],
-
-  data() {
-    return {
-      selectedMode: null as number | null,
-      selectedTemplateId: null as number | null,
-    };
-  },
-
-  computed: {
-    modeKeyTemplatesForSelectedMode() {
-      const elements = modeKeyTemplates
-        .filter((x) => x.mode === this.selectedMode)
-        .map((x) =>
-          Object.assign(
-            ModeKeyElement.createFromTemplate(
-              x,
-              this.pageSetup.useOptionalDiatonicFthoras,
-              TextBoxAlignment.Left,
-            ),
-            { descriptionSelector: x.description },
-          ),
-        );
-
-      const height = TextMeasurementService.getFontHeight(
-        `${elements[0].fontSize}px ${this.pageSetup.neumeDefaultFontFamily}`,
-      );
-
-      for (const element of elements) {
-        element.height = height;
-        element.computedFontFamily = this.pageSetup.neumeDefaultFontFamily;
-      }
-
-      return elements;
-    },
-  },
-
-  created() {
-    this.selectMode(this.element.mode);
-
-    window.addEventListener('keydown', this.onKeyDown);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  methods: {
-    onKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        this.$emit('close');
-      }
-    },
-
-    selectMode(mode: number) {
-      this.selectedMode = mode;
-      this.selectedTemplateId =
-        this.modeKeyTemplatesForSelectedMode.find(
-          (x) => x.templateId === this.element.templateId,
-        )?.templateId || this.modeKeyTemplatesForSelectedMode[0].templateId;
-    },
-
-    updateModeKey() {
-      const modeKey = this.modeKeyTemplatesForSelectedMode.find(
-        (x) => x.templateId === this.selectedTemplateId,
-      );
-
-      this.$emit('update', modeKey);
-      this.$emit('close');
-    },
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
 });
+
+const selectedMode = ref<number | null>(null);
+const selectedTemplateId = ref<number | null>(null);
+
+const modeKeyTemplatesForSelectedMode = computed(() => {
+  const elements = modeKeyTemplates
+    .filter((x) => x.mode === selectedMode.value)
+    .map((x) =>
+      Object.assign(
+        ModeKeyElement.createFromTemplate(
+          x,
+          props.pageSetup.useOptionalDiatonicFthoras,
+          TextBoxAlignment.Left,
+        ),
+        { descriptionSelector: x.description },
+      ),
+    );
+
+  const height = TextMeasurementService.getFontHeight(
+    `${elements[0].fontSize}px ${props.pageSetup.neumeDefaultFontFamily}`,
+  );
+
+  for (const element of elements) {
+    element.height = height;
+    element.computedFontFamily = props.pageSetup.neumeDefaultFontFamily;
+  }
+
+  return elements;
+});
+
+selectMode(props.element.mode);
+
+window.addEventListener('keydown', onKeyDown);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+});
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.code === 'Escape') {
+    emit('close');
+  }
+}
+
+function selectMode(mode: number) {
+  selectedMode.value = mode;
+  selectedTemplateId.value =
+    modeKeyTemplatesForSelectedMode.value.find(
+      (x) => x.templateId === props.element.templateId,
+    )?.templateId || modeKeyTemplatesForSelectedMode.value[0].templateId;
+}
+
+function updateModeKey() {
+  const modeKey = modeKeyTemplatesForSelectedMode.value.find(
+    (x) => x.templateId === selectedTemplateId.value,
+  );
+
+  emit('update', modeKey);
+  emit('close');
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/NeumeBoxMartyria.vue
+++ b/src/components/NeumeBoxMartyria.vue
@@ -45,119 +45,83 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, PropType, StyleValue } from 'vue';
 
 import Neume from '@/components/NeumeGlyph.vue';
 import { MartyriaElement } from '@/models/Element';
-import { Note } from '@/models/Neumes';
 import { PageSetup } from '@/models/PageSetup';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { Neume },
-  props: {
-    neume: {
-      type: Object as PropType<MartyriaElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const props = defineProps({
+  neume: {
+    type: Object as PropType<MartyriaElement>,
+    required: true,
   },
-  emits: ['select-single', 'select-range'],
-
-  data() {
-    return {
-      Note,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
+});
 
-  computed: {
-    hasFthora() {
-      return this.neume.fthora != null;
-    },
+defineEmits(['select-single', 'select-range']);
 
-    hasTempoLeft() {
-      return this.neume.tempoLeft != null;
-    },
+const hasFthora = computed(() => props.neume.fthora != null);
+const hasTempoLeft = computed(() => props.neume.tempoLeft != null);
+const hasTempo = computed(() => props.neume.tempo != null);
+const hasTempoRight = computed(() => props.neume.tempoRight != null);
+const hasMeasureBarLeft = computed(() => props.neume.measureBarLeft != null);
+const hasMeasureBarRight = computed(() => props.neume.measureBarRight != null);
+const hasQuantitativeNeume = computed(
+  () => props.neume.quantitativeNeume != null && props.neume.alignRight,
+);
+const isMeasureBarAbove = computed(() =>
+  props.neume.measureBarLeft?.endsWith('Above'),
+);
 
-    hasTempo() {
-      return this.neume.tempo != null;
-    },
+const style = computed(() => {
+  const verticalOffset =
+    props.pageSetup.martyriaVerticalOffset + props.neume.verticalOffset;
 
-    hasTempoRight() {
-      return this.neume.tempoRight != null;
-    },
+  return {
+    color: props.pageSetup.martyriaDefaultColor,
+    fontFamily: props.pageSetup.neumeDefaultFontFamily,
+    fontSize: withZoom(props.pageSetup.neumeDefaultFontSize),
+    webkitTextStrokeWidth: withZoom(props.pageSetup.martyriaDefaultStrokeWidth),
+    position: verticalOffset != 0 ? 'relative' : undefined,
+    top: verticalOffset != 0 ? withZoom(verticalOffset) : undefined,
+  } as StyleValue;
+});
 
-    hasMeasureBarLeft() {
-      return this.neume.measureBarLeft != null;
-    },
+const fthoraStyle = computed(() => {
+  return {
+    color: props.pageSetup.fthoraDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.fthoraDefaultStrokeWidth),
+  } as StyleValue;
+});
 
-    hasMeasureBarRight() {
-      return this.neume.measureBarRight != null;
-    },
+const quantitativeNeumeStyle = computed(() => {
+  return {
+    marginLeft: withZoom(props.neume.padding),
+    color: props.pageSetup.neumeDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.neumeDefaultStrokeWidth),
+  } as StyleValue;
+});
 
-    hasQuantitativeNeume() {
-      return this.neume.quantitativeNeume != null && this.neume.alignRight;
-    },
+const tempoStyle = computed(() => {
+  return {
+    color: props.pageSetup.tempoDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.tempoDefaultStrokeWidth),
+  } as StyleValue;
+});
 
-    isMeasureBarAbove() {
-      return this.neume.measureBarLeft?.endsWith('Above');
-    },
-
-    style() {
-      const verticalOffset =
-        this.pageSetup.martyriaVerticalOffset + this.neume.verticalOffset;
-
-      return {
-        color: this.pageSetup.martyriaDefaultColor,
-        fontFamily: this.pageSetup.neumeDefaultFontFamily,
-        fontSize: withZoom(this.pageSetup.neumeDefaultFontSize),
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.martyriaDefaultStrokeWidth,
-        ),
-        position: verticalOffset != 0 ? 'relative' : undefined,
-        top: verticalOffset != 0 ? withZoom(verticalOffset) : undefined,
-      } as StyleValue;
-    },
-
-    fthoraStyle() {
-      return {
-        color: this.pageSetup.fthoraDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.fthoraDefaultStrokeWidth,
-        ),
-      } as StyleValue;
-    },
-
-    quantitativeNeumeStyle() {
-      return {
-        marginLeft: withZoom(this.neume.padding),
-        color: this.pageSetup.neumeDefaultColor,
-        webkitTextStrokeWidth: withZoom(this.pageSetup.neumeDefaultStrokeWidth),
-      } as StyleValue;
-    },
-
-    tempoStyle() {
-      return {
-        color: this.pageSetup.tempoDefaultColor,
-        webkitTextStrokeWidth: withZoom(this.pageSetup.tempoDefaultStrokeWidth),
-      } as StyleValue;
-    },
-
-    measureBarStyle() {
-      return {
-        color: this.pageSetup.measureBarDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.measureBarDefaultStrokeWidth,
-        ),
-      } as StyleValue;
-    },
-  },
-
-  methods: {},
+const measureBarStyle = computed(() => {
+  return {
+    color: props.pageSetup.measureBarDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.measureBarDefaultStrokeWidth,
+    ),
+  } as StyleValue;
 });
 </script>
 

--- a/src/components/NeumeBoxSyllable.vue
+++ b/src/components/NeumeBoxSyllable.vue
@@ -98,10 +98,10 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, PropType, StyleValue } from 'vue';
 
-import NeumeVue from '@/components/NeumeGlyph.vue';
+import Neume from '@/components/NeumeGlyph.vue';
 import { NoteElement } from '@/models/Element';
 import {
   QuantitativeNeume,
@@ -111,472 +111,316 @@ import {
 import { PageSetup } from '@/models/PageSetup';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { Neume: NeumeVue },
-  props: {
-    note: {
-      type: Object as PropType<NoteElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    alternateLine: {
-      type: Boolean,
-      default: false,
-    },
+const props = defineProps({
+  note: {
+    type: Object as PropType<NoteElement>,
+    required: true,
   },
-  emits: ['select-single', 'select-range'],
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
+  },
+  alternateLine: {
+    type: Boolean,
+    default: false,
+  },
+});
 
-  data() {
+defineEmits(['select-single', 'select-range']);
+
+const hasVocalExpressionNeume = computed(
+  () => props.note.vocalExpressionNeume != null,
+);
+const hasTimeNeume = computed(() => props.note.timeNeume != null);
+const hasGorgonNeume = computed(() => props.note.gorgonNeume != null);
+const hasSecondaryGorgonNeume = computed(
+  () => props.note.secondaryGorgonNeume != null,
+);
+const hasFthora = computed(() => props.note.fthora != null);
+const hasSecondaryFthora = computed(() => props.note.secondaryFthora != null);
+const hasTertiaryFthora = computed(() => props.note.tertiaryFthora != null);
+const hasAccidental = computed(() => props.note.accidental != null);
+const hasSecondaryAccidental = computed(
+  () => props.note.secondaryAccidental != null,
+);
+const hasTertiaryAccidental = computed(
+  () => props.note.tertiaryAccidental != null,
+);
+const hasMeasureBarLeft = computed(
+  () =>
+    props.note.measureBarLeft != null ||
+    props.note.computedMeasureBarLeft != null,
+);
+const hasMeasureBarRight = computed(
+  () =>
+    props.note.measureBarRight != null ||
+    props.note.computedMeasureBarRight != null,
+);
+const getMeasureBarLeft = computed(() =>
+  props.note.measureBarLeft
+    ? props.note.measureBarLeft
+    : props.note.computedMeasureBarLeft,
+);
+const getMeasureBarRight = computed(() =>
+  props.note.measureBarRight
+    ? props.note.measureBarRight
+    : props.note.computedMeasureBarRight,
+);
+const isMeasureBarAbove = computed(() =>
+  (props.note.measureBarLeft
+    ? props.note.measureBarLeft
+    : props.note.computedMeasureBarLeft
+  )?.endsWith('Above'),
+);
+const hasMeasureNumber = computed(() => props.note.measureNumber != null);
+const hasIson = computed(() => props.note.ison != null);
+const hasTie = computed(() => props.note.tie != null);
+
+function offsetStyle(
+  left: number | null | undefined,
+  top: number | null | undefined,
+) {
+  return {
+    left: left != null ? `${left}em` : undefined,
+    top: top != null ? `${top}em` : undefined,
+  };
+}
+
+const style = computed(() => {
+  return {
+    fontFamily: props.pageSetup.neumeDefaultFontFamily,
+    fontSize: props.alternateLine
+      ? withZoom(props.pageSetup.alternateLineDefaultFontSize)
+      : withZoom(props.pageSetup.neumeDefaultFontSize),
+    color: props.alternateLine
+      ? props.pageSetup.alternateLineDefaultColor
+      : props.pageSetup.neumeDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.neumeDefaultStrokeWidth),
+  } as StyleValue;
+});
+
+const gorgonStyle = computed(() => {
+  return {
+    color: props.pageSetup.gorgonDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.gorgonDefaultStrokeWidth),
+    ...offsetStyle(
+      props.note.gorgonNeumeOffsetX,
+      props.note.gorgonNeumeOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const secondaryGorgonStyle = computed(() => {
+  return {
+    color: props.pageSetup.gorgonDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.gorgonDefaultStrokeWidth),
+    ...offsetStyle(
+      props.note.secondaryGorgonNeumeOffsetX,
+      props.note.secondaryGorgonNeumeOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const fthoraStyle = computed(() => {
+  return {
+    color: props.pageSetup.fthoraDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.fthoraDefaultStrokeWidth),
+    ...offsetStyle(props.note.fthoraOffsetX, props.note.fthoraOffsetY),
+  } as StyleValue;
+});
+
+const secondaryFthoraStyle = computed(() => {
+  return {
+    color: props.pageSetup.fthoraDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.fthoraDefaultStrokeWidth),
+    ...offsetStyle(
+      props.note.secondaryFthoraOffsetX,
+      props.note.secondaryFthoraOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const tertiaryFthoraStyle = computed(() => {
+  return {
+    color: props.pageSetup.fthoraDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.fthoraDefaultStrokeWidth),
+    ...offsetStyle(
+      props.note.tertiaryFthoraOffsetX,
+      props.note.tertiaryFthoraOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const accidentalStyle = computed(() => {
+  return {
+    color: props.pageSetup.accidentalDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.accidentalDefaultStrokeWidth,
+    ),
+    ...offsetStyle(props.note.accidentalOffsetX, props.note.accidentalOffsetY),
+  } as StyleValue;
+});
+
+const secondaryAccidentalStyle = computed(() => {
+  return {
+    color: props.pageSetup.accidentalDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.accidentalDefaultStrokeWidth,
+    ),
+    ...offsetStyle(
+      props.note.secondaryAccidentalOffsetX,
+      props.note.secondaryAccidentalOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const tertiaryAccidentalStyle = computed(() => {
+  return {
+    color: props.pageSetup.accidentalDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.accidentalDefaultStrokeWidth,
+    ),
+    ...offsetStyle(
+      props.note.tertiaryAccidentalOffsetX,
+      props.note.tertiaryAccidentalOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const measureBarLeftStyle = computed(() => {
+  return {
+    color: props.pageSetup.measureBarDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.measureBarDefaultStrokeWidth,
+    ),
+    ...offsetStyle(
+      props.note.measureBarLeftOffsetX,
+      props.note.measureBarLeftOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const measureBarRightStyle = computed(() => {
+  return {
+    color: props.pageSetup.measureBarDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.measureBarDefaultStrokeWidth,
+    ),
+    ...offsetStyle(
+      props.note.measureBarRightOffsetX,
+      props.note.measureBarRightOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const measureNumberStyle = computed(() => {
+  return {
+    color: props.pageSetup.measureNumberDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.measureNumberDefaultStrokeWidth,
+    ),
+    ...offsetStyle(
+      props.note.measureNumberOffsetX,
+      props.note.measureNumberOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const noteIndicatorStyle = computed(() => {
+  return {
+    color: props.pageSetup.noteIndicatorDefaultColor,
+    webkitTextStrokeWidth: withZoom(
+      props.pageSetup.noteIndicatorDefaultStrokeWidth,
+    ),
+    ...offsetStyle(
+      props.note.noteIndicatorOffsetX,
+      props.note.noteIndicatorOffsetY,
+    ),
+  } as StyleValue;
+});
+
+const isonStyle = computed(() => {
+  return {
+    color: props.pageSetup.isonDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.isonDefaultStrokeWidth),
+    ...offsetStyle(props.note.isonOffsetX, props.note.computedIsonOffsetY),
+  } as StyleValue;
+});
+
+const timeStyle = computed(() => {
+  return offsetStyle(
+    props.note.timeNeumeOffsetX,
+    props.note.timeNeumeOffsetY,
+  ) as StyleValue;
+});
+
+const neumeStyle = computed(() => {
+  if (props.note.quantitativeNeume == QuantitativeNeume.Cross) {
     return {
-      TimeNeume,
-      VocalExpressionNeume,
-    };
-  },
+      color: props.pageSetup.crossDefaultColor,
+      webkitTextStrokeWidth: withZoom(props.pageSetup.crossDefaultStrokeWidth),
+    } as StyleValue;
+  } else if (props.note.quantitativeNeume == QuantitativeNeume.Breath) {
+    return {
+      color: props.pageSetup.breathDefaultColor,
+      webkitTextStrokeWidth: withZoom(props.pageSetup.breathDefaultStrokeWidth),
+    } as StyleValue;
+  }
 
-  computed: {
-    hasVocalExpressionNeume() {
-      return this.note.vocalExpressionNeume != null;
-    },
+  return {};
+});
 
-    hasTimeNeume() {
-      return this.note.timeNeume != null;
-    },
+const koronisStyle = computed(() => {
+  return {
+    color: props.pageSetup.koronisDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.koronisDefaultStrokeWidth),
+    ...offsetStyle(props.note.koronisOffsetX, props.note.koronisOffsetY),
+  } as StyleValue;
+});
 
-    hasGorgonNeume() {
-      return this.note.gorgonNeume != null;
-    },
+const stavrosStyle = computed(() => {
+  return {
+    color: props.pageSetup.crossDefaultColor,
+    webkitTextStrokeWidth: withZoom(props.pageSetup.crossDefaultStrokeWidth),
+    ...offsetStyle(props.note.stavrosOffsetX, props.note.stavrosOffsetY),
+  } as StyleValue;
+});
 
-    hasSecondaryGorgonNeume() {
-      return this.note.secondaryGorgonNeume != null;
-    },
+const vareiaStyle = computed(() => {
+  return offsetStyle(
+    props.note.vareiaOffsetX,
+    props.note.vareiaOffsetY,
+  ) as StyleValue;
+});
 
-    hasFthora() {
-      return this.note.fthora != null;
-    },
+const vocalExpressionStyle = computed(() => {
+  const style = offsetStyle(
+    props.note.vocalExpressionNeumeOffsetX,
+    props.note.vocalExpressionNeumeOffsetY,
+  ) as Partial<CSSStyleDeclaration>;
 
-    hasSecondaryFthora() {
-      return this.note.secondaryFthora != null;
-    },
+  if (
+    props.note.vocalExpressionNeume === VocalExpressionNeume.Heteron ||
+    props.note.vocalExpressionNeume ===
+      VocalExpressionNeume.HeteronConnecting ||
+    props.note.vocalExpressionNeume ===
+      VocalExpressionNeume.HeteronConnectingLong ||
+    props.note.vocalExpressionNeume === VocalExpressionNeume.Endofonon
+  ) {
+    style.color = props.pageSetup.heteronDefaultColor;
+    style.webkitTextStrokeWidth = withZoom(
+      props.pageSetup.heteronDefaultStrokeWidth,
+    );
+  }
 
-    hasTertiaryFthora() {
-      return this.note.tertiaryFthora != null;
-    },
+  return style;
+});
 
-    hasAccidental() {
-      return this.note.accidental != null;
-    },
-
-    hasSecondaryAccidental() {
-      return this.note.secondaryAccidental != null;
-    },
-
-    hasTertiaryAccidental() {
-      return this.note.tertiaryAccidental != null;
-    },
-
-    hasMeasureBarLeft() {
-      return (
-        this.note.measureBarLeft != null ||
-        this.note.computedMeasureBarLeft != null
-      );
-    },
-
-    hasMeasureBarRight() {
-      return (
-        this.note.measureBarRight != null ||
-        this.note.computedMeasureBarRight != null
-      );
-    },
-
-    getMeasureBarLeft() {
-      return this.note.measureBarLeft
-        ? this.note.measureBarLeft
-        : this.note.computedMeasureBarLeft;
-    },
-
-    getMeasureBarRight() {
-      return this.note.measureBarRight
-        ? this.note.measureBarRight
-        : this.note.computedMeasureBarRight;
-    },
-
-    isMeasureBarAbove() {
-      return (
-        this.note.measureBarLeft
-          ? this.note.measureBarLeft
-          : this.note.computedMeasureBarLeft
-      )?.endsWith('Above');
-    },
-
-    hasMeasureNumber() {
-      return this.note.measureNumber != null;
-    },
-
-    hasIson() {
-      return this.note.ison != null;
-    },
-
-    hasTie() {
-      return this.note.tie != null;
-    },
-
-    style() {
-      return {
-        fontFamily: this.pageSetup.neumeDefaultFontFamily,
-        fontSize: this.alternateLine
-          ? withZoom(this.pageSetup.alternateLineDefaultFontSize)
-          : withZoom(this.pageSetup.neumeDefaultFontSize),
-        color: this.alternateLine
-          ? this.pageSetup.alternateLineDefaultColor
-          : this.pageSetup.neumeDefaultColor,
-        webkitTextStrokeWidth: withZoom(this.pageSetup.neumeDefaultStrokeWidth),
-      } as StyleValue;
-    },
-
-    gorgonStyle() {
-      return {
-        color: this.pageSetup.gorgonDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.gorgonDefaultStrokeWidth,
-        ),
-        left:
-          this.note.gorgonNeumeOffsetX != null
-            ? `${this.note.gorgonNeumeOffsetX}em`
-            : undefined,
-        top:
-          this.note.gorgonNeumeOffsetY != null
-            ? `${this.note.gorgonNeumeOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    secondaryGorgonStyle() {
-      return {
-        color: this.pageSetup.gorgonDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.gorgonDefaultStrokeWidth,
-        ),
-        left:
-          this.note.secondaryGorgonNeumeOffsetX != null
-            ? `${this.note.secondaryGorgonNeumeOffsetX}em`
-            : undefined,
-        top:
-          this.note.secondaryGorgonNeumeOffsetY != null
-            ? `${this.note.secondaryGorgonNeumeOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    fthoraStyle() {
-      return {
-        color: this.pageSetup.fthoraDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.fthoraDefaultStrokeWidth,
-        ),
-        left:
-          this.note.fthoraOffsetX != null
-            ? `${this.note.fthoraOffsetX}em`
-            : undefined,
-        top:
-          this.note.fthoraOffsetY != null
-            ? `${this.note.fthoraOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    secondaryFthoraStyle() {
-      return {
-        color: this.pageSetup.fthoraDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.fthoraDefaultStrokeWidth,
-        ),
-        left:
-          this.note.secondaryFthoraOffsetX != null
-            ? `${this.note.secondaryFthoraOffsetX}em`
-            : undefined,
-        top:
-          this.note.secondaryFthoraOffsetY != null
-            ? `${this.note.secondaryFthoraOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    tertiaryFthoraStyle() {
-      return {
-        color: this.pageSetup.fthoraDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.fthoraDefaultStrokeWidth,
-        ),
-        left:
-          this.note.tertiaryFthoraOffsetX != null
-            ? `${this.note.tertiaryFthoraOffsetX}em`
-            : undefined,
-        top:
-          this.note.tertiaryFthoraOffsetY != null
-            ? `${this.note.tertiaryFthoraOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    accidentalStyle() {
-      return {
-        color: this.pageSetup.accidentalDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.accidentalDefaultStrokeWidth,
-        ),
-        left:
-          this.note.accidentalOffsetX != null
-            ? `${this.note.accidentalOffsetX}em`
-            : undefined,
-        top:
-          this.note.accidentalOffsetY != null
-            ? `${this.note.accidentalOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    secondaryAccidentalStyle() {
-      return {
-        color: this.pageSetup.accidentalDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.accidentalDefaultStrokeWidth,
-        ),
-        left:
-          this.note.secondaryAccidentalOffsetX != null
-            ? `${this.note.secondaryAccidentalOffsetX}em`
-            : undefined,
-        top:
-          this.note.secondaryAccidentalOffsetY != null
-            ? `${this.note.secondaryAccidentalOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    tertiaryAccidentalStyle() {
-      return {
-        color: this.pageSetup.accidentalDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.accidentalDefaultStrokeWidth,
-        ),
-        left:
-          this.note.tertiaryAccidentalOffsetX != null
-            ? `${this.note.tertiaryAccidentalOffsetX}em`
-            : undefined,
-        top:
-          this.note.tertiaryAccidentalOffsetY != null
-            ? `${this.note.tertiaryAccidentalOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    measureBarLeftStyle() {
-      return {
-        color: this.pageSetup.measureBarDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.measureBarDefaultStrokeWidth,
-        ),
-        left:
-          this.note.measureBarLeftOffsetX != null
-            ? `${this.note.measureBarLeftOffsetX}em`
-            : undefined,
-        top:
-          this.note.measureBarLeftOffsetY != null
-            ? `${this.note.measureBarLeftOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    measureBarRightStyle() {
-      return {
-        color: this.pageSetup.measureBarDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.measureBarDefaultStrokeWidth,
-        ),
-        left:
-          this.note.measureBarRightOffsetX != null
-            ? `${this.note.measureBarRightOffsetX}em`
-            : undefined,
-        top:
-          this.note.measureBarRightOffsetY != null
-            ? `${this.note.measureBarRightOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    measureNumberStyle() {
-      return {
-        color: this.pageSetup.measureNumberDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.measureNumberDefaultStrokeWidth,
-        ),
-        left:
-          this.note.measureNumberOffsetX != null
-            ? `${this.note.measureNumberOffsetX}em`
-            : undefined,
-        top:
-          this.note.measureNumberOffsetY != null
-            ? `${this.note.measureNumberOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    noteIndicatorStyle() {
-      return {
-        color: this.pageSetup.noteIndicatorDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.noteIndicatorDefaultStrokeWidth,
-        ),
-        left:
-          this.note.noteIndicatorOffsetX != null
-            ? `${this.note.noteIndicatorOffsetX}em`
-            : undefined,
-        top:
-          this.note.noteIndicatorOffsetY != null
-            ? `${this.note.noteIndicatorOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    isonStyle() {
-      return {
-        color: this.pageSetup.isonDefaultColor,
-        webkitTextStrokeWidth: withZoom(this.pageSetup.isonDefaultStrokeWidth),
-        left:
-          this.note.isonOffsetX != null
-            ? `${this.note.isonOffsetX}em`
-            : undefined,
-        top:
-          this.note.computedIsonOffsetY != null
-            ? `${this.note.computedIsonOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    timeStyle() {
-      return {
-        left:
-          this.note.timeNeumeOffsetX != null
-            ? `${this.note.timeNeumeOffsetX}em`
-            : undefined,
-        top:
-          this.note.timeNeumeOffsetY != null
-            ? `${this.note.timeNeumeOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    neumeStyle() {
-      if (this.note.quantitativeNeume == QuantitativeNeume.Cross) {
-        return {
-          color: this.pageSetup.crossDefaultColor,
-          webkitTextStrokeWidth: withZoom(
-            this.pageSetup.crossDefaultStrokeWidth,
-          ),
-        } as StyleValue;
-      } else if (this.note.quantitativeNeume == QuantitativeNeume.Breath) {
-        return {
-          color: this.pageSetup.breathDefaultColor,
-          webkitTextStrokeWidth: withZoom(
-            this.pageSetup.breathDefaultStrokeWidth,
-          ),
-        } as StyleValue;
-      }
-
-      return {};
-    },
-
-    koronisStyle() {
-      return {
-        color: this.pageSetup.koronisDefaultColor,
-        webkitTextStrokeWidth: withZoom(
-          this.pageSetup.koronisDefaultStrokeWidth,
-        ),
-        left:
-          this.note.koronisOffsetX != null
-            ? `${this.note.koronisOffsetX}em`
-            : undefined,
-        top:
-          this.note.koronisOffsetY != null
-            ? `${this.note.koronisOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    stavrosStyle() {
-      return {
-        color: this.pageSetup.crossDefaultColor,
-        webkitTextStrokeWidth: withZoom(this.pageSetup.crossDefaultStrokeWidth),
-        left:
-          this.note.stavrosOffsetX != null
-            ? `${this.note.stavrosOffsetX}em`
-            : undefined,
-        top:
-          this.note.stavrosOffsetY != null
-            ? `${this.note.stavrosOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    vareiaStyle() {
-      return {
-        left:
-          this.note.vareiaOffsetX != null
-            ? `${this.note.vareiaOffsetX}em`
-            : undefined,
-        top:
-          this.note.vareiaOffsetY != null
-            ? `${this.note.vareiaOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-
-    vocalExpressionStyle() {
-      const style = {
-        left:
-          this.note.vocalExpressionNeumeOffsetX != null
-            ? `${this.note.vocalExpressionNeumeOffsetX}em`
-            : undefined,
-        top:
-          this.note.vocalExpressionNeumeOffsetY != null
-            ? `${this.note.vocalExpressionNeumeOffsetY}em`
-            : undefined,
-      } as Partial<CSSStyleDeclaration>;
-
-      if (
-        this.note.vocalExpressionNeume === VocalExpressionNeume.Heteron ||
-        this.note.vocalExpressionNeume ===
-          VocalExpressionNeume.HeteronConnecting ||
-        this.note.vocalExpressionNeume ===
-          VocalExpressionNeume.HeteronConnectingLong ||
-        this.note.vocalExpressionNeume === VocalExpressionNeume.Endofonon
-      ) {
-        style.color = this.pageSetup.heteronDefaultColor;
-        style.webkitTextStrokeWidth = withZoom(
-          this.pageSetup.heteronDefaultStrokeWidth,
-        );
-      }
-
-      return style;
-    },
-
-    tieStyle() {
-      return {
-        left:
-          this.note.tieOffsetX != null
-            ? `${this.note.tieOffsetX}em`
-            : undefined,
-        top:
-          this.note.tieOffsetY != null
-            ? `${this.note.tieOffsetY}em`
-            : undefined,
-      } as StyleValue;
-    },
-  },
-
-  methods: {},
+const tieStyle = computed(() => {
+  return offsetStyle(
+    props.note.tieOffsetX,
+    props.note.tieOffsetY,
+  ) as StyleValue;
 });
 </script>
 

--- a/src/components/NeumeBoxTempo.vue
+++ b/src/components/NeumeBoxTempo.vue
@@ -12,43 +12,33 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, PropType, StyleValue } from 'vue';
 
 import Neume from '@/components/NeumeGlyph.vue';
 import { TempoElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { Neume },
-  props: {
-    neume: {
-      type: Object as PropType<TempoElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const props = defineProps({
+  neume: {
+    type: Object as PropType<TempoElement>,
+    required: true,
   },
-  emits: ['select-single', 'select-range'],
-
-  data() {
-    return {};
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
+});
 
-  computed: {
-    style() {
-      return {
-        color: this.pageSetup.tempoDefaultColor,
-        fontSize: withZoom(this.pageSetup.neumeDefaultFontSize),
-        webkitTextStrokeWidth: withZoom(this.pageSetup.tempoDefaultStrokeWidth),
-      } as StyleValue;
-    },
-  },
+defineEmits(['select-single', 'select-range']);
 
-  methods: {},
+const style = computed(() => {
+  return {
+    color: props.pageSetup.tempoDefaultColor,
+    fontSize: withZoom(props.pageSetup.neumeDefaultFontSize),
+    webkitTextStrokeWidth: withZoom(props.pageSetup.tempoDefaultStrokeWidth),
+  } as StyleValue;
 });
 </script>
 

--- a/src/components/NeumeGlyph.vue
+++ b/src/components/NeumeGlyph.vue
@@ -2,76 +2,63 @@
   <span class="neume" :style="style">{{ text }}</span>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, PropType, StyleValue } from 'vue';
 
 import { ScoreElementOffset } from '@/models/Element';
 import { Neume as NeumeType } from '@/models/Neumes';
 import { NeumeMappingService } from '@/services/NeumeMappingService';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: {},
-  props: {
-    neume: {
-      type: String as PropType<NeumeType>,
-      required: true,
-    },
-    offset: {
-      type: Object as PropType<ScoreElementOffset>,
-      default: undefined,
-    },
-    fontFamily: {
-      type: String,
-      default: undefined,
-    },
+defineEmits(['update']);
+const props = defineProps({
+  neume: {
+    type: String as PropType<NeumeType>,
+    required: true,
   },
-  emits: ['update'],
-
-  data() {
-    return {};
+  offset: {
+    type: Object as PropType<ScoreElementOffset>,
+    default: undefined,
   },
-
-  computed: {
-    mapping() {
-      let mapping = NeumeMappingService.getMapping(this.neume);
-
-      if (!mapping) {
-        console.warn('Could not find mapping for neume ' + this.neume);
-        mapping = {
-          text: '?',
-          glyphName: 'ison',
-        };
-      }
-
-      return mapping;
-    },
-
-    text() {
-      return this.mapping.text;
-    },
-
-    style() {
-      const style = {} as Partial<CSSStyleDeclaration>;
-
-      if (this.fontFamily != null) {
-        style.fontFamily = this.fontFamily;
-      }
-
-      if (this.mapping.salt != null) {
-        style.fontFeatureSettings = `"salt" ${this.mapping.salt}`;
-      }
-
-      if (this.offset) {
-        style.left = withZoom(this.offset.x);
-        style.top = withZoom(this.offset.y);
-      }
-
-      return style as StyleValue;
-    },
+  fontFamily: {
+    type: String,
+    default: undefined,
   },
+});
 
-  methods: {},
+const mapping = computed(() => {
+  let mapping = NeumeMappingService.getMapping(props.neume);
+
+  if (!mapping) {
+    console.warn('Could not find mapping for neume ' + props.neume);
+    mapping = {
+      text: '?',
+      glyphName: 'ison',
+    };
+  }
+
+  return mapping;
+});
+
+const text = computed(() => mapping.value.text);
+
+const style = computed(() => {
+  const style = {} as Partial<CSSStyleDeclaration>;
+
+  if (props.fontFamily != null) {
+    style.fontFamily = props.fontFamily;
+  }
+
+  if (mapping.value.salt != null) {
+    style.fontFeatureSettings = `"salt" ${mapping.value.salt}`;
+  }
+
+  if (props.offset) {
+    style.left = withZoom(props.offset.x);
+    style.top = withZoom(props.offset.y);
+  }
+
+  return style as StyleValue;
 });
 </script>
 

--- a/src/components/NeumeSelector.vue
+++ b/src/components/NeumeSelector.vue
@@ -379,8 +379,9 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { PropType, ref } from 'vue';
 
 import Neume from '@/components/NeumeGlyph.vue';
 import { getQuantitativeNeumeLabelSelector } from '@/models/NeumeI18nMappings';
@@ -506,221 +507,190 @@ const vareiaDottedMenuItems: QuantitativeNeume[] = [
   QuantitativeNeume.VareiaDotted,
 ];
 
-export default defineComponent({
-  components: { Neume },
-  props: {
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    neumeKeyboard: {
-      type: Object as PropType<NeumeKeyboard>,
-      required: true,
-    },
+const props = defineProps({
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-  emits: ['select-quantitative-neume'],
-
-  data() {
-    return {
-      QuantitativeNeume,
-
-      ascendingNeumes,
-      descendingNeumes,
-      ascendingNeumesWithPetasti,
-      combinationNeumes,
-      vareiaDottedMenuItems,
-      secondaryGorgonMenuItems,
-      secondaryGorgonMenuItemsDown,
-
-      showHyporoeKentemataMenu: false,
-      showIsonKentemataMenu: false,
-      showApostrophosKentemataMenu: false,
-      showElaphronKentemataMenu: false,
-      showElaphronApostrophosKentemataMenu: false,
-      showRunningElaphronKentemataMenu: false,
-      showHamiliKentemataMenu: false,
-      showVareiaDottedMenu: false,
-      selectedSecondaryGorgon: null as SecondaryGorgonMenuItem | null,
-      selectedVareiaDotted: null as QuantitativeNeume | null,
-    };
-  },
-
-  computed: {},
-
-  methods: {
-    openHyporoeKentemataMenu() {
-      this.showHyporoeKentemataMenu = true;
-      window.addEventListener('mouseup', this.onHyporoeMouseUp);
-    },
-
-    openIsonKentemataMenu() {
-      this.showIsonKentemataMenu = true;
-      window.addEventListener('mouseup', this.onIsonKentemataMouseUp);
-    },
-
-    openApostrophosKentemataMenu() {
-      this.showApostrophosKentemataMenu = true;
-      window.addEventListener('mouseup', this.onApostrophosKentemataMouseUp);
-    },
-
-    openElaphronKentemataMenu() {
-      this.showElaphronKentemataMenu = true;
-      window.addEventListener('mouseup', this.onElaphronKentemataMouseUp);
-    },
-
-    openElaphronApostrophosKentemataMenu() {
-      this.showElaphronApostrophosKentemataMenu = true;
-      window.addEventListener(
-        'mouseup',
-        this.onElaphronApostrophosKentemataMouseUp,
-      );
-    },
-
-    openRunningElaphronKentemataMenu() {
-      this.showRunningElaphronKentemataMenu = true;
-      window.addEventListener(
-        'mouseup',
-        this.onRunningElaphronKentemataMouseUp,
-      );
-    },
-
-    openHamiliKentemataMenu() {
-      this.showHamiliKentemataMenu = true;
-      window.addEventListener('mouseup', this.onHamiliKentemataMouseUp);
-    },
-
-    onHyporoeMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusHyporoePlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showHyporoeKentemataMenu = false;
-
-      window.removeEventListener('mouseup', this.onHyporoeMouseUp);
-    },
-
-    onIsonKentemataMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusIsonPlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showIsonKentemataMenu = false;
-
-      window.removeEventListener('mouseup', this.onIsonKentemataMouseUp);
-    },
-
-    onApostrophosKentemataMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusApostrophosPlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showApostrophosKentemataMenu = false;
-
-      window.removeEventListener('mouseup', this.onApostrophosKentemataMouseUp);
-    },
-
-    onElaphronKentemataMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusElaphronPlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showElaphronKentemataMenu = false;
-
-      window.removeEventListener('mouseup', this.onElaphronKentemataMouseUp);
-    },
-
-    onElaphronApostrophosKentemataMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showElaphronApostrophosKentemataMenu = false;
-
-      window.removeEventListener(
-        'mouseup',
-        this.onElaphronApostrophosKentemataMouseUp,
-      );
-    },
-
-    onRunningElaphronKentemataMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showRunningElaphronKentemataMenu = false;
-
-      window.removeEventListener(
-        'mouseup',
-        this.onRunningElaphronKentemataMouseUp,
-      );
-    },
-
-    onHamiliKentemataMouseUp() {
-      if (this.selectedSecondaryGorgon) {
-        this.$emit(
-          'select-quantitative-neume',
-          QuantitativeNeume.OligonPlusHamiliPlusKentemata,
-          this.selectedSecondaryGorgon.gorgon,
-        );
-      }
-
-      this.showHamiliKentemataMenu = false;
-
-      window.removeEventListener('mouseup', this.onHamiliKentemataMouseUp);
-    },
-
-    openVareiaDottedMenu() {
-      this.showVareiaDottedMenu = true;
-      window.addEventListener('mouseup', this.onVareiaDottedMouseUp);
-    },
-
-    onVareiaDottedMouseUp() {
-      if (this.selectedVareiaDotted) {
-        this.$emit('select-quantitative-neume', this.selectedVareiaDotted);
-      }
-
-      this.showVareiaDottedMenu = false;
-
-      window.removeEventListener('mouseup', this.onVareiaDottedMouseUp);
-    },
-
-    tooltip(neume: QuantitativeNeume) {
-      const displayName = getQuantitativeNeumeLabelSelector(neume);
-      const mapping = this.neumeKeyboard.findMappingForNeume(neume);
-      if (mapping) {
-        return `${this.$t(displayName, { ns: 'model' })} (${this.neumeKeyboard.generateTooltip(
-          mapping,
-        )})`;
-      } else {
-        return `${this.$t(displayName, { ns: 'model' })}`;
-      }
-    },
+  neumeKeyboard: {
+    type: Object as PropType<NeumeKeyboard>,
+    required: true,
   },
 });
+
+const emit = defineEmits(['select-quantitative-neume']);
+const { t } = useTranslation();
+
+const showHyporoeKentemataMenu = ref(false);
+const showIsonKentemataMenu = ref(false);
+const showApostrophosKentemataMenu = ref(false);
+const showElaphronKentemataMenu = ref(false);
+const showElaphronApostrophosKentemataMenu = ref(false);
+const showRunningElaphronKentemataMenu = ref(false);
+const showHamiliKentemataMenu = ref(false);
+const showVareiaDottedMenu = ref(false);
+const selectedSecondaryGorgon = ref<SecondaryGorgonMenuItem | null>(null);
+const selectedVareiaDotted = ref<QuantitativeNeume | null>(null);
+
+function openHyporoeKentemataMenu() {
+  showHyporoeKentemataMenu.value = true;
+  window.addEventListener('mouseup', onHyporoeMouseUp);
+}
+
+function openIsonKentemataMenu() {
+  showIsonKentemataMenu.value = true;
+  window.addEventListener('mouseup', onIsonKentemataMouseUp);
+}
+
+function openApostrophosKentemataMenu() {
+  showApostrophosKentemataMenu.value = true;
+  window.addEventListener('mouseup', onApostrophosKentemataMouseUp);
+}
+
+function openElaphronKentemataMenu() {
+  showElaphronKentemataMenu.value = true;
+  window.addEventListener('mouseup', onElaphronKentemataMouseUp);
+}
+
+function openElaphronApostrophosKentemataMenu() {
+  showElaphronApostrophosKentemataMenu.value = true;
+  window.addEventListener('mouseup', onElaphronApostrophosKentemataMouseUp);
+}
+
+function openRunningElaphronKentemataMenu() {
+  showRunningElaphronKentemataMenu.value = true;
+  window.addEventListener('mouseup', onRunningElaphronKentemataMouseUp);
+}
+
+function openHamiliKentemataMenu() {
+  showHamiliKentemataMenu.value = true;
+  window.addEventListener('mouseup', onHamiliKentemataMouseUp);
+}
+
+function onHyporoeMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusHyporoePlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showHyporoeKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onHyporoeMouseUp);
+}
+
+function onIsonKentemataMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusIsonPlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showIsonKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onIsonKentemataMouseUp);
+}
+
+function onApostrophosKentemataMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusApostrophosPlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showApostrophosKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onApostrophosKentemataMouseUp);
+}
+
+function onElaphronKentemataMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusElaphronPlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showElaphronKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onElaphronKentemataMouseUp);
+}
+
+function onElaphronApostrophosKentemataMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showElaphronApostrophosKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onElaphronApostrophosKentemataMouseUp);
+}
+
+function onRunningElaphronKentemataMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showRunningElaphronKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onRunningElaphronKentemataMouseUp);
+}
+
+function onHamiliKentemataMouseUp() {
+  if (selectedSecondaryGorgon.value) {
+    emit(
+      'select-quantitative-neume',
+      QuantitativeNeume.OligonPlusHamiliPlusKentemata,
+      selectedSecondaryGorgon.value.gorgon,
+    );
+  }
+
+  showHamiliKentemataMenu.value = false;
+
+  window.removeEventListener('mouseup', onHamiliKentemataMouseUp);
+}
+
+function openVareiaDottedMenu() {
+  showVareiaDottedMenu.value = true;
+  window.addEventListener('mouseup', onVareiaDottedMouseUp);
+}
+
+function onVareiaDottedMouseUp() {
+  if (selectedVareiaDotted.value) {
+    emit('select-quantitative-neume', selectedVareiaDotted.value);
+  }
+
+  showVareiaDottedMenu.value = false;
+
+  window.removeEventListener('mouseup', onVareiaDottedMouseUp);
+}
+
+function tooltip(neume: QuantitativeNeume) {
+  const displayName = getQuantitativeNeumeLabelSelector(neume);
+  const mapping = props.neumeKeyboard.findMappingForNeume(neume);
+  if (mapping) {
+    return `${t(displayName, { ns: 'model' })} (${props.neumeKeyboard.generateTooltip(
+      mapping,
+    )})`;
+  } else {
+    return `${t(displayName, { ns: 'model' })}`;
+  }
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -10,28 +10,28 @@
             <div
               class="nav-item"
               :class="{ active: currentSection === 'pageSizeRef' }"
-              @click="scrollTo($refs.pageSizeRef as HTMLElement)"
+              @click="scrollTo(pageSizeRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.pageSize, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'marginsRef' }"
-              @click="scrollTo($refs.marginsRef as HTMLElement)"
+              @click="scrollTo(marginsRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.margins, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'spacingRef' }"
-              @click="scrollTo($refs.spacingRef as HTMLElement)"
+              @click="scrollTo(spacingRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.spacing, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'headersFootersRef' }"
-              @click="scrollTo($refs.headersFootersRef as HTMLElement)"
+              @click="scrollTo(headersFootersRef)"
             >
               {{
                 $t(($) => $.dialog.pageSetup.headersAndFooters, {
@@ -42,7 +42,7 @@
             <div
               class="nav-item"
               :class="{ active: currentSection === 'miscellaneousRef' }"
-              @click="scrollTo($refs.miscellaneousRef as HTMLElement)"
+              @click="scrollTo(miscellaneousRef)"
             >
               {{
                 $t(($) => $.dialog.pageSetup.miscellaneous, { ns: 'dialog' })
@@ -51,42 +51,42 @@
             <div
               class="nav-item"
               :class="{ active: currentSection === 'dropCapsRef' }"
-              @click="scrollTo($refs.dropCapsRef as HTMLElement)"
+              @click="scrollTo(dropCapsRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.dropCaps, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'lyricsRef' }"
-              @click="scrollTo($refs.lyricsRef as HTMLElement)"
+              @click="scrollTo(lyricsRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.lyrics, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'textBoxesRef' }"
-              @click="scrollTo($refs.textBoxesRef as HTMLElement)"
+              @click="scrollTo(textBoxesRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.textBoxes, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'modeKeysRef' }"
-              @click="scrollTo($refs.modeKeysRef as HTMLElement)"
+              @click="scrollTo(modeKeysRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.modeKeys, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'neumesRef' }"
-              @click="scrollTo($refs.neumesRef as HTMLElement)"
+              @click="scrollTo(neumesRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.neumes, { ns: 'dialog' }) }}
             </div>
             <div
               class="nav-item"
               :class="{ active: currentSection === 'neumeStylesRef' }"
-              @click="scrollTo($refs.neumeStylesRef as HTMLElement)"
+              @click="scrollTo(neumeStylesRef)"
             >
               {{ $t(($) => $.dialog.pageSetup.neumeStyles, { ns: 'dialog' }) }}
             </div>
@@ -94,7 +94,7 @@
           <div
             ref="rightPaneRef"
             class="right-pane"
-            @scroll="updateCurrentSectionThrottled!"
+            @scroll="updateCurrentSectionThrottled"
           >
             <div ref="pageSizeRef" class="subheader">
               {{ $t(($) => $.dialog.pageSetup.pageSize, { ns: 'dialog' }) }}
@@ -1826,10 +1826,17 @@
   </ModalDialog>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { SelectorParam } from 'i18next';
 import { throttle } from 'throttle-debounce';
-import { defineComponent, PropType } from 'vue';
+import {
+  computed,
+  getCurrentInstance,
+  onBeforeUnmount,
+  PropType,
+  ref,
+  useTemplateRef,
+} from 'vue';
 
 import ColorPicker from '@/components/ColorPicker.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
@@ -1845,7 +1852,6 @@ import {
   NoteElement,
   TempoElement,
 } from '@/models/Element';
-import { Accidental, QuantitativeNeume } from '@/models/Neumes';
 import { PageSetup, PageSize, pageSizes } from '@/models/PageSetup';
 import { PageSetup as PageSetup_v1 } from '@/models/save/v1/PageSetup';
 import { SaveService } from '@/services/SaveService';
@@ -1924,504 +1930,481 @@ const previewNeumes = [
   },
 ] as any;
 
-export default defineComponent({
-  components: {
-    ModalDialog,
-    ColorPicker,
-    InputUnit,
-    InputStrokeWidth,
-    InputFontSize,
-    NeumeBoxSyllable,
-    NeumeBoxMartyria,
-    NeumeBoxTempo,
+const sectionIds = [
+  'dropCapsRef',
+  'headersFootersRef',
+  'lyricsRef',
+  'marginsRef',
+  'miscellaneousRef',
+  'modeKeysRef',
+  'neumesRef',
+  'neumeStylesRef',
+  'pageSizeRef',
+  'textBoxesRef',
+  'spacingRef',
+] as const;
+
+type SectionRefName = (typeof sectionIds)[number];
+
+const emit = defineEmits<{
+  close: [];
+  update: [pageSetup: PageSetup];
+}>();
+const instance = getCurrentInstance();
+
+const props = defineProps({
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-  props: {
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    fonts: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
-  },
-  emits: ['close', 'update'],
-
-  data() {
-    return {
-      form: new PageSetup(),
-      currentSection: 'pageSizeRef',
-      neumeBulkColor: '#000000',
-
-      QuantitativeNeume,
-      Accidental,
-      NeumeColorOptions,
-
-      MartyriaElement,
-      NoteElement,
-      TempoElement,
-
-      previewNeumes,
-
-      selectedNeumeColorOptions: [] as NeumeColorOptions[],
-
-      updateCurrentSectionThrottled: null as (() => void) | null,
-    };
-  },
-
-  computed: {
-    topMargin() {
-      return this.toDisplayUnit(this.form.topMargin).toFixed(2);
-    },
-
-    bottomMargin() {
-      return this.toDisplayUnit(this.form.bottomMargin).toFixed(2);
-    },
-
-    leftMargin() {
-      return this.toDisplayUnit(this.form.leftMargin).toFixed(2);
-    },
-
-    rightMargin() {
-      return this.toDisplayUnit(this.form.rightMargin).toFixed(2);
-    },
-
-    headerMargin() {
-      return this.toDisplayUnit(this.form.headerMargin).toFixed(2);
-    },
-
-    footerMargin() {
-      return this.toDisplayUnit(this.form.footerMargin).toFixed(2);
-    },
-
-    lyricsVerticalOffset() {
-      return this.toDisplayUnit(this.form.lyricsVerticalOffset).toFixed(3);
-    },
-
-    lyricsMinimumSpacing() {
-      return this.toDisplayUnit(this.form.lyricsMinimumSpacing).toFixed(3);
-    },
-
-    lineHeight() {
-      return this.toDisplayUnit(this.form.lineHeight).toFixed(3);
-    },
-
-    hyphenSpacing() {
-      return this.toDisplayUnit(this.form.hyphenSpacing).toFixed(3);
-    },
-    dropCapFontFamilies() {
-      return [
-        'Source Serif',
-        'GFS Didot',
-        'Noto Naskh Arabic',
-        'Old Standard',
-        ...this.fonts,
-      ];
-    },
-
-    lyricsFontFamilies() {
-      return [
-        'Source Serif',
-        'GFS Didot',
-        'Noto Naskh Arabic',
-        'Old Standard',
-        ...this.fonts,
-      ];
-    },
-
-    neumeFontFamilies() {
-      if (this.form.melkiteRtl) {
-        return [{ displayName: 'EZ Psaltica RTL', value: 'NeanesRTL' }];
-      } else {
-        return [
-          { displayName: 'EZ Psaltica', value: 'Neanes' },
-          { displayName: 'Stathis Series', value: 'NeanesStathisSeries' },
-        ];
-      }
-    },
-
-    neumeSpacingMax() {
-      return Math.round(this.toDisplayUnit(this.form.pageWidth));
-    },
-
-    heightAdjustmentMin() {
-      return -Math.round(Unit.fromPt(this.pageSetup.pageHeight));
-    },
-
-    heightAdjustmentMax() {
-      return Unit.toPt(this.pageSetup.pageHeight);
-    },
-
-    pageSizes() {
-      return pageSizes;
-    },
-
-    pageSize: {
-      get() {
-        return this.form.pageSize;
-      },
-      set(value: PageSize) {
-        this.form.pageSize = value;
-
-        this.updatePageSize();
-      },
-    },
-
-    landscape: {
-      get() {
-        return this.form.landscape;
-      },
-      set(value: boolean) {
-        this.form.landscape = value;
-
-        this.updatePageSize();
-      },
-    },
-
-    marginUnitLabel(): SelectorParam<'dialog'> | undefined {
-      switch (this.form.pageSizeUnit) {
-        case 'pc':
-          return ($) => $.dialog.pageSetup.pc;
-        case 'pt':
-          return ($) => $.dialog.pageSetup.pt;
-        case 'cm':
-          return ($) => $.dialog.pageSetup.cm;
-        case 'mm':
-          return ($) => $.dialog.pageSetup.mm;
-        case 'in':
-          return ($) => $.dialog.pageSetup.in;
-        default:
-          console.warn(`Unknown page size unit: ${this.form.pageSizeUnit}`);
-          return undefined;
-      }
-    },
-
-    marginStep() {
-      switch (this.form.pageSizeUnit) {
-        case 'pc':
-          return 1;
-        case 'pt':
-          return 1;
-        case 'cm':
-          return 0.1;
-        case 'mm':
-          return 1;
-        case 'in':
-          return 0.1;
-        default:
-          console.warn(`Unknown page size unit: ${this.form.pageSizeUnit}`);
-          return 1;
-      }
-    },
-
-    spacingStep() {
-      switch (this.form.pageSizeUnit) {
-        case 'pc':
-          return 0.05;
-        case 'pt':
-          return 0.5;
-        case 'cm':
-          return 0.01;
-        case 'mm':
-          return 0.1;
-        case 'in':
-          return 0.005;
-        default:
-          console.warn(`Unknown page size unit: ${this.form.pageSizeUnit}`);
-          return 1;
-      }
-    },
-  },
-
-  created() {
-    Object.assign(this.form, this.pageSetup);
-
-    window.addEventListener('keydown', this.onKeyDown);
-
-    this.updateCurrentSectionThrottled = throttle(
-      50,
-      this.updateCurrentSection,
-    );
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  methods: {
-    toDisplayUnit(value: number) {
-      switch (this.form.pageSizeUnit) {
-        case 'pc':
-          return Unit.toPc(value);
-        case 'pt':
-          return Unit.toPt(value);
-        case 'cm':
-          return Unit.toCm(value);
-        case 'mm':
-          return Unit.toMm(value);
-        case 'in':
-          return Unit.toInch(value);
-        default:
-          console.warn(`Unknown page size unit: ${this.form.pageSizeUnit}`);
-          return 0;
-      }
-    },
-
-    toStorageUnit(value: number) {
-      switch (this.form.pageSizeUnit) {
-        case 'pc':
-          return Unit.fromPc(value);
-        case 'pt':
-          return Unit.fromPt(value);
-        case 'cm':
-          return Unit.fromCm(value);
-        case 'mm':
-          return Unit.fromMm(value);
-        case 'in':
-          return Unit.fromInch(value);
-        default:
-          console.warn(`Unknown page size unit: ${this.form.pageSizeUnit}`);
-          return 0;
-      }
-    },
-    updateCurrentSection() {
-      const scrollParentTop = (
-        this.$refs.rightPaneRef as HTMLElement
-      ).getBoundingClientRect().top;
-
-      let closest: string | null = null;
-      let closestDistance = Infinity;
-
-      const sectionIds = [
-        'dropCapsRef',
-        'headersFootersRef',
-        'lyricsRef',
-        'marginsRef',
-        'miscellaneousRef',
-        'modeKeysRef',
-        'neumesRef',
-        'neumeStylesRef',
-        'pageSizeRef',
-        'textBoxesRef',
-        'spacingRef',
-      ];
-
-      for (const id of sectionIds) {
-        const el = this.$refs[id] as HTMLElement;
-
-        const top = Math.abs(el.getBoundingClientRect().top - scrollParentTop);
-
-        if (top < closestDistance) {
-          closest = id;
-          closestDistance = top;
-        }
-      }
-
-      if (closest !== null) {
-        this.currentSection = closest;
-      }
-    },
-
-    changeNeumeColorInBulk() {
-      for (const neume of this.selectedNeumeColorOptions) {
-        switch (neume) {
-          case NeumeColorOptions.Accidentals:
-            this.form.accidentalDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Fthoras:
-            this.form.fthoraDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Gorgons:
-            this.form.gorgonDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Heterons:
-            this.form.heteronDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Ison:
-            this.form.isonDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Koronis:
-            this.form.koronisDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Martyria:
-            this.form.martyriaDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.MeasureBars:
-            this.form.measureBarDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.MeasureNumbers:
-            this.form.accidentalDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.NoteIndicators:
-            this.form.noteIndicatorDefaultColor = this.neumeBulkColor;
-            break;
-          case NeumeColorOptions.Tempos:
-            this.form.tempoDefaultColor = this.neumeBulkColor;
-            break;
-        }
-      }
-    },
-    updateTopMargin(value: number) {
-      this.form.topMargin = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.pageHeight - this.form.bottomMargin - Unit.fromInch(0.5),
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateBottomMargin(value: number) {
-      this.form.bottomMargin = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.pageHeight - this.form.topMargin - Unit.fromInch(0.5),
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateLeftMargin(value: number) {
-      this.form.leftMargin = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.pageWidth - this.form.rightMargin - Unit.fromInch(0.5),
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateRightMargin(value: number) {
-      this.form.rightMargin = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.pageWidth - this.form.leftMargin - Unit.fromInch(0.5),
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateHeaderMargin(value: number) {
-      this.form.headerMargin = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.innerPageHeight,
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateFooterMargin(value: number) {
-      this.form.footerMargin = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.innerPageHeight,
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateLyricsVerticalOffset(value: number) {
-      this.form.lyricsVerticalOffset = Math.min(
-        this.toStorageUnit(value),
-        this.form.innerPageHeight -
-          this.form.lyricsDefaultFontSize -
-          this.form.neumeDefaultFontSize,
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateLyricsMinimumSpacing(value: number) {
-      this.form.lyricsMinimumSpacing = Math.min(
-        this.toStorageUnit(value),
-        this.form.innerPageWidth,
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateLineHeight(value: number) {
-      this.form.lineHeight = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.innerPageHeight,
-      );
-
-      this.$forceUpdate();
-    },
-
-    updateHyphenSpacing(value: number) {
-      this.form.hyphenSpacing = Math.min(
-        Math.max(this.toStorageUnit(value), 0),
-        this.form.innerPageWidth,
-      );
-
-      this.$forceUpdate();
-    },
-
-    onChangeMelkiteRtl() {
-      this.form.neumeDefaultFontFamily = this.form.melkiteRtl
-        ? 'NeanesRTL'
-        : 'Neanes';
-    },
-
-    isSyllableElement(elementType: ElementType) {
-      return elementType == ElementType.Note;
-    },
-
-    isMartyriaElement(elementType: ElementType) {
-      return elementType == ElementType.Martyria;
-    },
-
-    isTempoElement(elementType: ElementType) {
-      return elementType == ElementType.Tempo;
-    },
-
-    onKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        this.$emit('close');
-      }
-    },
-
-    updatePageSize() {
-      if (this.form.pageSize === 'Custom') {
-        if (this.form.landscape) {
-          this.form.pageWidth = this.form.pageHeightCustom;
-          this.form.pageHeight = this.form.pageWidthCustom;
-        } else {
-          this.form.pageWidth = this.form.pageWidthCustom;
-          this.form.pageHeight = this.form.pageHeightCustom;
-        }
-        return;
-      }
-
-      const pageSize = pageSizes.find((x) => x.name === this.form.pageSize);
-      if (pageSize) {
-        if (this.form.landscape) {
-          this.form.pageWidth = pageSize.height;
-          this.form.pageHeight = pageSize.width;
-        } else {
-          this.form.pageWidth = pageSize.width;
-          this.form.pageHeight = pageSize.height;
-        }
-      }
-    },
-
-    updatePageSetup() {
-      this.$emit('update', this.form);
-      this.$emit('close');
-    },
-
-    saveAsDefault() {
-      const defaults = new PageSetup_v1();
-      SaveService.SavePageSetup(defaults, this.form);
-
-      localStorage.setItem('pageSetupDefault', JSON.stringify(defaults));
-    },
-
-    resetToSystemDefaults() {
-      this.form = new PageSetup();
-    },
-
-    scrollTo(el: HTMLElement) {
-      el.scrollIntoView({ behavior: 'instant', block: 'start' });
-    },
+  fonts: {
+    type: Array as PropType<string[]>,
+    required: true,
   },
 });
+
+const form = ref(new PageSetup());
+const currentSection = ref<SectionRefName>('pageSizeRef');
+const neumeBulkColor = ref('#000000');
+const selectedNeumeColorOptions = ref<NeumeColorOptions[]>([]);
+
+const rightPaneRef = useTemplateRef<HTMLElement>('rightPaneRef');
+const pageSizeRef = useTemplateRef<HTMLElement>('pageSizeRef');
+const marginsRef = useTemplateRef<HTMLElement>('marginsRef');
+const spacingRef = useTemplateRef<HTMLElement>('spacingRef');
+const headersFootersRef = useTemplateRef<HTMLElement>('headersFootersRef');
+const miscellaneousRef = useTemplateRef<HTMLElement>('miscellaneousRef');
+const dropCapsRef = useTemplateRef<HTMLElement>('dropCapsRef');
+const lyricsRef = useTemplateRef<HTMLElement>('lyricsRef');
+const textBoxesRef = useTemplateRef<HTMLElement>('textBoxesRef');
+const modeKeysRef = useTemplateRef<HTMLElement>('modeKeysRef');
+const neumesRef = useTemplateRef<HTMLElement>('neumesRef');
+const neumeStylesRef = useTemplateRef<HTMLElement>('neumeStylesRef');
+
+const sectionRefs = {
+  dropCapsRef,
+  headersFootersRef,
+  lyricsRef,
+  marginsRef,
+  miscellaneousRef,
+  modeKeysRef,
+  neumesRef,
+  neumeStylesRef,
+  pageSizeRef,
+  textBoxesRef,
+  spacingRef,
+};
+
+const topMargin = computed(() =>
+  toDisplayUnit(form.value.topMargin).toFixed(2),
+);
+const bottomMargin = computed(() =>
+  toDisplayUnit(form.value.bottomMargin).toFixed(2),
+);
+const leftMargin = computed(() =>
+  toDisplayUnit(form.value.leftMargin).toFixed(2),
+);
+const rightMargin = computed(() =>
+  toDisplayUnit(form.value.rightMargin).toFixed(2),
+);
+const headerMargin = computed(() =>
+  toDisplayUnit(form.value.headerMargin).toFixed(2),
+);
+const footerMargin = computed(() =>
+  toDisplayUnit(form.value.footerMargin).toFixed(2),
+);
+const lyricsVerticalOffset = computed(() =>
+  toDisplayUnit(form.value.lyricsVerticalOffset).toFixed(3),
+);
+const lyricsMinimumSpacing = computed(() =>
+  toDisplayUnit(form.value.lyricsMinimumSpacing).toFixed(3),
+);
+const lineHeight = computed(() =>
+  toDisplayUnit(form.value.lineHeight).toFixed(3),
+);
+const hyphenSpacing = computed(() =>
+  toDisplayUnit(form.value.hyphenSpacing).toFixed(3),
+);
+const dropCapFontFamilies = computed(() => [
+  'Source Serif',
+  'GFS Didot',
+  'Noto Naskh Arabic',
+  'Old Standard',
+  ...props.fonts,
+]);
+const lyricsFontFamilies = computed(() => [
+  'Source Serif',
+  'GFS Didot',
+  'Noto Naskh Arabic',
+  'Old Standard',
+  ...props.fonts,
+]);
+const neumeFontFamilies = computed(() => {
+  if (form.value.melkiteRtl) {
+    return [{ displayName: 'EZ Psaltica RTL', value: 'NeanesRTL' }];
+  } else {
+    return [
+      { displayName: 'EZ Psaltica', value: 'Neanes' },
+      { displayName: 'Stathis Series', value: 'NeanesStathisSeries' },
+    ];
+  }
+});
+const neumeSpacingMax = computed(() =>
+  Math.round(toDisplayUnit(form.value.pageWidth)),
+);
+const heightAdjustmentMin = computed(
+  () => -Math.round(Unit.fromPt(props.pageSetup.pageHeight)),
+);
+const heightAdjustmentMax = computed(() =>
+  Unit.toPt(props.pageSetup.pageHeight),
+);
+const pageSize = computed({
+  get: () => form.value.pageSize,
+  set: (value: PageSize) => {
+    form.value.pageSize = value;
+    updatePageSize();
+  },
+});
+const landscape = computed({
+  get: () => form.value.landscape,
+  set: (value: boolean) => {
+    form.value.landscape = value;
+    updatePageSize();
+  },
+});
+const marginUnitLabel = computed<SelectorParam<'dialog'> | undefined>(() => {
+  switch (form.value.pageSizeUnit) {
+    case 'pc':
+      return ($) => $.dialog.pageSetup.pc;
+    case 'pt':
+      return ($) => $.dialog.pageSetup.pt;
+    case 'cm':
+      return ($) => $.dialog.pageSetup.cm;
+    case 'mm':
+      return ($) => $.dialog.pageSetup.mm;
+    case 'in':
+      return ($) => $.dialog.pageSetup.in;
+    default:
+      console.warn(`Unknown page size unit: ${form.value.pageSizeUnit}`);
+      return undefined;
+  }
+});
+const marginStep = computed(() => {
+  switch (form.value.pageSizeUnit) {
+    case 'pc':
+      return 1;
+    case 'pt':
+      return 1;
+    case 'cm':
+      return 0.1;
+    case 'mm':
+      return 1;
+    case 'in':
+      return 0.1;
+    default:
+      console.warn(`Unknown page size unit: ${form.value.pageSizeUnit}`);
+      return 1;
+  }
+});
+const spacingStep = computed(() => {
+  switch (form.value.pageSizeUnit) {
+    case 'pc':
+      return 0.05;
+    case 'pt':
+      return 0.5;
+    case 'cm':
+      return 0.01;
+    case 'mm':
+      return 0.1;
+    case 'in':
+      return 0.005;
+    default:
+      console.warn(`Unknown page size unit: ${form.value.pageSizeUnit}`);
+      return 1;
+  }
+});
+
+Object.assign(form.value, props.pageSetup);
+
+window.addEventListener('keydown', onKeyDown);
+
+const updateCurrentSectionThrottled = throttle(50, updateCurrentSection);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+});
+
+function toDisplayUnit(value: number) {
+  switch (form.value.pageSizeUnit) {
+    case 'pc':
+      return Unit.toPc(value);
+    case 'pt':
+      return Unit.toPt(value);
+    case 'cm':
+      return Unit.toCm(value);
+    case 'mm':
+      return Unit.toMm(value);
+    case 'in':
+      return Unit.toInch(value);
+    default:
+      console.warn(`Unknown page size unit: ${form.value.pageSizeUnit}`);
+      return 0;
+  }
+}
+
+function toStorageUnit(value: number) {
+  switch (form.value.pageSizeUnit) {
+    case 'pc':
+      return Unit.fromPc(value);
+    case 'pt':
+      return Unit.fromPt(value);
+    case 'cm':
+      return Unit.fromCm(value);
+    case 'mm':
+      return Unit.fromMm(value);
+    case 'in':
+      return Unit.fromInch(value);
+    default:
+      console.warn(`Unknown page size unit: ${form.value.pageSizeUnit}`);
+      return 0;
+  }
+}
+
+function forceUpdate() {
+  instance?.proxy?.$forceUpdate();
+}
+
+function updateCurrentSection() {
+  const rightPane = rightPaneRef.value;
+
+  if (!rightPane) {
+    return;
+  }
+
+  const scrollParentTop = rightPane.getBoundingClientRect().top;
+
+  let closest: SectionRefName | null = null;
+  let closestDistance = Infinity;
+
+  for (const id of sectionIds) {
+    const el = sectionRefs[id].value;
+
+    if (!el) {
+      continue;
+    }
+
+    const top = Math.abs(el.getBoundingClientRect().top - scrollParentTop);
+
+    if (top < closestDistance) {
+      closest = id;
+      closestDistance = top;
+    }
+  }
+
+  if (closest !== null) {
+    currentSection.value = closest;
+  }
+}
+
+function changeNeumeColorInBulk() {
+  for (const neume of selectedNeumeColorOptions.value) {
+    switch (neume) {
+      case NeumeColorOptions.Accidentals:
+        form.value.accidentalDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Fthoras:
+        form.value.fthoraDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Gorgons:
+        form.value.gorgonDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Heterons:
+        form.value.heteronDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Ison:
+        form.value.isonDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Koronis:
+        form.value.koronisDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Martyria:
+        form.value.martyriaDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.MeasureBars:
+        form.value.measureBarDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.MeasureNumbers:
+        form.value.accidentalDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.NoteIndicators:
+        form.value.noteIndicatorDefaultColor = neumeBulkColor.value;
+        break;
+      case NeumeColorOptions.Tempos:
+        form.value.tempoDefaultColor = neumeBulkColor.value;
+        break;
+    }
+  }
+}
+
+function updateTopMargin(value: number) {
+  form.value.topMargin = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.pageHeight - form.value.bottomMargin - Unit.fromInch(0.5),
+  );
+
+  forceUpdate();
+}
+
+function updateBottomMargin(value: number) {
+  form.value.bottomMargin = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.pageHeight - form.value.topMargin - Unit.fromInch(0.5),
+  );
+
+  forceUpdate();
+}
+
+function updateLeftMargin(value: number) {
+  form.value.leftMargin = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.pageWidth - form.value.rightMargin - Unit.fromInch(0.5),
+  );
+
+  forceUpdate();
+}
+
+function updateRightMargin(value: number) {
+  form.value.rightMargin = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.pageWidth - form.value.leftMargin - Unit.fromInch(0.5),
+  );
+
+  forceUpdate();
+}
+
+function updateHeaderMargin(value: number) {
+  form.value.headerMargin = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.innerPageHeight,
+  );
+
+  forceUpdate();
+}
+
+function updateFooterMargin(value: number) {
+  form.value.footerMargin = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.innerPageHeight,
+  );
+
+  forceUpdate();
+}
+
+function updateLyricsVerticalOffset(value: number) {
+  form.value.lyricsVerticalOffset = Math.min(
+    toStorageUnit(value),
+    form.value.innerPageHeight -
+      form.value.lyricsDefaultFontSize -
+      form.value.neumeDefaultFontSize,
+  );
+
+  forceUpdate();
+}
+
+function updateLyricsMinimumSpacing(value: number) {
+  form.value.lyricsMinimumSpacing = Math.min(
+    toStorageUnit(value),
+    form.value.innerPageWidth,
+  );
+
+  forceUpdate();
+}
+
+function updateLineHeight(value: number) {
+  form.value.lineHeight = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.innerPageHeight,
+  );
+
+  forceUpdate();
+}
+
+function updateHyphenSpacing(value: number) {
+  form.value.hyphenSpacing = Math.min(
+    Math.max(toStorageUnit(value), 0),
+    form.value.innerPageWidth,
+  );
+
+  forceUpdate();
+}
+
+function onChangeMelkiteRtl() {
+  form.value.neumeDefaultFontFamily = form.value.melkiteRtl
+    ? 'NeanesRTL'
+    : 'Neanes';
+}
+
+function isSyllableElement(elementType: ElementType) {
+  return elementType == ElementType.Note;
+}
+
+function isMartyriaElement(elementType: ElementType) {
+  return elementType == ElementType.Martyria;
+}
+
+function isTempoElement(elementType: ElementType) {
+  return elementType == ElementType.Tempo;
+}
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.code === 'Escape') {
+    emit('close');
+  }
+}
+
+function updatePageSize() {
+  if (form.value.pageSize === 'Custom') {
+    if (form.value.landscape) {
+      form.value.pageWidth = form.value.pageHeightCustom;
+      form.value.pageHeight = form.value.pageWidthCustom;
+    } else {
+      form.value.pageWidth = form.value.pageWidthCustom;
+      form.value.pageHeight = form.value.pageHeightCustom;
+    }
+    return;
+  }
+
+  const pageSize = pageSizes.find((x) => x.name === form.value.pageSize);
+  if (pageSize) {
+    if (form.value.landscape) {
+      form.value.pageWidth = pageSize.height;
+      form.value.pageHeight = pageSize.width;
+    } else {
+      form.value.pageWidth = pageSize.width;
+      form.value.pageHeight = pageSize.height;
+    }
+  }
+}
+
+function updatePageSetup() {
+  emit('update', form.value);
+  emit('close');
+}
+
+function saveAsDefault() {
+  const defaults = new PageSetup_v1();
+  SaveService.SavePageSetup(defaults, form.value);
+
+  localStorage.setItem('pageSetupDefault', JSON.stringify(defaults));
+}
+
+function resetToSystemDefaults() {
+  form.value = new PageSetup();
+}
+
+function scrollTo(el: HTMLElement | null) {
+  el?.scrollIntoView({ behavior: 'instant', block: 'start' });
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -1831,10 +1831,10 @@ import { SelectorParam } from 'i18next';
 import { throttle } from 'throttle-debounce';
 import {
   computed,
-  getCurrentInstance,
   onBeforeUnmount,
   PropType,
   ref,
+  triggerRef,
   useTemplateRef,
 } from 'vue';
 
@@ -1950,7 +1950,6 @@ const emit = defineEmits<{
   close: [];
   update: [pageSetup: PageSetup];
 }>();
-const instance = getCurrentInstance();
 
 const props = defineProps({
   pageSetup: {
@@ -2170,8 +2169,8 @@ function toStorageUnit(value: number) {
   }
 }
 
-function forceUpdate() {
-  instance?.proxy?.$forceUpdate();
+function refreshFormInputs() {
+  triggerRef(form);
 }
 
 function updateCurrentSection() {
@@ -2252,7 +2251,7 @@ function updateTopMargin(value: number) {
     form.value.pageHeight - form.value.bottomMargin - Unit.fromInch(0.5),
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateBottomMargin(value: number) {
@@ -2261,7 +2260,7 @@ function updateBottomMargin(value: number) {
     form.value.pageHeight - form.value.topMargin - Unit.fromInch(0.5),
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateLeftMargin(value: number) {
@@ -2270,7 +2269,7 @@ function updateLeftMargin(value: number) {
     form.value.pageWidth - form.value.rightMargin - Unit.fromInch(0.5),
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateRightMargin(value: number) {
@@ -2279,7 +2278,7 @@ function updateRightMargin(value: number) {
     form.value.pageWidth - form.value.leftMargin - Unit.fromInch(0.5),
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateHeaderMargin(value: number) {
@@ -2288,7 +2287,7 @@ function updateHeaderMargin(value: number) {
     form.value.innerPageHeight,
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateFooterMargin(value: number) {
@@ -2297,7 +2296,7 @@ function updateFooterMargin(value: number) {
     form.value.innerPageHeight,
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateLyricsVerticalOffset(value: number) {
@@ -2308,7 +2307,7 @@ function updateLyricsVerticalOffset(value: number) {
       form.value.neumeDefaultFontSize,
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateLyricsMinimumSpacing(value: number) {
@@ -2317,7 +2316,7 @@ function updateLyricsMinimumSpacing(value: number) {
     form.value.innerPageWidth,
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateLineHeight(value: number) {
@@ -2326,7 +2325,7 @@ function updateLineHeight(value: number) {
     form.value.innerPageHeight,
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function updateHyphenSpacing(value: number) {
@@ -2335,7 +2334,7 @@ function updateHyphenSpacing(value: number) {
     form.value.innerPageWidth,
   );
 
-  forceUpdate();
+  refreshFormInputs();
 }
 
 function onChangeMelkiteRtl() {

--- a/src/components/PlaybackSettingsDialog.vue
+++ b/src/components/PlaybackSettingsDialog.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/no-mutating-props -->
 <template>
   <ModalDialog>
-    <div class="container">
+    <div class="container" :data-render-version="renderVersion">
       <div class="header">
         {{ $t(($) => $.dialog.playbackSettings.root, { ns: 'dialog' }) }}
       </div>
@@ -683,14 +683,7 @@
 // TODO don't rely on this eslint-disable line
 // Instead, make a copy of the options prop (a la Page Setup Dialog)
 // and have TheEditor update the actual options.
-import {
-  computed,
-  getCurrentInstance,
-  onBeforeUnmount,
-  onMounted,
-  PropType,
-  ref,
-} from 'vue';
+import { computed, onBeforeUnmount, onMounted, PropType, ref } from 'vue';
 
 import ModalDialog from '@/components/ModalDialog.vue';
 import { Accidental } from '@/models/Neumes';
@@ -706,10 +699,9 @@ const props = defineProps({
   },
 });
 
-const instance = getCurrentInstance();
-
 const tuning = ref(0);
 const error = ref<string | null>(null);
+const renderVersion = ref(0);
 
 const volumeIson = computed({
   get() {
@@ -756,7 +748,7 @@ function onIntervalChanged(intervals: number[], index: number, value: number) {
 
   validateIntervals();
 
-  forceUpdate();
+  refreshPlaybackInputs();
 }
 
 function validateIntervals() {
@@ -827,7 +819,7 @@ function onDiesisChanged(neume: Accidental, moria: number) {
 
   props.options.alterationMoriaMap[neume] = moria;
 
-  forceUpdate();
+  refreshPlaybackInputs();
 }
 
 function onYfesisChanged(neume: Accidental, moria: number) {
@@ -838,7 +830,7 @@ function onYfesisChanged(neume: Accidental, moria: number) {
 
   props.options.alterationMoriaMap[neume] = moria;
 
-  forceUpdate();
+  refreshPlaybackInputs();
 }
 
 function onDefaultAttractionZoMoriaChanged(value: number) {
@@ -848,7 +840,7 @@ function onDefaultAttractionZoMoriaChanged(value: number) {
 
   props.options.defaultAttractionZoMoria = value;
 
-  forceUpdate();
+  refreshPlaybackInputs();
 }
 
 function onTuningChanged(value: number) {
@@ -859,7 +851,7 @@ function onTuningChanged(value: number) {
     FREQUENCY_G3 * Math.pow(2, tuning.value / 1200)
   ).toFixed(1);
 
-  forceUpdate();
+  refreshPlaybackInputs();
 }
 
 function onAlterationMultiplierChanged(index: number, multiplier: number) {
@@ -868,15 +860,15 @@ function onAlterationMultiplierChanged(index: number, multiplier: number) {
 
   props.options.alterationMultipliers[index] = multiplier;
 
-  forceUpdate();
+  refreshPlaybackInputs();
 }
 
 function close() {
   emit('close');
 }
 
-function forceUpdate() {
-  instance?.proxy?.$forceUpdate();
+function refreshPlaybackInputs() {
+  renderVersion.value += 1;
 }
 </script>
 

--- a/src/components/PlaybackSettingsDialog.vue
+++ b/src/components/PlaybackSettingsDialog.vue
@@ -678,12 +678,19 @@
   </ModalDialog>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 /* eslint-disable vue/no-mutating-props */
 // TODO don't rely on this eslint-disable line
 // Instead, make a copy of the options prop (a la Page Setup Dialog)
 // and have TheEditor update the actual options.
-import { defineComponent, PropType } from 'vue';
+import {
+  computed,
+  getCurrentInstance,
+  onBeforeUnmount,
+  onMounted,
+  PropType,
+  ref,
+} from 'vue';
 
 import ModalDialog from '@/components/ModalDialog.vue';
 import { Accidental } from '@/models/Neumes';
@@ -691,194 +698,186 @@ import { PlaybackOptions } from '@/services/audio/PlaybackService';
 
 const FREQUENCY_G3 = 196;
 
-export default defineComponent({
-  components: { ModalDialog },
-  props: {
-    options: {
-      type: Object as PropType<PlaybackOptions>,
-      required: true,
-    },
-  },
-  emits: ['close', 'play-test-tone'],
-
-  data() {
-    return {
-      Accidental,
-
-      tuning: 0,
-
-      error: null as string | null,
-    };
-  },
-
-  computed: {
-    volumeIson: {
-      get() {
-        return 100 * Math.pow(10, this.options.volumeIson / 20);
-      },
-      set(value: number) {
-        this.options.volumeIson = 20 * Math.log10(value / 100);
-      },
-    },
-
-    volumeMelody: {
-      get() {
-        return 100 * Math.pow(10, this.options.volumeMelody / 20);
-      },
-      set(value: number) {
-        this.options.volumeMelody = 20 * Math.log10(value / 100);
-      },
-    },
-  },
-
-  mounted() {
-    window.addEventListener('keydown', this.onKeyDown);
-
-    this.tuning = Math.round(
-      1200 * Math.log2(this.options.frequencyDi / FREQUENCY_G3),
-    );
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  methods: {
-    onKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        this.close();
-      }
-    },
-
-    onIntervalChanged(intervals: number[], index: number, value: number) {
-      value = Math.max(1, value);
-      value = Math.min(27, value);
-      value = Math.round(value);
-
-      intervals[index] = value;
-
-      this.validateIntervals();
-
-      this.$forceUpdate();
-    },
-
-    validateIntervals() {
-      this.error = null;
-
-      if (!this.validateTetrachord(this.options.diatonicIntervals)) {
-        this.error = 'The diatonic intervals do not sum to 30.';
-      }
-
-      if (!this.validateTetrachord(this.options.softChromaticIntervals)) {
-        this.error = 'The soft chromatic intervals do not sum to 30.';
-      }
-
-      if (!this.validateTetrachord(this.options.hardChromaticIntervals)) {
-        this.error = 'The hard chromatic intervals do not sum to 30.';
-      }
-
-      if (!this.validateTetrachord(this.options.legetosIntervals)) {
-        this.error = 'The legetos intervals do not sum to 30.';
-      }
-    },
-
-    validateTetrachord(intervals: number[]) {
-      let sum = 0;
-
-      intervals.map((x) => (sum += x));
-
-      return sum === 30;
-    },
-
-    resetIntervals() {
-      this.options.diatonicIntervals = [12, 10, 8];
-      this.options.hardChromaticIntervals = [6, 20, 4];
-      this.options.softChromaticIntervals = [8, 14, 8];
-      this.options.legetosIntervals = [8, 10, 12];
-      this.options.zygosIntervals = [18, 4, 16, 4];
-      this.options.zygosLegetosIntervals = [18, 4, 20, 4];
-      this.options.spathiIntervals = [20, 4, 4, 14];
-      this.options.klitonIntervals = [14, 12, 4];
-    },
-
-    resetAlterationMultipliers() {
-      this.options.alterationMultipliers = [0.5, 0.25, 0.75];
-    },
-
-    resetAlterationMoria() {
-      this.options.alterationMoriaMap = {
-        [Accidental.Flat_2_Right]: -2,
-        [Accidental.Flat_4_Right]: -4,
-        [Accidental.Flat_6_Right]: -6,
-        [Accidental.Flat_8_Right]: -8,
-        [Accidental.Sharp_2_Left]: 2,
-        [Accidental.Sharp_4_Left]: 4,
-        [Accidental.Sharp_6_Left]: 6,
-        [Accidental.Sharp_8_Left]: 8,
-      };
-    },
-
-    resetDefaultAttractionZoMoria() {
-      this.options.defaultAttractionZoMoria = -4;
-    },
-
-    onDiesisChanged(neume: Accidental, moria: number) {
-      moria = Math.round(moria);
-
-      moria = Math.max(0, moria);
-      moria = Math.min(72, moria);
-
-      this.options.alterationMoriaMap[neume] = moria;
-
-      this.$forceUpdate();
-    },
-
-    onYfesisChanged(neume: Accidental, moria: number) {
-      moria = Math.round(moria);
-
-      moria = Math.max(-72, moria);
-      moria = Math.min(0, moria);
-
-      this.options.alterationMoriaMap[neume] = moria;
-
-      this.$forceUpdate();
-    },
-
-    onDefaultAttractionZoMoriaChanged(value: number) {
-      value = Math.max(-72, value);
-      value = Math.min(0, value);
-      value = Math.round(value);
-
-      this.options.defaultAttractionZoMoria = value;
-
-      this.$forceUpdate();
-    },
-
-    onTuningChanged(value: number) {
-      this.tuning = Math.max(-2400, value);
-      this.tuning = Math.min(2400, this.tuning);
-      this.tuning = Math.round(this.tuning);
-      this.options.frequencyDi = +(
-        FREQUENCY_G3 * Math.pow(2, this.tuning / 1200)
-      ).toFixed(1);
-
-      this.$forceUpdate();
-    },
-
-    onAlterationMultiplierChanged(index: number, multiplier: number) {
-      multiplier = Math.max(0, multiplier);
-      multiplier = Math.min(1, multiplier);
-
-      this.options.alterationMultipliers[index] = multiplier;
-
-      this.$forceUpdate();
-    },
-
-    close() {
-      this.$emit('close');
-    },
+const emit = defineEmits(['close', 'play-test-tone']);
+const props = defineProps({
+  options: {
+    type: Object as PropType<PlaybackOptions>,
+    required: true,
   },
 });
+
+const instance = getCurrentInstance();
+
+const tuning = ref(0);
+const error = ref<string | null>(null);
+
+const volumeIson = computed({
+  get() {
+    return 100 * Math.pow(10, props.options.volumeIson / 20);
+  },
+  set(value: number) {
+    props.options.volumeIson = 20 * Math.log10(value / 100);
+  },
+});
+
+const volumeMelody = computed({
+  get() {
+    return 100 * Math.pow(10, props.options.volumeMelody / 20);
+  },
+  set(value: number) {
+    props.options.volumeMelody = 20 * Math.log10(value / 100);
+  },
+});
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeyDown);
+
+  tuning.value = Math.round(
+    1200 * Math.log2(props.options.frequencyDi / FREQUENCY_G3),
+  );
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+});
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.code === 'Escape') {
+    close();
+  }
+}
+
+function onIntervalChanged(intervals: number[], index: number, value: number) {
+  value = Math.max(1, value);
+  value = Math.min(27, value);
+  value = Math.round(value);
+
+  intervals[index] = value;
+
+  validateIntervals();
+
+  forceUpdate();
+}
+
+function validateIntervals() {
+  error.value = null;
+
+  if (!validateTetrachord(props.options.diatonicIntervals)) {
+    error.value = 'The diatonic intervals do not sum to 30.';
+  }
+
+  if (!validateTetrachord(props.options.softChromaticIntervals)) {
+    error.value = 'The soft chromatic intervals do not sum to 30.';
+  }
+
+  if (!validateTetrachord(props.options.hardChromaticIntervals)) {
+    error.value = 'The hard chromatic intervals do not sum to 30.';
+  }
+
+  if (!validateTetrachord(props.options.legetosIntervals)) {
+    error.value = 'The legetos intervals do not sum to 30.';
+  }
+}
+
+function validateTetrachord(intervals: number[]) {
+  let sum = 0;
+
+  intervals.map((x) => (sum += x));
+
+  return sum === 30;
+}
+
+function resetIntervals() {
+  props.options.diatonicIntervals = [12, 10, 8];
+  props.options.hardChromaticIntervals = [6, 20, 4];
+  props.options.softChromaticIntervals = [8, 14, 8];
+  props.options.legetosIntervals = [8, 10, 12];
+  props.options.zygosIntervals = [18, 4, 16, 4];
+  props.options.zygosLegetosIntervals = [18, 4, 20, 4];
+  props.options.spathiIntervals = [20, 4, 4, 14];
+  props.options.klitonIntervals = [14, 12, 4];
+}
+
+function resetAlterationMultipliers() {
+  props.options.alterationMultipliers = [0.5, 0.25, 0.75];
+}
+
+function resetAlterationMoria() {
+  props.options.alterationMoriaMap = {
+    [Accidental.Flat_2_Right]: -2,
+    [Accidental.Flat_4_Right]: -4,
+    [Accidental.Flat_6_Right]: -6,
+    [Accidental.Flat_8_Right]: -8,
+    [Accidental.Sharp_2_Left]: 2,
+    [Accidental.Sharp_4_Left]: 4,
+    [Accidental.Sharp_6_Left]: 6,
+    [Accidental.Sharp_8_Left]: 8,
+  };
+}
+
+function resetDefaultAttractionZoMoria() {
+  props.options.defaultAttractionZoMoria = -4;
+}
+
+function onDiesisChanged(neume: Accidental, moria: number) {
+  moria = Math.round(moria);
+
+  moria = Math.max(0, moria);
+  moria = Math.min(72, moria);
+
+  props.options.alterationMoriaMap[neume] = moria;
+
+  forceUpdate();
+}
+
+function onYfesisChanged(neume: Accidental, moria: number) {
+  moria = Math.round(moria);
+
+  moria = Math.max(-72, moria);
+  moria = Math.min(0, moria);
+
+  props.options.alterationMoriaMap[neume] = moria;
+
+  forceUpdate();
+}
+
+function onDefaultAttractionZoMoriaChanged(value: number) {
+  value = Math.max(-72, value);
+  value = Math.min(0, value);
+  value = Math.round(value);
+
+  props.options.defaultAttractionZoMoria = value;
+
+  forceUpdate();
+}
+
+function onTuningChanged(value: number) {
+  tuning.value = Math.max(-2400, value);
+  tuning.value = Math.min(2400, tuning.value);
+  tuning.value = Math.round(tuning.value);
+  props.options.frequencyDi = +(
+    FREQUENCY_G3 * Math.pow(2, tuning.value / 1200)
+  ).toFixed(1);
+
+  forceUpdate();
+}
+
+function onAlterationMultiplierChanged(index: number, multiplier: number) {
+  multiplier = Math.max(0, multiplier);
+  multiplier = Math.min(1, multiplier);
+
+  props.options.alterationMultipliers[index] = multiplier;
+
+  forceUpdate();
+}
+
+function close() {
+  emit('close');
+}
+
+function forceUpdate() {
+  instance?.proxy?.$forceUpdate();
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/SearchText.vue
+++ b/src/components/SearchText.vue
@@ -27,35 +27,28 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { onMounted, useTemplateRef } from 'vue';
 
-export default defineComponent({
-  components: {},
-  props: {
-    query: {
-      type: String,
-      required: true,
-    },
-  },
-  emits: ['close', 'search', 'update:query'],
-
-  data() {
-    return {};
-  },
-
-  computed: {},
-
-  mounted() {
-    this.focus();
-  },
-
-  methods: {
-    focus() {
-      (this.$refs.input as HTMLInputElement).select();
-    },
+defineEmits(['close', 'search', 'update:query']);
+defineProps({
+  query: {
+    type: String,
+    required: true,
   },
 });
+
+const input = useTemplateRef<HTMLInputElement>('input');
+
+onMounted(() => {
+  focus();
+});
+
+function focus() {
+  input.value!.select();
+}
+
+defineExpose({ focus });
 </script>
 
 <style scoped>

--- a/src/components/SyllablePositioningDialog.vue
+++ b/src/components/SyllablePositioningDialog.vue
@@ -696,8 +696,8 @@
   </ModalDialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, StyleValue } from 'vue';
+<script setup lang="ts">
+import { computed, onBeforeUnmount, PropType, ref, StyleValue } from 'vue';
 
 import DragHandle from '@/components/DragHandle.vue';
 import InputUnit, { UnitOfMeasure } from '@/components/InputUnit.vue';
@@ -717,278 +717,225 @@ import { TimeNeume, VocalExpressionNeume } from '@/models/Neumes';
 import { PageSetup } from '@/models/PageSetup';
 import { TextMeasurementService } from '@/services/TextMeasurementService';
 
-export default defineComponent({
-  components: {
-    ModalDialog,
-    NeumeBoxSyllable,
-    NeumeBoxMartyria,
-    NeumeBoxTempo,
-    InputUnit,
-    DragHandle,
+const emit = defineEmits(['close', 'update']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<NoteElement>,
+    required: true,
   },
-  props: {
-    element: {
-      type: Object as PropType<NoteElement>,
-      required: true,
-    },
-    previousElement: {
-      type: Object as PropType<ScoreElement>,
-      default: undefined,
-    },
-    nextElement: {
-      type: Object as PropType<ScoreElement>,
-      default: undefined,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+  previousElement: {
+    type: Object as PropType<ScoreElement>,
+    default: undefined,
   },
-  emits: ['close', 'update'],
-
-  data() {
-    return {
-      TimeNeume,
-      VocalExpressionNeume,
-      ElementType,
-      TempoElement,
-      MartyriaElement,
-
-      form: new NoteElement(),
-      stepSize: 0.01,
-      min: -10,
-      max: 10,
-      precision: 2,
-      unit: 'unitless' as UnitOfMeasure,
-
-      paneContainerWidthPx: 420,
-
-      zoom: 2,
-    };
+  nextElement: {
+    type: Object as PropType<ScoreElement>,
+    default: undefined,
   },
-
-  computed: {
-    hasVocalExpressionNeume() {
-      return this.form.vocalExpressionNeume != null;
-    },
-
-    hasTimeNeume() {
-      return this.form.timeNeume != null;
-    },
-
-    hasGorgonNeume() {
-      return this.form.gorgonNeume != null;
-    },
-
-    hasSecondaryGorgonNeume() {
-      return this.form.secondaryGorgonNeume != null;
-    },
-
-    hasFthora() {
-      return this.form.fthora != null;
-    },
-
-    hasSecondaryFthora() {
-      return this.form.secondaryFthora != null;
-    },
-
-    hasTertiaryFthora() {
-      return this.form.tertiaryFthora != null;
-    },
-
-    hasAccidental() {
-      return this.form.accidental != null;
-    },
-
-    hasSecondaryAccidental() {
-      return this.form.secondaryAccidental != null;
-    },
-
-    hasTertiaryAccidental() {
-      return this.form.tertiaryAccidental != null;
-    },
-
-    hasMeasureBarLeft() {
-      return this.form.measureBarLeft != null;
-    },
-
-    hasMeasureBarRight() {
-      return this.form.measureBarRight != null;
-    },
-
-    hasMeasureNumber() {
-      return this.form.measureNumber != null;
-    },
-
-    hasIson() {
-      return this.form.ison != null;
-    },
-
-    hasTie() {
-      return this.form.tie != null;
-    },
-
-    centerLeft() {
-      return this.paneContainerWidthPx / 2;
-    },
-
-    previousElementStyle() {
-      return {
-        left: `calc(${this.centerLeft}px - ${
-          this.element.x - this.previousElement!.x
-        }px * var(--zoom, 1))`,
-      } as StyleValue;
-    },
-
-    nextElementStyle() {
-      return {
-        left: `calc(${this.centerLeft}px + ${
-          this.nextElement!.x - this.element.x
-        }px * var(--zoom, 1))`,
-      } as StyleValue;
-    },
-
-    mainStyle() {
-      return {
-        left: this.centerLeft + 'px',
-      } as StyleValue;
-    },
-
-    topPaneStyle() {
-      const neumeHeight = TextMeasurementService.getFontHeight(
-        `${this.pageSetup.neumeDefaultFontSize}px ${this.pageSetup.neumeDefaultFontFamily}`,
-      );
-
-      return {
-        height: neumeHeight * this.zoom + 'px',
-      } as StyleValue;
-    },
-
-    paneContainerStyle() {
-      return {
-        width: this.paneContainerWidthPx + 'px',
-      } as StyleValue;
-    },
-  },
-
-  created() {
-    Object.assign(this.form, this.element);
-
-    window.addEventListener('keydown', this.onKeyDown);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown);
-  },
-
-  methods: {
-    onKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        this.$emit('close');
-      }
-    },
-
-    update() {
-      this.$emit('update', this.form);
-      this.$emit('close');
-    },
-
-    updateAccidentalOffset(args: ScoreElementOffset) {
-      this.form.accidentalOffsetX = args.x;
-      this.form.accidentalOffsetY = args.y;
-    },
-
-    updateSecondaryAccidentalOffset(args: ScoreElementOffset) {
-      this.form.secondaryAccidentalOffsetX = args.x;
-      this.form.secondaryAccidentalOffsetY = args.y;
-    },
-
-    updateTertiaryAccidentalOffset(args: ScoreElementOffset) {
-      this.form.tertiaryAccidentalOffsetX = args.x;
-      this.form.tertiaryAccidentalOffsetY = args.y;
-    },
-
-    updateMeasureBarLeftOffset(args: ScoreElementOffset) {
-      this.form.measureBarLeftOffsetX = args.x;
-      this.form.measureBarLeftOffsetY = args.y;
-    },
-
-    updateMeasureBarRightOffset(args: ScoreElementOffset) {
-      this.form.measureBarRightOffsetX = args.x;
-      this.form.measureBarRightOffsetY = args.y;
-    },
-
-    updateFthoraOffset(args: ScoreElementOffset) {
-      this.form.fthoraOffsetX = args.x;
-      this.form.fthoraOffsetY = args.y;
-    },
-
-    updateSecondaryFthoraOffset(args: ScoreElementOffset) {
-      this.form.secondaryFthoraOffsetX = args.x;
-      this.form.secondaryFthoraOffsetY = args.y;
-    },
-
-    updateTertiaryFthoraOffset(args: ScoreElementOffset) {
-      this.form.tertiaryFthoraOffsetX = args.x;
-      this.form.tertiaryFthoraOffsetY = args.y;
-    },
-
-    updateGorgonOffset(args: ScoreElementOffset) {
-      this.form.gorgonNeumeOffsetX = args.x;
-      this.form.gorgonNeumeOffsetY = args.y;
-    },
-
-    updateGorgon2Offset(args: ScoreElementOffset) {
-      this.form.secondaryGorgonNeumeOffsetX = args.x;
-      this.form.secondaryGorgonNeumeOffsetY = args.y;
-    },
-
-    updateIsonOffset(args: ScoreElementOffset) {
-      this.form.isonOffsetX = args.x;
-      this.form.isonOffsetY = args.y;
-    },
-
-    updateKoronisOffset(args: ScoreElementOffset) {
-      this.form.koronisOffsetX = args.x;
-      this.form.koronisOffsetY = args.y;
-    },
-
-    updateMeasureNumberOffset(args: ScoreElementOffset) {
-      this.form.measureNumberOffsetX = args.x;
-      this.form.measureNumberOffsetY = args.y;
-    },
-
-    updateNoteIndicatorOffset(args: ScoreElementOffset) {
-      this.form.noteIndicatorOffsetX = args.x;
-      this.form.noteIndicatorOffsetY = args.y;
-    },
-
-    updateStavrosOffset(args: ScoreElementOffset) {
-      this.form.stavrosOffsetX = args.x;
-      this.form.stavrosOffsetY = args.y;
-    },
-
-    updateTieOffset(args: ScoreElementOffset) {
-      this.form.tieOffsetX = args.x;
-      this.form.tieOffsetY = args.y;
-    },
-
-    updateTimeOffset(args: ScoreElementOffset) {
-      this.form.timeNeumeOffsetX = args.x;
-      this.form.timeNeumeOffsetY = args.y;
-    },
-
-    updateVareiaOffset(args: ScoreElementOffset) {
-      this.form.vareiaOffsetX = args.x;
-      this.form.vareiaOffsetY = args.y;
-    },
-
-    updateQualityOffset(args: ScoreElementOffset) {
-      this.form.vocalExpressionNeumeOffsetX = args.x;
-      this.form.vocalExpressionNeumeOffsetY = args.y;
-    },
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
 });
+
+const form = ref(new NoteElement());
+const stepSize = 0.01;
+const min = -10;
+const max = 10;
+const precision = 2;
+const unit = 'unitless' as UnitOfMeasure;
+const paneContainerWidthPx = 420;
+const zoom = 2;
+
+const hasVocalExpressionNeume = computed(() => {
+  return form.value.vocalExpressionNeume != null;
+});
+
+const hasTimeNeume = computed(() => {
+  return form.value.timeNeume != null;
+});
+
+const hasGorgonNeume = computed(() => {
+  return form.value.gorgonNeume != null;
+});
+
+const hasSecondaryGorgonNeume = computed(() => {
+  return form.value.secondaryGorgonNeume != null;
+});
+
+const hasFthora = computed(() => {
+  return form.value.fthora != null;
+});
+
+const hasSecondaryFthora = computed(() => {
+  return form.value.secondaryFthora != null;
+});
+
+const hasTertiaryFthora = computed(() => {
+  return form.value.tertiaryFthora != null;
+});
+
+const hasAccidental = computed(() => {
+  return form.value.accidental != null;
+});
+
+const hasSecondaryAccidental = computed(() => {
+  return form.value.secondaryAccidental != null;
+});
+
+const hasTertiaryAccidental = computed(() => {
+  return form.value.tertiaryAccidental != null;
+});
+
+const hasMeasureNumber = computed(() => {
+  return form.value.measureNumber != null;
+});
+
+const hasIson = computed(() => {
+  return form.value.ison != null;
+});
+
+const hasTie = computed(() => {
+  return form.value.tie != null;
+});
+
+const centerLeft = computed(() => paneContainerWidthPx / 2);
+
+const previousElementStyle = computed(() => {
+  return {
+    left: `calc(${centerLeft.value}px - ${
+      props.element.x - props.previousElement!.x
+    }px * var(--zoom, 1))`,
+  } as StyleValue;
+});
+
+const nextElementStyle = computed(() => {
+  return {
+    left: `calc(${centerLeft.value}px + ${
+      props.nextElement!.x - props.element.x
+    }px * var(--zoom, 1))`,
+  } as StyleValue;
+});
+
+const mainStyle = computed(() => {
+  return {
+    left: centerLeft.value + 'px',
+  } as StyleValue;
+});
+
+const topPaneStyle = computed(() => {
+  const neumeHeight = TextMeasurementService.getFontHeight(
+    `${props.pageSetup.neumeDefaultFontSize}px ${props.pageSetup.neumeDefaultFontFamily}`,
+  );
+
+  return {
+    height: neumeHeight * zoom + 'px',
+  } as StyleValue;
+});
+
+const paneContainerStyle = computed(() => {
+  return {
+    width: paneContainerWidthPx + 'px',
+  } as StyleValue;
+});
+
+Object.assign(form.value, props.element);
+
+window.addEventListener('keydown', onKeyDown);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown);
+});
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.code === 'Escape') {
+    emit('close');
+  }
+}
+
+function update() {
+  emit('update', form.value);
+  emit('close');
+}
+
+function updateAccidentalOffset(args: ScoreElementOffset) {
+  form.value.accidentalOffsetX = args.x;
+  form.value.accidentalOffsetY = args.y;
+}
+
+function updateSecondaryAccidentalOffset(args: ScoreElementOffset) {
+  form.value.secondaryAccidentalOffsetX = args.x;
+  form.value.secondaryAccidentalOffsetY = args.y;
+}
+
+function updateTertiaryAccidentalOffset(args: ScoreElementOffset) {
+  form.value.tertiaryAccidentalOffsetX = args.x;
+  form.value.tertiaryAccidentalOffsetY = args.y;
+}
+
+function updateFthoraOffset(args: ScoreElementOffset) {
+  form.value.fthoraOffsetX = args.x;
+  form.value.fthoraOffsetY = args.y;
+}
+
+function updateSecondaryFthoraOffset(args: ScoreElementOffset) {
+  form.value.secondaryFthoraOffsetX = args.x;
+  form.value.secondaryFthoraOffsetY = args.y;
+}
+
+function updateTertiaryFthoraOffset(args: ScoreElementOffset) {
+  form.value.tertiaryFthoraOffsetX = args.x;
+  form.value.tertiaryFthoraOffsetY = args.y;
+}
+
+function updateGorgonOffset(args: ScoreElementOffset) {
+  form.value.gorgonNeumeOffsetX = args.x;
+  form.value.gorgonNeumeOffsetY = args.y;
+}
+
+function updateGorgon2Offset(args: ScoreElementOffset) {
+  form.value.secondaryGorgonNeumeOffsetX = args.x;
+  form.value.secondaryGorgonNeumeOffsetY = args.y;
+}
+
+function updateIsonOffset(args: ScoreElementOffset) {
+  form.value.isonOffsetX = args.x;
+  form.value.isonOffsetY = args.y;
+}
+
+function updateKoronisOffset(args: ScoreElementOffset) {
+  form.value.koronisOffsetX = args.x;
+  form.value.koronisOffsetY = args.y;
+}
+
+function updateMeasureNumberOffset(args: ScoreElementOffset) {
+  form.value.measureNumberOffsetX = args.x;
+  form.value.measureNumberOffsetY = args.y;
+}
+
+function updateNoteIndicatorOffset(args: ScoreElementOffset) {
+  form.value.noteIndicatorOffsetX = args.x;
+  form.value.noteIndicatorOffsetY = args.y;
+}
+
+function updateStavrosOffset(args: ScoreElementOffset) {
+  form.value.stavrosOffsetX = args.x;
+  form.value.stavrosOffsetY = args.y;
+}
+
+function updateTieOffset(args: ScoreElementOffset) {
+  form.value.tieOffsetX = args.x;
+  form.value.tieOffsetY = args.y;
+}
+
+function updateTimeOffset(args: ScoreElementOffset) {
+  form.value.timeNeumeOffsetX = args.x;
+  form.value.timeNeumeOffsetY = args.y;
+}
+
+function updateQualityOffset(args: ScoreElementOffset) {
+  form.value.vocalExpressionNeumeOffsetX = args.x;
+  form.value.vocalExpressionNeumeOffsetY = args.y;
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/SyllablePositioningDialog.vue
+++ b/src/components/SyllablePositioningDialog.vue
@@ -700,7 +700,8 @@
 import { computed, onBeforeUnmount, PropType, ref, StyleValue } from 'vue';
 
 import DragHandle from '@/components/DragHandle.vue';
-import InputUnit, { UnitOfMeasure } from '@/components/InputUnit.vue';
+import type { UnitOfMeasure } from '@/components/InputUnit.types';
+import InputUnit from '@/components/InputUnit.vue';
 import ModalDialog from '@/components/ModalDialog.vue';
 import NeumeBoxMartyria from '@/components/NeumeBoxMartyria.vue';
 import NeumeBoxSyllable from '@/components/NeumeBoxSyllable.vue';

--- a/src/components/TextAnnotation.vue
+++ b/src/components/TextAnnotation.vue
@@ -10,7 +10,7 @@
     <ckeditor
       ref="editor"
       class="rich-text-editor"
-      :editor="editor"
+      :editor="ckeditorEditor"
       :model-value="element.text"
       :config="editorConfig"
       :disable-watchdog="true"
@@ -19,10 +19,17 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 import { EditorConfig, FontSizeOption } from 'ckeditor5';
-import { defineComponent, PropType } from 'vue';
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  PropType,
+  ref,
+  useTemplateRef,
+} from 'vue';
 import { ComponentExposed } from 'vue-component-type-helpers';
 
 import InlineEditor from '@/customEditor';
@@ -33,306 +40,288 @@ import { withZoom } from '@/utils/withZoom';
 
 const ANNOTATION_LOCK_ID = 'ANNOTATION_LOCK_ID';
 
-export default defineComponent({
-  components: { Ckeditor },
-  props: {
-    element: {
-      type: Object as PropType<AnnotationElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    fonts: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
-    selected: Boolean,
+const emit = defineEmits(['update', 'delete']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<AnnotationElement>,
+    required: true,
   },
-  emits: ['update', 'delete'],
-
-  data() {
-    return {
-      offsetX: 0,
-      offsetY: 0,
-      elementX: 0,
-      elementY: 0,
-
-      zoom: 1,
-
-      clampingInterval: null as ReturnType<typeof setTimeout> | null,
-
-      editor: InlineEditor,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    style() {
-      return {
-        left: withZoom(this.elementX),
-        top: withZoom(this.elementY),
-        '--ck-content-font-family': getFontFamilyWithFallback(
-          this.pageSetup.textBoxDefaultFontFamily,
-          this.pageSetup.neumeDefaultFontFamily,
-        ),
-        '--ck-content-font-size': `${this.pageSetup.lyricsDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
-        '--ck-content-line-height': 'normal',
-      };
-    },
-
-    editorConfig(): EditorConfig {
-      const fontSizeOptions: FontSizeOption[] = [];
-
-      for (let i = 8; i <= 72; i++) {
-        fontSizeOptions.push({
-          title: `${i}`,
-          model: `${i}pt`,
-        });
-      }
-
-      // Add a fall back font to each font so that neumes "just work"
-      const fonts = this.fonts.map(
-        (x) => x + ',' + this.pageSetup.neumeDefaultFontFamily,
-      );
-
-      return {
-        fontFamily: {
-          options: [
-            'default',
-            'Source Serif' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'GFS Didot' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'Noto Naskh Arabic' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'Old Standard' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'Neanes',
-            'NeanesStathisSeries',
-            ...fonts,
-          ],
-        },
-        fontSize: {
-          supportAllValues: true,
-          options: ['default', ...fontSizeOptions],
-        },
-        // TODO support rtl
-        // language: {
-        //   content: this.element.rtl ? 'ar' : 'en',
-        // },
-        licenseKey: 'GPL',
-        insertNeume: {
-          neumeDefaultFontFamily: this.pageSetup.neumeDefaultFontFamily,
-          defaultFontSize: this.pageSetup.lyricsDefaultFontSize,
-          defaultFontFamily: this.pageSetup.lyricsDefaultFontFamily,
-          fthoraDefaultColor: this.pageSetup.fthoraDefaultColor,
-        },
-        toolbar: {
-          items: [
-            'fontFamily',
-            'fontSize',
-            '|',
-            'bold',
-            'italic',
-            'underline',
-            '|',
-            'fontColor',
-            '|',
-            'link',
-            '|',
-            'removeFormat',
-            '|',
-            'insertNeume',
-            'insertMartyria',
-            'insertPlagal',
-          ],
-          shouldNotGroupWhenFull: true,
-        },
-      };
-    },
+  fonts: {
+    type: Array as PropType<string[]>,
+    required: true,
   },
-
-  mounted() {
-    this.elementX = this.element.x;
-    this.elementY = this.element.y;
-    this.clampingInterval = setInterval(this.clampToPageBounds, 250);
-  },
-
-  beforeUnmount() {
-    document.removeEventListener('mouseup', this.handleMouseUp);
-    document.removeEventListener('mousemove', this.handleMouseMove);
-
-    if (this.clampingInterval != null) {
-      clearInterval(this.clampingInterval);
-    }
-  },
-
-  methods: {
-    getEditorInstance() {
-      return (this.$refs.editor as ComponentExposed<typeof Ckeditor>)?.instance;
-    },
-
-    onEditorReady(editor: InlineEditor) {
-      // If the text is empty, we want to focus the editor
-      // because this is a new annotation
-      if (this.element.text.trim() === '') {
-        editor.editing.view.focus();
-      } else {
-        // Otherwise, we want to enable read-only mode
-        editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
-      }
-
-      editor.ui.focusTracker.on('change:isFocused', (evt, name, isFocused) => {
-        if (!isFocused) {
-          editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
-
-          const text = editor.getData();
-
-          if (text.trim() === '') {
-            this.$emit('delete');
-          } else if (this.element.text !== text) {
-            this.$emit('update', { text });
-          }
-        }
-      });
-
-      const toolbarEl = editor.ui.view.toolbar.element;
-      if (toolbarEl) {
-        toolbarEl.style.maxWidth = '400px';
-      }
-    },
-
-    async handleDoubleClick() {
-      const editor = this.getEditorInstance();
-
-      if (editor == null) {
-        return;
-      }
-
-      if (editor.isReadOnly) {
-        editor.disableReadOnlyMode(ANNOTATION_LOCK_ID);
-        editor.editing.view.focus();
-      }
-    },
-
-    handleMouseDown(e: MouseEvent) {
-      if (this.getEditorInstance()?.isReadOnly === false) {
-        return;
-      }
-
-      // We only calculate zoom once when the mouse is pressed down
-      // to avoid recalculating it on every mouse move
-      this.zoom = Number(
-        getComputedStyle(this.$refs.container as HTMLElement).getPropertyValue(
-          '--zoom',
-        ),
-      );
-
-      const draggedEl = this.$refs.container as HTMLElement;
-      const rect = draggedEl.getBoundingClientRect();
-
-      // Calculate the offset of the mouse click relative to the element
-      this.offsetX = e.clientX - rect.left;
-      this.offsetY = e.clientY - rect.top;
-
-      document.addEventListener('mouseup', this.handleMouseUp);
-      document.addEventListener('mousemove', this.handleMouseMove);
-    },
-
-    handleMouseMove(e: MouseEvent) {
-      e.preventDefault();
-
-      const draggedEl = this.$refs.container as HTMLElement;
-      const pageEl = draggedEl.closest('.page') as HTMLElement;
-      if (!draggedEl || !pageEl) {
-        console.warn('Could not find dragged element or page element');
-        return;
-      }
-
-      const elRect = draggedEl.getBoundingClientRect();
-      const pageRect = pageEl.getBoundingClientRect();
-
-      const elWidth = elRect.width;
-      const elHeight = elRect.height;
-
-      // Compute desired top-left corner of element in viewport space
-      const desiredLeft = e.clientX - this.offsetX;
-      const desiredTop = e.clientY - this.offsetY;
-
-      // Clamp those values to page bounds
-      const clampedLeft = Math.max(
-        pageRect.left,
-        Math.min(desiredLeft, pageRect.right - elWidth),
-      );
-      const clampedTop = Math.max(
-        pageRect.top,
-        Math.min(desiredTop, pageRect.bottom - elHeight),
-      );
-
-      // Convert clamped screen coords into coordinates relative to the element's offsetParent
-      const offsetParent = draggedEl.offsetParent as HTMLElement;
-      const parentRect = offsetParent.getBoundingClientRect();
-
-      const newX = clampedLeft - parentRect.left;
-      const newY = clampedTop - parentRect.top;
-
-      const zoom = Number(
-        getComputedStyle(this.$refs.container as HTMLElement).getPropertyValue(
-          '--zoom',
-        ),
-      );
-
-      this.elementX = newX / zoom;
-      this.elementY = newY / zoom;
-    },
-
-    clampToPageBounds() {
-      const el = this.$refs.container as HTMLElement;
-
-      if (!el) {
-        return;
-      }
-
-      const pageEl = el.closest('.page') as HTMLElement;
-      const offsetParent = el.offsetParent as HTMLElement;
-
-      if (!pageEl || !offsetParent) {
-        return;
-      }
-
-      const zoom = Number(
-        getComputedStyle(this.$refs.container as HTMLElement).getPropertyValue(
-          '--zoom',
-        ),
-      );
-
-      const elRect = el.getBoundingClientRect();
-      const pageRect = pageEl.getBoundingClientRect();
-      const parentRect = offsetParent.getBoundingClientRect();
-
-      const elWidth = elRect.width;
-      const elHeight = elRect.height;
-
-      // Current position relative to offset parent
-      const currentX = this.elementX * zoom;
-      const currentY = this.elementY * zoom;
-
-      // Convert .page bounds into offsetParent-relative coordinates
-      const minX = pageRect.left - parentRect.left;
-      const minY = pageRect.top - parentRect.top;
-      const maxX = pageRect.right - parentRect.left - elWidth;
-      const maxY = pageRect.bottom - parentRect.top - elHeight;
-
-      // Clamp
-      this.elementX = Math.max(minX, Math.min(currentX, maxX)) / zoom;
-      this.elementY = Math.max(minY, Math.min(currentY, maxY)) / zoom;
-    },
-
-    handleMouseUp() {
-      this.$emit('update', { x: this.elementX, y: this.elementY });
-
-      document.removeEventListener('mouseup', this.handleMouseUp);
-      document.removeEventListener('mousemove', this.handleMouseMove);
-    },
-  },
+  selected: Boolean,
 });
+
+const container = useTemplateRef<HTMLElement>('container');
+const editorRef = useTemplateRef<ComponentExposed<typeof Ckeditor>>('editor');
+
+const offsetX = ref(0);
+const offsetY = ref(0);
+const elementX = ref(0);
+const elementY = ref(0);
+const zoom = ref(1);
+const ckeditorEditor = InlineEditor;
+
+let clampingInterval: ReturnType<typeof setInterval> | null = null;
+
+const style = computed(() => {
+  return {
+    left: withZoom(elementX.value),
+    top: withZoom(elementY.value),
+    '--ck-content-font-family': getFontFamilyWithFallback(
+      props.pageSetup.textBoxDefaultFontFamily,
+      props.pageSetup.neumeDefaultFontFamily,
+    ),
+    '--ck-content-font-size': `${props.pageSetup.lyricsDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
+    '--ck-content-line-height': 'normal',
+  };
+});
+
+const editorConfig = computed((): EditorConfig => {
+  const fontSizeOptions: FontSizeOption[] = [];
+
+  for (let i = 8; i <= 72; i++) {
+    fontSizeOptions.push({
+      title: `${i}`,
+      model: `${i}pt`,
+    });
+  }
+
+  // Add a fall back font to each font so that neumes "just work"
+  const fonts = props.fonts.map(
+    (x) => x + ',' + props.pageSetup.neumeDefaultFontFamily,
+  );
+
+  return {
+    fontFamily: {
+      options: [
+        'default',
+        'Source Serif' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'GFS Didot' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'Noto Naskh Arabic' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'Old Standard' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'Neanes',
+        'NeanesStathisSeries',
+        ...fonts,
+      ],
+    },
+    fontSize: {
+      supportAllValues: true,
+      options: ['default', ...fontSizeOptions],
+    },
+    // TODO support rtl
+    // language: {
+    //   content: props.element.rtl ? 'ar' : 'en',
+    // },
+    licenseKey: 'GPL',
+    insertNeume: {
+      neumeDefaultFontFamily: props.pageSetup.neumeDefaultFontFamily,
+      defaultFontSize: props.pageSetup.lyricsDefaultFontSize,
+      defaultFontFamily: props.pageSetup.lyricsDefaultFontFamily,
+      fthoraDefaultColor: props.pageSetup.fthoraDefaultColor,
+    },
+    toolbar: {
+      items: [
+        'fontFamily',
+        'fontSize',
+        '|',
+        'bold',
+        'italic',
+        'underline',
+        '|',
+        'fontColor',
+        '|',
+        'link',
+        '|',
+        'removeFormat',
+        '|',
+        'insertNeume',
+        'insertMartyria',
+        'insertPlagal',
+      ],
+      shouldNotGroupWhenFull: true,
+    },
+  };
+});
+
+onMounted(() => {
+  elementX.value = props.element.x;
+  elementY.value = props.element.y;
+  clampingInterval = setInterval(clampToPageBounds, 250);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mouseup', handleMouseUp);
+  document.removeEventListener('mousemove', handleMouseMove);
+
+  if (clampingInterval != null) {
+    clearInterval(clampingInterval);
+  }
+});
+
+function getEditorInstance() {
+  return editorRef.value?.instance;
+}
+
+function onEditorReady(editor: InlineEditor) {
+  // If the text is empty, we want to focus the editor
+  // because this is a new annotation
+  if (props.element.text.trim() === '') {
+    editor.editing.view.focus();
+  } else {
+    // Otherwise, we want to enable read-only mode
+    editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
+  }
+
+  editor.ui.focusTracker.on('change:isFocused', (evt, name, isFocused) => {
+    if (!isFocused) {
+      editor.enableReadOnlyMode(ANNOTATION_LOCK_ID);
+
+      const text = editor.getData();
+
+      if (text.trim() === '') {
+        emit('delete');
+      } else if (props.element.text !== text) {
+        emit('update', { text });
+      }
+    }
+  });
+
+  const toolbarEl = editor.ui.view.toolbar.element;
+  if (toolbarEl) {
+    toolbarEl.style.maxWidth = '400px';
+  }
+}
+
+async function handleDoubleClick() {
+  const editor = getEditorInstance();
+
+  if (editor == null) {
+    return;
+  }
+
+  if (editor.isReadOnly) {
+    editor.disableReadOnlyMode(ANNOTATION_LOCK_ID);
+    editor.editing.view.focus();
+  }
+}
+
+function handleMouseDown(e: MouseEvent) {
+  if (getEditorInstance()?.isReadOnly === false) {
+    return;
+  }
+
+  // We only calculate zoom once when the mouse is pressed down
+  // to avoid recalculating it on every mouse move
+  zoom.value = Number(
+    getComputedStyle(container.value!).getPropertyValue('--zoom'),
+  );
+
+  const draggedEl = container.value!;
+  const rect = draggedEl.getBoundingClientRect();
+
+  // Calculate the offset of the mouse click relative to the element
+  offsetX.value = e.clientX - rect.left;
+  offsetY.value = e.clientY - rect.top;
+
+  document.addEventListener('mouseup', handleMouseUp);
+  document.addEventListener('mousemove', handleMouseMove);
+}
+
+function handleMouseMove(e: MouseEvent) {
+  e.preventDefault();
+
+  const draggedEl = container.value!;
+  const pageEl = draggedEl.closest('.page') as HTMLElement;
+  if (!draggedEl || !pageEl) {
+    console.warn('Could not find dragged element or page element');
+    return;
+  }
+
+  const elRect = draggedEl.getBoundingClientRect();
+  const pageRect = pageEl.getBoundingClientRect();
+
+  const elWidth = elRect.width;
+  const elHeight = elRect.height;
+
+  // Compute desired top-left corner of element in viewport space
+  const desiredLeft = e.clientX - offsetX.value;
+  const desiredTop = e.clientY - offsetY.value;
+
+  // Clamp those values to page bounds
+  const clampedLeft = Math.max(
+    pageRect.left,
+    Math.min(desiredLeft, pageRect.right - elWidth),
+  );
+  const clampedTop = Math.max(
+    pageRect.top,
+    Math.min(desiredTop, pageRect.bottom - elHeight),
+  );
+
+  // Convert clamped screen coords into coordinates relative to the element's offsetParent
+  const offsetParent = draggedEl.offsetParent as HTMLElement;
+  const parentRect = offsetParent.getBoundingClientRect();
+
+  const newX = clampedLeft - parentRect.left;
+  const newY = clampedTop - parentRect.top;
+
+  const zoom = Number(
+    getComputedStyle(container.value!).getPropertyValue('--zoom'),
+  );
+
+  elementX.value = newX / zoom;
+  elementY.value = newY / zoom;
+}
+
+function clampToPageBounds() {
+  const el = container.value;
+
+  if (!el) {
+    return;
+  }
+
+  const pageEl = el.closest('.page') as HTMLElement;
+  const offsetParent = el.offsetParent as HTMLElement;
+
+  if (!pageEl || !offsetParent) {
+    return;
+  }
+
+  const zoom = Number(getComputedStyle(el).getPropertyValue('--zoom'));
+
+  const elRect = el.getBoundingClientRect();
+  const pageRect = pageEl.getBoundingClientRect();
+  const parentRect = offsetParent.getBoundingClientRect();
+
+  const elWidth = elRect.width;
+  const elHeight = elRect.height;
+
+  // Current position relative to offset parent
+  const currentX = elementX.value * zoom;
+  const currentY = elementY.value * zoom;
+
+  // Convert .page bounds into offsetParent-relative coordinates
+  const minX = pageRect.left - parentRect.left;
+  const minY = pageRect.top - parentRect.top;
+  const maxX = pageRect.right - parentRect.left - elWidth;
+  const maxY = pageRect.bottom - parentRect.top - elHeight;
+
+  // Clamp
+  elementX.value = Math.max(minX, Math.min(currentX, maxX)) / zoom;
+  elementY.value = Math.max(minY, Math.min(currentY, maxY)) / zoom;
+}
+
+function handleMouseUp() {
+  emit('update', { x: elementX.value, y: elementY.value });
+
+  document.removeEventListener('mouseup', handleMouseUp);
+  document.removeEventListener('mousemove', handleMouseMove);
+}
 </script>
 
 <style scoped>

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -74,380 +74,377 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { debounce, throttle } from 'throttle-debounce';
-import { defineComponent, PropType, StyleValue } from 'vue';
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  PropType,
+  ref,
+  StyleValue,
+  useTemplateRef,
+  watch,
+} from 'vue';
+import { ComponentExposed } from 'vue-component-type-helpers';
 
 import ContentEditable from '@/components/ContentEditable.vue';
+import { useResizeObserver } from '@/composables/useResizeObserver';
 import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
 import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
 import { replaceTokens, TokenMetadata } from '@/utils/replaceTokens';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: { ContentEditable },
-  props: {
-    element: {
-      type: Object as PropType<TextBoxElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    editMode: {
-      type: Boolean,
-      default: true,
-    },
-    selected: {
-      type: Boolean,
-      default: false,
-    },
-    metadata: {
-      type: Object as PropType<TokenMetadata>,
-      default: undefined,
-    },
+const emit = defineEmits(['update', 'update:height', 'select-single']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<TextBoxElement>,
+    required: true,
   },
-  emits: ['update', 'update:height', 'select-single'],
-
-  data() {
-    return {
-      resizeObserver: null as ResizeObserver | null,
-      unmounting: false,
-      setupResizeObserverDebounced: null as (() => void) | null,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    htmlElement() {
-      return this.$refs.container as HTMLElement;
-    },
-
-    content() {
-      return this.editMode || this.metadata == null
-        ? this.element.content
-        : replaceTokens(
-            this.element.content,
-            this.metadata,
-            this.element.alignment,
-          );
-    },
-
-    contentBottom() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentBottom
-        : replaceTokens(
-            this.element.contentBottom,
-            this.metadata,
-            this.element.alignment,
-          );
-    },
-
-    contentLeft() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentLeft
-        : replaceTokens(
-            this.element.contentLeft,
-            this.metadata,
-            TextBoxAlignment.Left,
-          );
-    },
-
-    contentCenter() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentCenter
-        : replaceTokens(
-            this.element.contentCenter,
-            this.metadata,
-            TextBoxAlignment.Center,
-          );
-    },
-
-    contentRight() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentRight
-        : replaceTokens(
-            this.element.contentRight,
-            this.metadata,
-            TextBoxAlignment.Right,
-          );
-    },
-
-    width() {
-      return withZoom(this.element.width);
-    },
-
-    containerStyle() {
-      const style = {
-        color: this.element.computedColor,
-        fontFamily: getFontFamilyWithFallback(this.element.computedFontFamily),
-        fontSize: withZoom(this.element.computedFontSize),
-        fontWeight: this.element.computedFontWeight,
-        fontStyle: this.element.computedFontStyle,
-        textAlign: this.element.alignment,
-        width: this.width,
-        height: withZoom(this.element.height),
-        minHeight: withZoom(this.element.minHeight),
-        webkitTextStrokeWidth: withZoom(this.element.computedStrokeWidth),
-        lineHeight: `${this.element.computedLineHeight ?? 'normal'}`,
-      } as StyleValue;
-
-      return style;
-    },
-
-    textBoxStyle() {
-      const style: any = {
-        width: !this.element.multipanel ? this.width : undefined,
-        height:
-          this.element.inline || this.element.customHeight
-            ? withZoom(this.element.height)
-            : undefined,
-        minHeight: withZoom(this.element.minHeight),
-        textWrap: this.element.alignment === 'center' ? 'balance' : 'pretty',
-      };
-
-      return style;
-    },
-
-    textBoxStyleTop() {
-      const style: any = {
-        width: this.width,
-        height: withZoom(this.element.height),
-        textWrap: this.element.alignment === 'center' ? 'balance' : 'pretty',
-      };
-
-      return style;
-    },
-
-    textBoxStyleBottom() {
-      const style: any = {
-        width: this.width,
-        textWrap: this.element.alignment === 'center' ? 'balance' : 'pretty',
-        top: withZoom(this.pageSetup.lyricsVerticalOffset),
-      };
-
-      return style;
-    },
-
-    textBoxClass() {
-      return {
-        underline: this.element.underline,
-      };
-    },
+  editMode: {
+    type: Boolean,
+    default: true,
   },
-
-  watch: {
-    'element.customHeight'(newVal) {
-      if (newVal == null) {
-        this.update();
-      }
-    },
+  selected: {
+    type: Boolean,
+    default: false,
   },
-
-  created() {
-    this.setupResizeObserverDebounced = debounce(100, this.setupResizeObserver);
+  metadata: {
+    type: Object as PropType<TokenMetadata>,
+    default: undefined,
   },
+});
 
-  mounted() {
-    const height = this.getHeight();
+const container = useTemplateRef<HTMLElement>('container');
+const text = useTemplateRef<ComponentExposed<typeof ContentEditable>>('text');
+const textLeft =
+  useTemplateRef<ComponentExposed<typeof ContentEditable>>('textLeft');
+const textRight =
+  useTemplateRef<ComponentExposed<typeof ContentEditable>>('textRight');
+const textCenter =
+  useTemplateRef<ComponentExposed<typeof ContentEditable>>('textCenter');
+const textBottom =
+  useTemplateRef<ComponentExposed<typeof ContentEditable>>('textBottom');
 
-    if (height != null && Math.abs(this.element.height - height) > 0.001) {
-      this.$emit('update:height', height);
-    }
+const unmounting = ref(false);
+const { disconnect: disconnectResizeObserver, observe: observeResize } =
+  useResizeObserver();
+const setupResizeObserverDebounced = debounce(100, setupResizeObserver);
 
-    this.setupResizeObserver();
-  },
+const htmlElement = computed(() => container.value!);
 
-  beforeUnmount() {
-    this.unmounting = true;
-    this.update();
+const content = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.content
+    : replaceTokens(
+        props.element.content,
+        props.metadata,
+        props.element.alignment,
+      );
+});
 
-    if (this.resizeObserver != null) {
-      this.resizeObserver.disconnect();
+const contentBottom = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentBottom
+    : replaceTokens(
+        props.element.contentBottom,
+        props.metadata,
+        props.element.alignment,
+      );
+});
+
+const contentLeft = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentLeft
+    : replaceTokens(
+        props.element.contentLeft,
+        props.metadata,
+        TextBoxAlignment.Left,
+      );
+});
+
+const contentCenter = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentCenter
+    : replaceTokens(
+        props.element.contentCenter,
+        props.metadata,
+        TextBoxAlignment.Center,
+      );
+});
+
+const contentRight = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentRight
+    : replaceTokens(
+        props.element.contentRight,
+        props.metadata,
+        TextBoxAlignment.Right,
+      );
+});
+
+const width = computed(() => withZoom(props.element.width));
+
+const containerStyle = computed(() => {
+  const style = {
+    color: props.element.computedColor,
+    fontFamily: getFontFamilyWithFallback(props.element.computedFontFamily),
+    fontSize: withZoom(props.element.computedFontSize),
+    fontWeight: props.element.computedFontWeight,
+    fontStyle: props.element.computedFontStyle,
+    textAlign: props.element.alignment,
+    width: width.value,
+    height: withZoom(props.element.height),
+    minHeight: withZoom(props.element.minHeight),
+    webkitTextStrokeWidth: withZoom(props.element.computedStrokeWidth),
+    lineHeight: `${props.element.computedLineHeight ?? 'normal'}`,
+  } as StyleValue;
+
+  return style;
+});
+
+const textBoxStyle = computed(() => {
+  const style: any = {
+    width: !props.element.multipanel ? width.value : undefined,
+    height:
+      props.element.inline || props.element.customHeight
+        ? withZoom(props.element.height)
+        : undefined,
+    minHeight: withZoom(props.element.minHeight),
+    textWrap: props.element.alignment === 'center' ? 'balance' : 'pretty',
+  };
+
+  return style;
+});
+
+const textBoxStyleTop = computed(() => {
+  const style: any = {
+    width: width.value,
+    height: withZoom(props.element.height),
+    textWrap: props.element.alignment === 'center' ? 'balance' : 'pretty',
+  };
+
+  return style;
+});
+
+const textBoxStyleBottom = computed(() => {
+  const style: any = {
+    width: width.value,
+    textWrap: props.element.alignment === 'center' ? 'balance' : 'pretty',
+    top: withZoom(props.pageSetup.lyricsVerticalOffset),
+  };
+
+  return style;
+});
+
+const textBoxClass = computed(() => {
+  return {
+    underline: props.element.underline,
+  };
+});
+
+watch(
+  () => props.element.customHeight,
+  (newVal) => {
+    if (newVal == null) {
+      update();
     }
   },
+);
 
-  methods: {
-    getTextElement() {
-      return this.$refs.text as InstanceType<typeof ContentEditable>;
-    },
+onMounted(() => {
+  const height = getHeight();
 
-    getTextElementLeft() {
-      return this.$refs.textLeft as InstanceType<typeof ContentEditable>;
-    },
+  if (height != null && Math.abs(props.element.height - height) > 0.001) {
+    emit('update:height', height);
+  }
 
-    getTextElementRight() {
-      return this.$refs.textRight as InstanceType<typeof ContentEditable>;
-    },
+  setupResizeObserver();
+});
 
-    getTextElementCenter() {
-      return this.$refs.textCenter as InstanceType<typeof ContentEditable>;
-    },
+onBeforeUnmount(() => {
+  unmounting.value = true;
+  update();
+  disconnectResizeObserver();
+});
 
-    getTextElementBottom() {
-      return this.$refs.textBottom as InstanceType<typeof ContentEditable>;
-    },
+function getTextElement() {
+  return text.value!;
+}
 
-    onEditorReady() {
-      this.setupResizeObserverDebounced!();
-    },
+function getTextElementLeft() {
+  return textLeft.value!;
+}
 
-    update() {
-      const updates: Partial<TextBoxElement> = {};
+function getTextElementRight() {
+  return textRight.value!;
+}
 
-      let updated = false;
+function getTextElementCenter() {
+  return textCenter.value!;
+}
 
-      const height = this.getHeight();
+function getTextElementBottom() {
+  return textBottom.value!;
+}
 
-      const content = this.getTextElement()?.getContent() ?? '';
-      const contentBottom = this.getTextElementBottom()?.getContent() ?? '';
-      const contentLeft = this.getTextElementLeft()?.getContent() ?? '';
-      const contentRight = this.getTextElementRight()?.getContent() ?? '';
-      const contentCenter = this.getTextElementCenter()?.getContent() ?? '';
+function onEditorReady() {
+  setupResizeObserverDebounced();
+}
 
-      // This should never happen, but if it does, we don't want
-      // to save garbage values.
-      if (height == null) {
-        return;
-      }
+function update() {
+  const updates: Partial<TextBoxElement> = {};
 
-      // Nothing actually changed, so do nothing
-      if (this.editMode && this.element.content !== content) {
-        updates.content = content;
-        updated = true;
-      }
+  let updated = false;
 
-      if (this.editMode && this.element.contentBottom !== contentBottom) {
-        updates.contentBottom = contentBottom;
-        updated = true;
-      }
+  const height = getHeight();
 
-      if (this.editMode && this.element.contentLeft !== contentLeft) {
-        updates.contentLeft = contentLeft;
-        updated = true;
-      }
+  const currentContent = getTextElement()?.getContent() ?? '';
+  const currentContentBottom = getTextElementBottom()?.getContent() ?? '';
+  const currentContentLeft = getTextElementLeft()?.getContent() ?? '';
+  const currentContentRight = getTextElementRight()?.getContent() ?? '';
+  const currentContentCenter = getTextElementCenter()?.getContent() ?? '';
 
-      if (this.editMode && this.element.contentRight !== contentRight) {
-        updates.contentRight = contentRight;
-        updated = true;
-      }
+  // This should never happen, but if it does, we don't want
+  // to save garbage values.
+  if (height == null) {
+    return;
+  }
 
-      if (this.editMode && this.element.contentCenter !== contentCenter) {
-        updates.contentCenter = contentCenter;
-        updated = true;
-      }
+  // Nothing actually changed, so do nothing
+  if (props.editMode && props.element.content !== currentContent) {
+    updates.content = currentContent;
+    updated = true;
+  }
 
-      if (
-        !this.element.inline &&
-        Math.abs(this.element.height - height) > 0.001
-      ) {
-        updates.height = height;
-        updated = true;
-      }
+  if (props.editMode && props.element.contentBottom !== currentContentBottom) {
+    updates.contentBottom = currentContentBottom;
+    updated = true;
+  }
 
-      if (updated) {
-        this.$emit('update', updates);
-      }
-    },
+  if (props.editMode && props.element.contentLeft !== currentContentLeft) {
+    updates.contentLeft = currentContentLeft;
+    updated = true;
+  }
 
-    blur() {
-      this.getTextElement()?.blur();
-    },
+  if (props.editMode && props.element.contentRight !== currentContentRight) {
+    updates.contentRight = currentContentRight;
+    updated = true;
+  }
 
-    focus() {
-      this.getTextElement()?.focus(true);
-    },
+  if (props.editMode && props.element.contentCenter !== currentContentCenter) {
+    updates.contentCenter = currentContentCenter;
+    updated = true;
+  }
 
-    setupResizeObserver() {
-      if (
-        this.getTextElement() ||
-        (this.getTextElementLeft() &&
-          this.getTextElementCenter() &&
-          this.getTextElementRight())
-      ) {
-        if (this.resizeObserver != null) {
-          this.resizeObserver.disconnect();
-        }
+  if (
+    !props.element.inline &&
+    Math.abs(props.element.height - height) > 0.001
+  ) {
+    updates.height = height;
+    updated = true;
+  }
 
-        this.resizeObserver = new ResizeObserver(
-          throttle(100, () => {
-            const resizedHeight = this.getHeight();
+  if (updated) {
+    emit('update', updates);
+  }
+}
 
-            if (
-              resizedHeight != null &&
-              Math.abs(this.element.height - resizedHeight) > 0.001
-            ) {
-              this.$emit('update', { height: resizedHeight });
-            }
-          }),
-        );
+function blur() {
+  getTextElement()?.blur();
+}
 
-        if (this.getTextElement()) {
-          this.resizeObserver.observe(this.getTextElement().htmlElement);
-        }
+function focus() {
+  getTextElement()?.focus(true);
+}
 
-        if (this.getTextElementLeft()) {
-          this.resizeObserver.observe(this.getTextElementLeft().htmlElement);
-        }
-        if (this.getTextElementCenter()) {
-          this.resizeObserver.observe(this.getTextElementCenter().htmlElement);
-        }
-        if (this.getTextElementRight()) {
-          this.resizeObserver.observe(this.getTextElementRight().htmlElement);
-        }
-      }
-    },
+function setupResizeObserver() {
+  const textElement = getTextElement();
+  const textElementLeft = getTextElementLeft();
+  const textElementCenter = getTextElementCenter();
+  const textElementRight = getTextElementRight();
 
-    getHeight() {
-      if (this.element.multipanel) {
+  if (
+    textElement ||
+    (textElementLeft && textElementCenter && textElementRight)
+  ) {
+    const elements = [
+      textElement,
+      textElementLeft,
+      textElementCenter,
+      textElementRight,
+    ]
+      .filter((element) => element != null)
+      .map((element) => element.htmlElement);
+
+    observeResize(
+      elements,
+      throttle(100, () => {
+        const resizedHeight = getHeight();
+
         if (
-          this.getTextElementLeft() == null ||
-          this.getTextElementCenter() == null ||
-          this.getTextElementRight() == null
+          resizedHeight != null &&
+          Math.abs(props.element.height - resizedHeight) > 0.001
         ) {
-          return null;
+          emit('update', { height: resizedHeight });
         }
+      }),
+    );
+  }
+}
 
-        const zoom = Number(
-          getComputedStyle(
-            this.getTextElementCenter().htmlElement,
-          ).getPropertyValue('--zoom'),
-        );
+function getHeight() {
+  if (props.element.multipanel) {
+    if (
+      getTextElementLeft() == null ||
+      getTextElementCenter() == null ||
+      getTextElementRight() == null
+    ) {
+      return null;
+    }
 
-        return (
-          Math.max(
-            this.getTextElementLeft().htmlElement.getBoundingClientRect()
-              .height,
-            this.getTextElementCenter().htmlElement.getBoundingClientRect()
-              .height,
-            this.getTextElementRight().htmlElement.getBoundingClientRect()
-              .height,
-          ) / zoom
-        );
-      }
+    const zoom = Number(
+      getComputedStyle(getTextElementCenter()!.htmlElement).getPropertyValue(
+        '--zoom',
+      ),
+    );
 
-      if (this.getTextElement() == null) {
-        return null;
-      }
+    return (
+      Math.max(
+        getTextElementLeft()!.htmlElement.getBoundingClientRect().height,
+        getTextElementCenter()!.htmlElement.getBoundingClientRect().height,
+        getTextElementRight()!.htmlElement.getBoundingClientRect().height,
+      ) / zoom
+    );
+  }
 
-      const zoom = Number(
-        getComputedStyle(this.getTextElement().htmlElement).getPropertyValue(
-          '--zoom',
-        ),
-      );
+  if (getTextElement() == null) {
+    return null;
+  }
 
-      return (
-        this.getTextElement().htmlElement.getBoundingClientRect().height / zoom
-      );
-    },
+  const zoom = Number(
+    getComputedStyle(getTextElement()!.htmlElement).getPropertyValue('--zoom'),
+  );
 
-    onBlur() {
-      if (!this.unmounting) {
-        this.update();
-      }
-    },
-  },
+  return getTextElement()!.htmlElement.getBoundingClientRect().height / zoom;
+}
+
+function onBlur() {
+  if (!unmounting.value) {
+    update();
+  }
+}
+
+defineExpose({
+  blur,
+  focus,
+  getTextElement,
+  htmlElement,
 });
 </script>
 

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -132,8 +132,7 @@ const textBottom =
   useTemplateRef<ComponentExposed<typeof ContentEditable>>('textBottom');
 
 const unmounting = ref(false);
-const { disconnect: disconnectResizeObserver, observe: observeResize } =
-  useResizeObserver();
+const { observe: observeResize } = useResizeObserver();
 const setupResizeObserverDebounced = debounce(100, setupResizeObserver);
 
 const htmlElement = computed(() => container.value!);
@@ -270,7 +269,8 @@ onMounted(() => {
 onBeforeUnmount(() => {
   unmounting.value = true;
   update();
-  disconnectResizeObserver();
+  // Observer is disconnected automatically by useResizeObserver's own
+  // onBeforeUnmount hook.
 });
 
 function getTextElement() {

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -15,7 +15,7 @@
       <ckeditor
         ref="editorLeft"
         class="rich-text-editor multipanel left"
-        :editor="editor"
+        :editor="ckeditorEditor"
         :model-value="contentLeft"
         :config="editorConfig"
         :disable-watchdog="true"
@@ -24,7 +24,7 @@
       <ckeditor
         ref="editorCenter"
         class="rich-text-editor multipanel center"
-        :editor="editor"
+        :editor="ckeditorEditor"
         :model-value="contentCenter"
         :config="editorConfig"
         :disable-watchdog="true"
@@ -34,7 +34,7 @@
       <ckeditor
         ref="editorRight"
         class="rich-text-editor multipanel right"
-        :editor="editor"
+        :editor="ckeditorEditor"
         :model-value="contentRight"
         :config="editorConfig"
         :disable-watchdog="true"
@@ -51,7 +51,7 @@
             ref="editor"
             class="rich-text-editor inline-top"
             :style="textBoxStyleTop"
-            :editor="editor"
+            :editor="ckeditorEditor"
             :model-value="content"
             :config="editorConfig"
             :disable-watchdog="true"
@@ -65,7 +65,7 @@
           ref="editorBottom"
           class="rich-text-editor inline-bottom"
           :style="textBoxStyleBottom"
-          :editor="editor"
+          :editor="ckeditorEditor"
           :model-value="contentBottom"
           :config="editorConfig"
           :disable-watchdog="true"
@@ -78,7 +78,7 @@
       v-else-if="element.scrollable"
       ref="editor"
       class="rich-text-editor single scrollable"
-      :editor="editor"
+      :editor="ckeditorEditor"
       :model-value="content"
       :config="editorConfig"
       :disable-watchdog="true"
@@ -90,7 +90,7 @@
       v-else
       ref="editor"
       class="rich-text-editor single"
-      :editor="editor"
+      :editor="ckeditorEditor"
       :model-value="content"
       :config="editorConfig"
       :disable-watchdog="true"
@@ -101,14 +101,23 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { FontSizeOption } from '@ckeditor/ckeditor5-font';
 import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 import { Editor, EditorConfig } from 'ckeditor5';
 import { debounce, throttle } from 'throttle-debounce';
-import { defineComponent, PropType, StyleValue } from 'vue';
-import type { ComponentExposed } from 'vue-component-type-helpers';
+import {
+  computed,
+  onBeforeUnmount,
+  PropType,
+  ref,
+  StyleValue,
+  useTemplateRef,
+  watch,
+} from 'vue';
+import { ComponentExposed } from 'vue-component-type-helpers';
 
+import { useResizeObserver } from '@/composables/useResizeObserver';
 import InlineEditor from '@/customEditor';
 import { RichTextBoxElement, TextBoxAlignment } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
@@ -116,526 +125,499 @@ import { getFontFamilyWithFallback } from '@/utils/getFontFamilyWithFallback';
 import { replaceTokens, TokenMetadata } from '@/utils/replaceTokens';
 import { withZoom } from '@/utils/withZoom';
 
-export default defineComponent({
-  components: {},
-  props: {
-    element: {
-      type: Object as PropType<RichTextBoxElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    fonts: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
-    editMode: {
-      type: Boolean,
-      default: true,
-    },
-    selected: {
-      type: Boolean,
-      default: false,
-    },
-    metadata: {
-      type: Object as PropType<TokenMetadata>,
-      default: undefined,
-    },
-    recalc: {
-      type: Boolean,
-      default: false,
-    },
+const emit = defineEmits(['update', 'update:height', 'select-single']);
+const props = defineProps({
+  element: {
+    type: Object as PropType<RichTextBoxElement>,
+    required: true,
   },
-  emits: ['update', 'update:height', 'select-single'],
-
-  data() {
-    return {
-      editor: InlineEditor,
-      editorData: '',
-
-      focusOnReady: false,
-      unmounting: false,
-
-      heightBottom: 0,
-      heightTop: 0,
-      resizeObserver: null as ResizeObserver | null,
-      inlineBottomObserver: null as ResizeObserver | null,
-      inlineTopObserver: null as ResizeObserver | null,
-      debouncedPhoneHome: null as ((x: number) => void) | null,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
+  fonts: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
+  editMode: {
+    type: Boolean,
+    default: true,
+  },
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+  metadata: {
+    type: Object as PropType<TokenMetadata>,
+    default: undefined,
+  },
+  recalc: {
+    type: Boolean,
+    default: false,
+  },
+});
 
-  computed: {
-    editorConfig(): EditorConfig {
-      const fontSizeOptions: FontSizeOption[] = [];
+const ckeditorEditor = InlineEditor;
 
-      for (let i = 8; i <= 72; i++) {
-        fontSizeOptions.push({
-          title: `${i}`,
-          model: `${i}pt`,
-        });
-      }
+const container = useTemplateRef<HTMLElement>('container');
+const editorRef = useTemplateRef<ComponentExposed<typeof Ckeditor>>('editor');
+const editorBottom =
+  useTemplateRef<ComponentExposed<typeof Ckeditor>>('editorBottom');
+const editorLeft =
+  useTemplateRef<ComponentExposed<typeof Ckeditor>>('editorLeft');
+const editorCenter =
+  useTemplateRef<ComponentExposed<typeof Ckeditor>>('editorCenter');
+const editorRight =
+  useTemplateRef<ComponentExposed<typeof Ckeditor>>('editorRight');
 
-      // Add a fall back font to each font so that neumes "just work"
-      const fonts = this.fonts.map(
-        (x) => x + ',' + this.pageSetup.neumeDefaultFontFamily,
+const focusOnReady = ref(false);
+const unmounting = ref(false);
+const heightBottom = ref(0);
+const heightTop = ref(0);
+const debouncedPhoneHome = debounce(100, phoneHome);
+const { disconnect: disconnectResizeObserver, observe: observeResize } =
+  useResizeObserver();
+const { disconnect: disconnectInlineTopObserver, observe: observeInlineTop } =
+  useResizeObserver();
+const {
+  disconnect: disconnectInlineBottomObserver,
+  observe: observeInlineBottom,
+} = useResizeObserver();
+
+const htmlElement = computed(() => container.value!);
+
+const editorConfig = computed((): EditorConfig => {
+  const fontSizeOptions: FontSizeOption[] = [];
+
+  for (let i = 8; i <= 72; i++) {
+    fontSizeOptions.push({
+      title: `${i}`,
+      model: `${i}pt`,
+    });
+  }
+
+  // Add a fall back font to each font so that neumes "just work"
+  const fonts = props.fonts.map(
+    (x) => x + ',' + props.pageSetup.neumeDefaultFontFamily,
+  );
+
+  return {
+    fontFamily: {
+      options: [
+        'default',
+        'Source Serif' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'GFS Didot' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'Noto Naskh Arabic' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'Old Standard' + ',' + props.pageSetup.neumeDefaultFontFamily,
+        'Neanes',
+        'NeanesStathisSeries',
+        ...fonts,
+      ],
+    },
+    fontSize: {
+      supportAllValues: true,
+      options: ['default', ...fontSizeOptions],
+    },
+    language: {
+      content: props.element.rtl ? 'ar' : 'en',
+    },
+    licenseKey: 'GPL',
+    insertNeume: {
+      neumeDefaultFontFamily: props.pageSetup.neumeDefaultFontFamily,
+      defaultFontSize: props.element.inline
+        ? props.pageSetup.lyricsDefaultFontSize
+        : props.pageSetup.textBoxDefaultFontSize,
+      defaultFontFamily: props.element.inline
+        ? props.pageSetup.lyricsDefaultFontFamily
+        : props.pageSetup.textBoxDefaultFontFamily,
+      fthoraDefaultColor: props.pageSetup.fthoraDefaultColor,
+    },
+  };
+});
+
+const content = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.content
+    : replaceTokens(
+        props.element.content,
+        props.metadata,
+        TextBoxAlignment.Center,
       );
+});
 
-      return {
-        fontFamily: {
-          options: [
-            'default',
-            'Source Serif' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'GFS Didot' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'Noto Naskh Arabic' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'Old Standard' + ',' + this.pageSetup.neumeDefaultFontFamily,
-            'Neanes',
-            'NeanesStathisSeries',
-            ...fonts,
-          ],
-        },
-        fontSize: {
-          supportAllValues: true,
-          options: ['default', ...fontSizeOptions],
-        },
-        language: {
-          content: this.element.rtl ? 'ar' : 'en',
-        },
-        licenseKey: 'GPL',
-        insertNeume: {
-          neumeDefaultFontFamily: this.pageSetup.neumeDefaultFontFamily,
-          defaultFontSize: this.element.inline
-            ? this.pageSetup.lyricsDefaultFontSize
-            : this.pageSetup.textBoxDefaultFontSize,
-          defaultFontFamily: this.element.inline
-            ? this.pageSetup.lyricsDefaultFontFamily
-            : this.pageSetup.textBoxDefaultFontFamily,
-          fthoraDefaultColor: this.pageSetup.fthoraDefaultColor,
-        },
-      };
-    },
+const contentBottom = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentBottom
+    : replaceTokens(
+        props.element.contentBottom,
+        props.metadata,
+        TextBoxAlignment.Center,
+      );
+});
 
-    content() {
-      return this.editMode || this.metadata == null
-        ? this.element.content
-        : replaceTokens(
-            this.element.content,
-            this.metadata,
-            TextBoxAlignment.Center,
-          );
-    },
+const contentLeft = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentLeft
+    : replaceTokens(
+        props.element.contentLeft,
+        props.metadata,
+        TextBoxAlignment.Left,
+      );
+});
 
-    contentBottom() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentBottom
-        : replaceTokens(
-            this.element.contentBottom,
-            this.metadata,
-            TextBoxAlignment.Center,
-          );
-    },
+const contentCenter = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentCenter
+    : replaceTokens(
+        props.element.contentCenter,
+        props.metadata,
+        TextBoxAlignment.Center,
+      );
+});
 
-    contentLeft() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentLeft
-        : replaceTokens(
-            this.element.contentLeft,
-            this.metadata,
-            TextBoxAlignment.Left,
-          );
-    },
+const contentRight = computed(() => {
+  return props.editMode || props.metadata == null
+    ? props.element.contentRight
+    : replaceTokens(
+        props.element.contentRight,
+        props.metadata,
+        TextBoxAlignment.Right,
+      );
+});
 
-    contentCenter() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentCenter
-        : replaceTokens(
-            this.element.contentCenter,
-            this.metadata,
-            TextBoxAlignment.Center,
-          );
-    },
+const containerStyle = computed(() => {
+  const style: StyleValue = {
+    width: withZoom(props.element.width),
+    height: withZoom(props.element.height),
+    '--ck-content-font-family': getFontFamilyWithFallback(
+      props.pageSetup.textBoxDefaultFontFamily,
+      props.pageSetup.neumeDefaultFontFamily,
+    ),
+    '--ck-content-font-size': props.element.inline
+      ? `${props.pageSetup.lyricsDefaultFontSize}px`
+      : `${props.pageSetup.textBoxDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
+    '--ck-content-line-height': 'normal',
+  };
 
-    contentRight() {
-      return this.editMode || this.metadata == null
-        ? this.element.contentRight
-        : replaceTokens(
-            this.element.contentRight,
-            this.metadata,
-            TextBoxAlignment.Right,
-          );
-    },
+  return style;
+});
 
-    containerStyle() {
-      const style: StyleValue = {
-        width: withZoom(this.element.width),
-        height: withZoom(this.element.height),
-        '--ck-content-font-family': getFontFamilyWithFallback(
-          this.pageSetup.textBoxDefaultFontFamily,
-          this.pageSetup.neumeDefaultFontFamily,
-        ),
-        '--ck-content-font-size': this.element.inline
-          ? `${this.pageSetup.lyricsDefaultFontSize}px`
-          : `${this.pageSetup.textBoxDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
-        '--ck-content-line-height': 'normal',
-      };
+const textBoxStyle = computed(() => {
+  const style: StyleValue = {
+    width: `${props.element.width}px`, // no zoom because we scale with the transform
+    maxHeight: withZoom(
+      props.pageSetup.pageHeight -
+        props.element.y -
+        props.pageSetup.bottomMargin,
+    ),
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    textBoxStyle() {
-      const style: StyleValue = {
-        width: `${this.element.width}px`, // no zoom because we scale with the transform
-        maxHeight: withZoom(
-          this.pageSetup.pageHeight -
-            this.element.y -
-            this.pageSetup.bottomMargin,
-        ),
-      };
+const textBoxTopInnerContainerStyle = computed(() => {
+  // The top text box is aligned such that the middle of the oligon sits in middle of the font.
+  const style: any = {
+    top: withZoom(
+      props.element.defaultNeumeFontAscent -
+        props.pageSetup.neumeDefaultFontSize * props.element.oligonMidpoint -
+        props.element.defaultLyricsFontHeight / 2 -
+        (heightTop.value - props.element.defaultLyricsFontHeight) +
+        props.element.offsetYTop,
+    ),
+    lineHeight: props.element.defaultLyricsFontHeight + 'px',
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    textBoxTopInnerContainerStyle() {
-      // The top text box is aligned such that the middle of the oligon sits in middle of the font.
-      const style: any = {
-        top: withZoom(
-          this.element.defaultNeumeFontAscent -
-            this.pageSetup.neumeDefaultFontSize * this.element.oligonMidpoint -
-            this.element.defaultLyricsFontHeight / 2 -
-            (this.heightTop - this.element.defaultLyricsFontHeight) +
-            this.element.offsetYTop,
-        ),
-        lineHeight: this.element.defaultLyricsFontHeight + 'px',
-      };
+const textBoxStyleTop = computed(() => {
+  const style: any = {
+    width: `${props.element.width}px`, // no zoom because we scale with the transform
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    textBoxStyleTop() {
-      const style: any = {
-        width: `${this.element.width}px`, // no zoom because we scale with the transform
-      };
+const textBoxStyleBottom = computed(() => {
+  const style: any = {
+    width: `${props.element.width}px`, // no zoom because we scale with the transform
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    textBoxStyleBottom() {
-      const style: any = {
-        width: `${this.element.width}px`, // no zoom because we scale with the transform
-      };
+const textBoxTopContainerStyle = computed(() => {
+  const style: any = {
+    height: withZoom(props.element.height),
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    textBoxTopContainerStyle() {
-      const style: any = {
-        height: withZoom(this.element.height),
-      };
+const textBoxBottomContainerStyle = computed(() => {
+  // The bottom text box is aligned so that the baseline of the font is aligned with the lyrics baseline.
+  const style: any = {
+    top: withZoom(
+      props.pageSetup.lyricsVerticalOffset -
+        (heightBottom.value - props.element.defaultLyricsFontHeight) +
+        props.element.offsetYBottom,
+    ),
+    lineHeight: props.element.defaultLyricsFontHeight + 'px',
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    textBoxBottomContainerStyle() {
-      // The bottom text box is aligned so that the baseline of the font is aligned with the lyrics baseline.
-      const style: any = {
-        top: withZoom(
-          this.pageSetup.lyricsVerticalOffset -
-            (this.heightBottom - this.element.defaultLyricsFontHeight) +
-            this.element.offsetYBottom,
-        ),
-        lineHeight: this.element.defaultLyricsFontHeight + 'px',
-      };
+const multipanelContainerStyle = computed(() => {
+  const style: StyleValue = {
+    width: `${props.element.width}px`, // no zoom because we scale with the transform
+  };
 
-      return style;
-    },
+  return style;
+});
 
-    multipanelContainerStyle() {
-      const style: StyleValue = {
-        width: `${this.element.width}px`, // no zoom because we scale with the transform
-      };
-
-      return style;
-    },
+watch(
+  () => props.element.centerOnPage,
+  () => {
+    setPadding(getEditorInstance());
+    setPadding(getEditorInstanceBottom());
   },
+);
 
-  watch: {
-    'element.centerOnPage'() {
-      this.setPadding(this.getEditorInstance());
-      this.setPadding(this.getEditorInstanceBottom());
-    },
-  },
+onBeforeUnmount(() => {
+  unmounting.value = true;
+  update();
+  disconnectInlineTopObserver();
+  disconnectInlineBottomObserver();
+  disconnectResizeObserver();
+});
 
-  created() {
-    this.debouncedPhoneHome = debounce(100, this.phoneHome);
-  },
+function getEditorInstance() {
+  return editorRef.value?.instance;
+}
 
-  beforeUnmount() {
-    this.unmounting = true;
-    this.update();
+function getEditorInstanceBottom() {
+  return editorBottom.value?.instance;
+}
 
-    if (this.inlineTopObserver != null) {
-      this.inlineTopObserver.disconnect();
+function getEditorInstanceLeft() {
+  return editorLeft.value?.instance;
+}
+
+function getEditorInstanceCenter() {
+  return editorCenter.value?.instance;
+}
+
+function getEditorInstanceRight() {
+  return editorRight.value?.instance;
+}
+
+function phoneHome(height: number) {
+  emit('update:height', height);
+}
+
+function onEditorReady(editor: InlineEditor) {
+  if (props.recalc) {
+    const height = getHeight();
+
+    if (height != null && Math.abs(props.element.height - height) > 0.001) {
+      debouncedPhoneHome(height);
     }
+  }
 
-    if (this.inlineBottomObserver != null) {
-      this.inlineBottomObserver.disconnect();
-    }
+  if (focusOnReady.value) {
+    editor.editing.view.focus();
+    focusOnReady.value = false;
+  }
 
-    if (this.resizeObserver != null) {
-      this.resizeObserver.disconnect();
-    }
-  },
+  const element = editor.sourceElement;
 
-  methods: {
-    getEditorInstance() {
-      return (this.$refs.editor as ComponentExposed<typeof Ckeditor>)?.instance;
-    },
-
-    getEditorInstanceBottom() {
-      return (this.$refs.editorBottom as ComponentExposed<typeof Ckeditor>)
-        ?.instance;
-    },
-
-    getEditorInstanceLeft() {
-      return (this.$refs.editorLeft as ComponentExposed<typeof Ckeditor>)
-        ?.instance;
-    },
-
-    getEditorInstanceCenter() {
-      return (this.$refs.editorCenter as ComponentExposed<typeof Ckeditor>)
-        ?.instance;
-    },
-
-    getEditorInstanceRight() {
-      return (this.$refs.editorRight as ComponentExposed<typeof Ckeditor>)
-        ?.instance;
-    },
-
-    phoneHome(height: number) {
-      this.$emit('update:height', height);
-    },
-
-    onEditorReady(editor: InlineEditor) {
-      if (this.recalc) {
-        const height = this.getHeight();
-
-        if (height != null && Math.abs(this.element.height - height) > 0.001) {
-          this.debouncedPhoneHome!(height);
-        }
-      }
-
-      if (this.focusOnReady) {
-        editor.editing.view.focus();
-        this.focusOnReady = false;
-      }
-
-      const element = editor.sourceElement;
-
-      if (this.resizeObserver != null) {
-        this.resizeObserver.disconnect();
-      }
-
-      this.resizeObserver = new ResizeObserver(
-        debounce(100, () => {
-          const resizedHeight = this.getHeight();
-
-          if (
-            resizedHeight != null &&
-            Math.abs(this.element.height - resizedHeight) > 0.001
-          ) {
-            if (this.recalc) {
-              this.debouncedPhoneHome!(resizedHeight);
-            } else {
-              this.$emit('update', { height: resizedHeight });
-            }
-          }
-        }),
-      );
-
-      this.resizeObserver.observe(element!);
-    },
-
-    onEditorReadyInline(editor: InlineEditor) {
-      this.heightTop = this.getHeightTop() ?? 0;
-
-      const element = editor.sourceElement;
-
-      if (this.inlineTopObserver != null) {
-        this.inlineTopObserver.disconnect();
-      }
-
-      this.inlineTopObserver = new ResizeObserver(
-        throttle(100, () => {
-          this.heightTop = this.getHeightTop() ?? 0;
-        }),
-      );
-
-      this.inlineTopObserver.observe(element!);
-
-      this.setPadding(editor);
-    },
-
-    onEditorReadyInlineBottom(editor: InlineEditor) {
-      if (this.focusOnReady) {
-        editor.editing.view.focus();
-        this.focusOnReady = false;
-      }
-
-      this.heightBottom = this.getHeightBottom() ?? 0;
-
-      const element = editor.sourceElement;
-
-      if (this.inlineBottomObserver != null) {
-        this.inlineBottomObserver.disconnect();
-      }
-
-      this.inlineBottomObserver = new ResizeObserver(
-        throttle(100, () => {
-          this.heightBottom = this.getHeightBottom() ?? 0;
-        }),
-      );
-
-      this.inlineBottomObserver.observe(element!);
-
-      this.setPadding(editor);
-    },
-
-    onBlur() {
-      if (!this.unmounting) {
-        this.update();
-      }
-    },
-
-    update() {
-      const updates: Partial<RichTextBoxElement> = {};
-
-      let updated = false;
-
-      const height = this.getHeight();
-
-      const content = this.getEditorInstance()?.getData() ?? '';
-      const contentBottom = this.getEditorInstanceBottom()?.getData() ?? '';
-      const contentLeft = this.getEditorInstanceLeft()?.getData() ?? '';
-      const contentCenter = this.getEditorInstanceCenter()?.getData() ?? '';
-      const contentRight = this.getEditorInstanceRight()?.getData() ?? '';
-
-      // This should never happen, but if it does, we don't want
-      // to save garbage values.
-      if (height == null) {
-        return;
-      }
-
-      if (this.editMode && this.element.content !== content) {
-        updates.content = content;
-        updated = true;
-      }
-
-      if (this.editMode && this.element.contentBottom !== contentBottom) {
-        updates.contentBottom = contentBottom;
-        updated = true;
-      }
-
-      if (this.editMode && this.element.contentLeft !== contentLeft) {
-        updates.contentLeft = contentLeft;
-        updated = true;
-      }
-
-      if (this.editMode && this.element.contentCenter !== contentCenter) {
-        updates.contentCenter = contentCenter;
-        updated = true;
-      }
-
-      if (this.editMode && this.element.contentRight !== contentRight) {
-        updates.contentRight = contentRight;
-        updated = true;
-      }
+  observeResize(
+    element!,
+    debounce(100, () => {
+      const resizedHeight = getHeight();
 
       if (
-        !this.element.inline &&
-        Math.abs(this.element.height - height) > 0.001
+        resizedHeight != null &&
+        Math.abs(props.element.height - resizedHeight) > 0.001
       ) {
-        updates.height = height;
-        updated = true;
-      }
-
-      if (this.element.inline) {
-        this.heightBottom = this.getHeightBottom() ?? 0;
-        this.heightTop = this.getHeightTop() ?? 0;
-      }
-
-      if (updated) {
-        this.$emit('update', updates);
-      }
-    },
-
-    getHeight() {
-      const element = (this.$refs.container as HTMLElement).querySelector(
-        '.ck-content',
-      );
-
-      if (element == null) {
-        return null;
-      }
-
-      const zoom = Number(getComputedStyle(element).getPropertyValue('--zoom'));
-
-      return element.getBoundingClientRect().height / zoom;
-    },
-
-    getHeightBottom() {
-      const element = (this.$refs.container as HTMLElement).querySelector(
-        '.ck-content.inline-bottom',
-      );
-
-      if (element == null) {
-        return null;
-      }
-
-      const zoom = Number(getComputedStyle(element).getPropertyValue('--zoom'));
-
-      return element.getBoundingClientRect().height / zoom;
-    },
-
-    getHeightTop() {
-      const element = (this.$refs.container as HTMLElement).querySelector(
-        '.ck-content.inline-top',
-      );
-
-      if (element == null) {
-        return null;
-      }
-
-      const zoom = Number(getComputedStyle(element).getPropertyValue('--zoom'));
-
-      return element.getBoundingClientRect().height / zoom;
-    },
-
-    setPadding(editor: Editor | undefined) {
-      if (editor == null) {
-        return;
-      }
-
-      editor.editing.view.change((writer) => {
-        const editable = editor.editing.view.document.getRoot();
-
-        if (this.element.centerOnPage) {
-          writer.setStyle(
-            'padding-right',
-            `${this.pageSetup.innerPageWidth - this.element.width}px`,
-            editable!,
-          );
+        if (props.recalc) {
+          debouncedPhoneHome(resizedHeight);
         } else {
-          writer.removeStyle('padding-right', editable!);
+          emit('update', { height: resizedHeight });
         }
-      });
-    },
+      }
+    }),
+  );
+}
 
-    focus() {
-      this.focusOnReady = true;
-    },
-  },
+function onEditorReadyInline(editor: InlineEditor) {
+  heightTop.value = getHeightTop() ?? 0;
+
+  const element = editor.sourceElement;
+
+  observeInlineTop(
+    element!,
+    throttle(100, () => {
+      heightTop.value = getHeightTop() ?? 0;
+    }),
+  );
+
+  setPadding(editor);
+}
+
+function onEditorReadyInlineBottom(editor: InlineEditor) {
+  if (focusOnReady.value) {
+    editor.editing.view.focus();
+    focusOnReady.value = false;
+  }
+
+  heightBottom.value = getHeightBottom() ?? 0;
+
+  const element = editor.sourceElement;
+
+  observeInlineBottom(
+    element!,
+    throttle(100, () => {
+      heightBottom.value = getHeightBottom() ?? 0;
+    }),
+  );
+
+  setPadding(editor);
+}
+
+function onBlur() {
+  if (!unmounting.value) {
+    update();
+  }
+}
+
+function update() {
+  const updates: Partial<RichTextBoxElement> = {};
+
+  let updated = false;
+
+  const height = getHeight();
+
+  const currentContent = getEditorInstance()?.getData() ?? '';
+  const currentContentBottom = getEditorInstanceBottom()?.getData() ?? '';
+  const currentContentLeft = getEditorInstanceLeft()?.getData() ?? '';
+  const currentContentCenter = getEditorInstanceCenter()?.getData() ?? '';
+  const currentContentRight = getEditorInstanceRight()?.getData() ?? '';
+
+  // This should never happen, but if it does, we don't want
+  // to save garbage values.
+  if (height == null) {
+    return;
+  }
+
+  if (props.editMode && props.element.content !== currentContent) {
+    updates.content = currentContent;
+    updated = true;
+  }
+
+  if (props.editMode && props.element.contentBottom !== currentContentBottom) {
+    updates.contentBottom = currentContentBottom;
+    updated = true;
+  }
+
+  if (props.editMode && props.element.contentLeft !== currentContentLeft) {
+    updates.contentLeft = currentContentLeft;
+    updated = true;
+  }
+
+  if (props.editMode && props.element.contentCenter !== currentContentCenter) {
+    updates.contentCenter = currentContentCenter;
+    updated = true;
+  }
+
+  if (props.editMode && props.element.contentRight !== currentContentRight) {
+    updates.contentRight = currentContentRight;
+    updated = true;
+  }
+
+  if (
+    !props.element.inline &&
+    Math.abs(props.element.height - height) > 0.001
+  ) {
+    updates.height = height;
+    updated = true;
+  }
+
+  if (props.element.inline) {
+    heightBottom.value = getHeightBottom() ?? 0;
+    heightTop.value = getHeightTop() ?? 0;
+  }
+
+  if (updated) {
+    emit('update', updates);
+  }
+}
+
+function getHeight() {
+  const element = container.value?.querySelector('.ck-content');
+
+  if (element == null) {
+    return null;
+  }
+
+  const zoom = Number(getComputedStyle(element).getPropertyValue('--zoom'));
+
+  return element.getBoundingClientRect().height / zoom;
+}
+
+function getHeightBottom() {
+  const element = container.value?.querySelector('.ck-content.inline-bottom');
+
+  if (element == null) {
+    return null;
+  }
+
+  const zoom = Number(getComputedStyle(element).getPropertyValue('--zoom'));
+
+  return element.getBoundingClientRect().height / zoom;
+}
+
+function getHeightTop() {
+  const element = container.value?.querySelector('.ck-content.inline-top');
+
+  if (element == null) {
+    return null;
+  }
+
+  const zoom = Number(getComputedStyle(element).getPropertyValue('--zoom'));
+
+  return element.getBoundingClientRect().height / zoom;
+}
+
+function setPadding(editor: Editor | undefined) {
+  if (editor == null) {
+    return;
+  }
+
+  editor.editing.view.change((writer) => {
+    const editable = editor.editing.view.document.getRoot();
+
+    if (props.element.centerOnPage) {
+      writer.setStyle(
+        'padding-right',
+        `${props.pageSetup.innerPageWidth - props.element.width}px`,
+        editable!,
+      );
+    } else {
+      writer.removeStyle('padding-right', editable!);
+    }
+  });
+}
+
+function focus() {
+  focusOnReady.value = true;
+}
+
+defineExpose({
+  focus,
+  htmlElement,
 });
 </script>
 

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -175,14 +175,9 @@ const unmounting = ref(false);
 const heightBottom = ref(0);
 const heightTop = ref(0);
 const debouncedPhoneHome = debounce(100, phoneHome);
-const { disconnect: disconnectResizeObserver, observe: observeResize } =
-  useResizeObserver();
-const { disconnect: disconnectInlineTopObserver, observe: observeInlineTop } =
-  useResizeObserver();
-const {
-  disconnect: disconnectInlineBottomObserver,
-  observe: observeInlineBottom,
-} = useResizeObserver();
+const { observe: observeResize } = useResizeObserver();
+const { observe: observeInlineTop } = useResizeObserver();
+const { observe: observeInlineBottom } = useResizeObserver();
 
 const htmlElement = computed(() => container.value!);
 
@@ -388,9 +383,8 @@ watch(
 onBeforeUnmount(() => {
   unmounting.value = true;
   update();
-  disconnectInlineTopObserver();
-  disconnectInlineBottomObserver();
-  disconnectResizeObserver();
+  // Observers are disconnected automatically by useResizeObserver's own
+  // onBeforeUnmount hook.
 });
 
 function getEditorInstance() {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -7,7 +7,6 @@ import { useTranslation } from 'i18next-vue';
 import { debounce, throttle } from 'throttle-debounce';
 import {
   computed,
-  getCurrentInstance,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -25,12 +24,13 @@ import AlternateLine from '@/components/AlternateLine.vue';
 import ContentEditable from '@/components/ContentEditable.vue';
 import DropCap from '@/components/DropCap.vue';
 import EditorPreferencesDialog from '@/components/EditorPreferencesDialog.vue';
-import ExportDialog, {
-  ExportAsLatexSettings,
-  ExportAsMusicXmlSettings,
-  ExportAsPngSettings,
+import {
+  type ExportAsLatexSettings,
+  type ExportAsMusicXmlSettings,
+  type ExportAsPngSettings,
   ExportFormat,
-} from '@/components/ExportDialog.vue';
+} from '@/components/ExportDialog.types';
+import ExportDialog from '@/components/ExportDialog.vue';
 import FileMenuBar from '@/components/FileMenuBar.vue';
 import ImageBox from '@/components/ImageBox.vue';
 import ModeKey from '@/components/ModeKey.vue';
@@ -204,7 +204,6 @@ const navigableElements = [
 ];
 
 const keydownThrottleIntervalMs = 100;
-const componentInstance = getCurrentInstance();
 const tabsRef = useTemplateRef<Vue3TabsChromeComponent>('tabsRef');
 const searchTextRef =
   useTemplateRef<InstanceType<typeof SearchText>>('searchTextRef');
@@ -224,8 +223,29 @@ const {
 } = useEditorServices();
 const { t } = useTranslation();
 
+const dynamicTemplateRefs = new Map<string, unknown[]>();
+const dynamicTemplateRefSetters = new Map<string, (value: unknown) => void>();
+
 function getTemplateRef<T>(name: string) {
-  return componentInstance?.proxy?.$refs[name] as T;
+  return (dynamicTemplateRefs.get(name) ?? []) as T;
+}
+
+function setTemplateRef(name: string) {
+  let setter = dynamicTemplateRefSetters.get(name);
+
+  if (setter == null) {
+    setter = (value: unknown) => {
+      if (value == null) {
+        dynamicTemplateRefs.delete(name);
+      } else {
+        dynamicTemplateRefs.set(name, [value]);
+      }
+    };
+
+    dynamicTemplateRefSetters.set(name, setter);
+  }
+
+  return setter;
 }
 
 const searchTextQuery = ref('');
@@ -942,9 +962,13 @@ onBeforeUnmount(() => {
 });
 
 async function initialize() {
-  // Attach the editor component to the window variable
-  // so that it can be used for debugging
-  (window as any)._editor = componentInstance?.proxy;
+  // Attach a small debugging surface without relying on the component proxy.
+  (window as any)._editor = {
+    elements,
+    score,
+    selectedWorkspace,
+    workspaces,
+  };
 
   try {
     const fontLoader = (document as any).fonts;
@@ -4271,32 +4295,6 @@ function updateMartyriaTempoRight(
   });
 }
 
-// Retained from the Options API method surface.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function updateMartyriaBpm(element: MartyriaElement, bpm: number) {
-  updateMartyria(element, { bpm });
-  save();
-}
-
-// Retained from the Options API method surface.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function updateMartyriaMeasureBar(
-  element: MartyriaElement,
-  {
-    measureBarLeft,
-    measureBarRight,
-  }: {
-    measureBarLeft: MeasureBar | null;
-    measureBarRight: MeasureBar | null;
-  },
-) {
-  updateMartyria(element, {
-    measureBarLeft,
-    measureBarRight,
-  });
-  save();
-}
-
 function updateTempo(element: TempoElement, newValues: Partial<TempoElement>) {
   commandService.value.execute(
     tempoCommandFactory.create('update-properties', {
@@ -5825,7 +5823,7 @@ function renderTabLabel(tab: Tab) {
                     :key="`element-${selectedWorkspace.id}-${getHeaderForPageIndex(pageIndex).id}-${
                       getHeaderForPageIndex(pageIndex).keyHelper
                     }`"
-                    :ref="`header-${pageIndex}`"
+                    :ref="setTemplateRef(`header-${pageIndex}`)"
                     class="element-box"
                     :element="
                       getHeaderForPageIndex(pageIndex) as RichTextBoxElement
@@ -5868,7 +5866,7 @@ function renderTabLabel(tab: Tab) {
                     :key="`element-${selectedWorkspace.id}-${getHeaderForPageIndex(pageIndex).id}-${
                       getHeaderForPageIndex(pageIndex).keyHelper
                     }`"
-                    :ref="`header-${pageIndex}`"
+                    :ref="setTemplateRef(`header-${pageIndex}`)"
                     class="element-box"
                     :element="
                       getHeaderForPageIndex(pageIndex) as TextBoxElement
@@ -5929,7 +5927,9 @@ function renderTabLabel(tab: Tab) {
                 >
                   <template v-if="isSyllableElement(element)">
                     <div
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       class="neume-box"
                     >
                       <span
@@ -6012,7 +6012,9 @@ function renderTabLabel(tab: Tab) {
                         :style="getLyricStyle(element as NoteElement)"
                       >
                         <ContentEditable
-                          :ref="`lyrics-${getElementIndex(element)}`"
+                          :ref="
+                            setTemplateRef(`lyrics-${getElementIndex(element)}`)
+                          "
                           class="lyrics"
                           :class="{
                             selectedLyrics: element === selectedLyrics,
@@ -6135,7 +6137,9 @@ function renderTabLabel(tab: Tab) {
                         ><img src="@/assets/icons/line-break.svg"
                       /></span>
                       <MartyriaNeumeBox
-                        :ref="`element-${getElementIndex(element)}`"
+                        :ref="
+                          setTemplateRef(`element-${getElementIndex(element)}`)
+                        "
                         class="marytria-neume-box"
                         :neume="element as MartyriaElement"
                         :page-setup="score.pageSetup"
@@ -6152,7 +6156,9 @@ function renderTabLabel(tab: Tab) {
                   </template>
                   <template v-else-if="isTempoElement(element)">
                     <div
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       class="neume-box"
                     >
                       <span
@@ -6182,7 +6188,9 @@ function renderTabLabel(tab: Tab) {
                   </template>
                   <template v-else-if="isEmptyElement(element)">
                     <div
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       class="neume-box"
                     >
                       <span
@@ -6223,7 +6231,9 @@ function renderTabLabel(tab: Tab) {
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <TextBox
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       :element="element as TextBoxElement"
                       :edit-mode="true"
                       :metadata="getTokenMetadata(pageIndex)"
@@ -6251,7 +6261,9 @@ function renderTabLabel(tab: Tab) {
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <TextBoxRich
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       :element="element as RichTextBoxElement"
                       :page-setup="score.pageSetup"
                       :fonts="fonts"
@@ -6283,7 +6295,9 @@ function renderTabLabel(tab: Tab) {
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <ModeKey
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       :element="element as ModeKeyElement"
                       :page-setup="score.pageSetup"
                       :class="[
@@ -6310,7 +6324,9 @@ function renderTabLabel(tab: Tab) {
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <DropCap
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       :element="element as DropCapElement"
                       :page-setup="score.pageSetup"
                       :editable="!lyricsLocked"
@@ -6333,7 +6349,9 @@ function renderTabLabel(tab: Tab) {
                       ><img src="@/assets/icons/line-break.svg"
                     /></span>
                     <ImageBox
-                      :ref="`element-${getElementIndex(element)}`"
+                      :ref="
+                        setTemplateRef(`element-${getElementIndex(element)}`)
+                      "
                       :element="element as ImageBoxElement"
                       :zoom="zoom"
                       :print-mode="printMode"
@@ -6376,7 +6394,7 @@ function renderTabLabel(tab: Tab) {
                     :key="`element-${selectedWorkspace.id}-${getFooterForPageIndex(pageIndex).id}-${
                       getFooterForPageIndex(pageIndex).keyHelper
                     }`"
-                    :ref="`footer-${pageIndex}`"
+                    :ref="setTemplateRef(`footer-${pageIndex}`)"
                     class="element-box"
                     :element="
                       getFooterForPageIndex(pageIndex) as RichTextBoxElement
@@ -6416,7 +6434,7 @@ function renderTabLabel(tab: Tab) {
                   v-else-if="isTextBoxElement(getFooterForPageIndex(pageIndex))"
                 >
                   <TextBox
-                    :ref="`footer-${pageIndex}`"
+                    :ref="setTemplateRef(`footer-${pageIndex}`)"
                     :key="`element-${selectedWorkspace.id}-${getFooterForPageIndex(pageIndex).id}-${
                       getFooterForPageIndex(pageIndex).keyHelper
                     }`"

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -4,14 +4,7 @@ import 'vue3-tabs-chrome/dist/vue3-tabs-chrome.css';
 import { getFontEmbedCSS, toPng } from 'html-to-image';
 import i18next from 'i18next';
 import { debounce, throttle } from 'throttle-debounce';
-import {
-  computed,
-  defineComponent,
-  inject,
-  nextTick,
-  StyleValue,
-  toRaw,
-} from 'vue';
+import { computed, defineComponent, nextTick, StyleValue, toRaw } from 'vue';
 import Vue3TabsChrome, { Tab } from 'vue3-tabs-chrome';
 
 import AlternateLine from '@/components/AlternateLine.vue';
@@ -52,20 +45,10 @@ import ToolbarNeume from '@/components/ToolbarNeume.vue';
 import ToolbarTempo from '@/components/ToolbarTempo.vue';
 import ToolbarTextBox from '@/components/ToolbarTextBox.vue';
 import ToolbarTextBoxRich from '@/components/ToolbarTextBoxRich.vue';
+import { useEditorServices } from '@/composables/useEditorServices';
 import { EventBus } from '@/eventBus';
 import { resolveLanguagePreference } from '@/i18n';
-import {
-  audioServiceKey,
-  ipcServiceKey,
-  latexExporterKey,
-  lyricServiceKey,
-  musicXmlExporterKey,
-  neumeKeyboardKey,
-  ocrImporterKey,
-  platformServiceKey,
-  playbackServiceKey,
-  textSearchServiceKey,
-} from '@/injectionKeys';
+import { editorPreferencesKey } from '@/injectionKeys';
 import {
   CloseWorkspacesArgs,
   CloseWorkspacesDisposition,
@@ -128,33 +111,19 @@ import { Score } from '@/models/Score';
 import { ScoreElementSelectionRange } from '@/models/ScoreElementSelectionRange';
 import { Workspace, WorkspaceLocalStorage } from '@/models/Workspace';
 import {
-  AudioService,
   AudioServiceEventNames,
   AudioState,
 } from '@/services/audio/AudioService';
 import {
   PlaybackOptions,
   PlaybackSequenceEvent,
-  PlaybackService,
 } from '@/services/audio/PlaybackService';
 import { Command, CommandFactory } from '@/services/history/CommandService';
 import { ByzHtmlExporter } from '@/services/integration/ByzHtmlExporter';
-import {
-  LatexExporter,
-  LatexExporterOptions,
-} from '@/services/integration/LatexExporter';
-import { MusicXmlExporter } from '@/services/integration/MusicXmlExporter';
-import { OcrImporter } from '@/services/integration/OcrImporter';
-import { IIpcService } from '@/services/ipc/IIpcService';
-import { IpcService } from '@/services/ipc/IpcService';
+import { LatexExporterOptions } from '@/services/integration/LatexExporter';
 import { LayoutService } from '@/services/LayoutService';
-import { LyricService } from '@/services/LyricService';
-import { NeumeKeyboard } from '@/services/NeumeKeyboard';
-import { IPlatformService } from '@/services/platform/IPlatformService';
-import { PlatformService } from '@/services/platform/PlatformService';
 import { SaveService } from '@/services/SaveService';
 import { TextMeasurementService } from '@/services/TextMeasurementService';
-import { TextSearchService } from '@/services/TextSearchService';
 import { GORTHMIKON, PELASTIKON, TATWEEL } from '@/utils/constants';
 import { getCursorPosition } from '@/utils/getCursorPosition';
 import { getFileNameFromPath } from '@/utils/getFileNameFromPath';
@@ -261,41 +230,12 @@ export default defineComponent({
   },
   provide() {
     return {
-      editorPreferences: computed(() => this.editorPreferences),
+      [editorPreferencesKey]: computed(() => this.editorPreferences),
     };
   },
   emits: [],
   setup() {
-    return {
-      audioService: inject<AudioService>(audioServiceKey, new AudioService()),
-      latexExporter: inject<LatexExporter>(
-        latexExporterKey,
-        new LatexExporter(),
-      ),
-      lyricService: inject<LyricService>(lyricServiceKey, new LyricService()),
-      musicXmlExporter: inject<MusicXmlExporter>(
-        musicXmlExporterKey,
-        new MusicXmlExporter(),
-      ),
-      neumeKeyboard: inject<NeumeKeyboard>(
-        neumeKeyboardKey,
-        new NeumeKeyboard(),
-      ),
-      ocrImporter: inject<OcrImporter>(ocrImporterKey, new OcrImporter()),
-      platformService: inject<IPlatformService>(
-        platformServiceKey,
-        new PlatformService(),
-      ),
-      playbackService: inject<PlaybackService>(
-        playbackServiceKey,
-        new PlaybackService(),
-      ),
-      textSearchService: inject<TextSearchService>(
-        textSearchServiceKey,
-        new TextSearchService(),
-      ),
-      ipcService: inject<IIpcService>(ipcServiceKey, new IpcService()),
-    };
+    return useEditorServices();
   },
   data() {
     return {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -1,10 +1,24 @@
-<script lang="ts">
+<script setup lang="ts">
 import 'vue3-tabs-chrome/dist/vue3-tabs-chrome.css';
 
 import { getFontEmbedCSS, toPng } from 'html-to-image';
 import i18next from 'i18next';
+import { useTranslation } from 'i18next-vue';
 import { debounce, throttle } from 'throttle-debounce';
-import { computed, defineComponent, nextTick, StyleValue, toRaw } from 'vue';
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  reactive,
+  ref,
+  StyleValue,
+  toRaw,
+  useTemplateRef,
+  watch,
+} from 'vue';
 import Vue3TabsChrome, { Tab } from 'vue3-tabs-chrome';
 
 import AlternateLine from '@/components/AlternateLine.vue';
@@ -190,5997 +204,5504 @@ const navigableElements = [
 ];
 
 const keydownThrottleIntervalMs = 100;
+const componentInstance = getCurrentInstance();
+const tabsRef = useTemplateRef<Vue3TabsChromeComponent>('tabsRef');
+const searchTextRef =
+  useTemplateRef<InstanceType<typeof SearchText>>('searchTextRef');
+const pageBackgroundRef = useTemplateRef<HTMLElement>('pageBackgroundRef');
+const pagesRef = useTemplateRef<HTMLElement[]>('pagesRef');
+const {
+  audioService,
+  ipcService,
+  latexExporter,
+  lyricService,
+  musicXmlExporter,
+  neumeKeyboard,
+  ocrImporter,
+  platformService,
+  playbackService,
+  textSearchService,
+} = useEditorServices();
+const { t } = useTranslation();
 
-export default defineComponent({
-  components: {
-    AlternateLine,
-    Annotation,
-    SyllableNeumeBox,
-    MartyriaNeumeBox,
-    TempoNeumeBox,
-    EmptyNeumeBox,
-    NeumeComboSelector,
-    NeumeSelector,
-    ContentEditable,
-    TextBox,
-    TextBoxRich,
-    DropCap,
-    ImageBox,
-    ModeKey,
-    ToolbarImageBox,
-    ToolbarTextBox,
-    ToolbarTextBoxRich,
-    ToolbarLyrics,
-    ToolbarLyricManager,
-    ToolbarModeKey,
-    ToolbarNeume,
-    ToolbarMartyria,
-    ToolbarTempo,
-    ToolbarDropCap,
-    ToolbarMain,
-    ModeKeyDialog,
-    SyllablePositioningDialog,
-    PlaybackSettingsDialog,
-    EditorPreferencesDialog,
-    ExportDialog,
-    PageSetupDialog,
-    FileMenuBar,
-    Vue3TabsChrome,
-    SearchText,
+function getTemplateRef<T>(name: string) {
+  return componentInstance?.proxy?.$refs[name] as T;
+}
+
+const searchTextQuery = ref('');
+const searchTextPanelIsOpen = ref(false);
+const showFileMenuBar = ref(!isElectron());
+const isDevelopment = ref(import.meta.env.DEV);
+const isBrowser = ref(!isElectron());
+const isLoading = ref(true);
+const printMode = ref(false);
+const showGuides = ref(false);
+const showAdjustmentRatios = ref(false);
+const workspaces = ref<Workspace[]>([]);
+const selectedWorkspaceValue = ref(new Workspace());
+const tabs = ref<Tab[]>([]);
+const pages = ref<Page[]>([]);
+const currentPageNumber = ref(0);
+const modeKeyDialogIsOpen = ref(false);
+const syllablePositioningDialogIsOpen = ref(false);
+const playbackSettingsDialogIsOpen = ref(false);
+const pageSetupDialogIsOpen = ref(false);
+const editorPreferencesDialogIsOpen = ref(false);
+const exportDialogIsOpen = ref(false);
+const neumeComboPanelIsExpanded = ref(false);
+const exportFormat = ref(ExportFormat.PNG);
+const clipboard = ref<ScoreElement[]>([]);
+const formatType = ref<ElementType | null>(null);
+const textBoxFormat = ref<Partial<TextBoxElement> | null>(null);
+const noteFormat = ref<Partial<NoteElement> | null>(null);
+const richTextBoxCalculation = ref(false);
+const richTextBoxCalculationCount = ref(0);
+const textBoxCalculation = ref(false);
+const textBoxCalculationCount = ref(0);
+const fonts = ref<string[]>([]);
+const toolbarInnerNeume = ref('Primary');
+const keyboardModifier = ref<string | null>(null);
+const audioElement = ref<ScoreElement | null>(null);
+const playbackEvents = ref<PlaybackSequenceEvent[]>([]);
+const playbackTimeInterval = ref<ReturnType<typeof setInterval> | null>(null);
+const audioOptions = reactive<PlaybackOptions>({
+  useLegetos: false,
+  useDefaultAttractionZo: true,
+  frequencyDi: 196,
+  speed: 1,
+
+  diatonicIntervals: [12, 10, 8],
+  hardChromaticIntervals: [6, 20, 4],
+  softChromaticIntervals: [8, 14, 8],
+  legetosIntervals: [8, 10, 12],
+  zygosIntervals: [18, 4, 16, 4],
+  zygosLegetosIntervals: [18, 4, 20, 4],
+  spathiIntervals: [20, 4, 4, 14],
+  klitonIntervals: [14, 12, 4],
+
+  defaultAttractionZoMoria: -4,
+  defaultAttractionKeMoria: 5,
+
+  volumeIson: -4,
+  volumeMelody: 0,
+
+  alterationMultipliers: [0.5, 0.25, 0.75],
+
+  alterationMoriaMap: {
+    [Accidental.Flat_2_Right]: -2,
+    [Accidental.Flat_4_Right]: -4,
+    [Accidental.Flat_6_Right]: -6,
+    [Accidental.Flat_8_Right]: -8,
+    [Accidental.Sharp_2_Left]: 2,
+    [Accidental.Sharp_4_Left]: 4,
+    [Accidental.Sharp_6_Left]: 6,
+    [Accidental.Sharp_8_Left]: 8,
   },
-  provide() {
-    return {
-      [editorPreferencesKey]: computed(() => this.editorPreferences),
+});
+const editorPreferences = ref(new EditorPreferences());
+const byzHtmlExporter = new ByzHtmlExporter();
+const exportInProgress = ref(false);
+
+const selectedWorkspaceId = computed({
+  get: () => {
+    return selectedWorkspace.value.id;
+  },
+  set: (value: string) => {
+    selectedWorkspace.value =
+      (workspaces.value.find((x) => x.id === value) as Workspace) ??
+      new Workspace();
+  },
+});
+
+const rtl = computed(() => {
+  return score.value.pageSetup.melkiteRtl;
+});
+
+const selectedWorkspace = computed({
+  get: () => {
+    return selectedWorkspaceValue.value as Workspace;
+  },
+  set: (value: Workspace) => {
+    // Save the scroll position
+    const pageBackgroundElement = pageBackgroundRef.value!;
+    selectedWorkspace.value.scrollLeft = pageBackgroundElement.scrollLeft;
+    selectedWorkspace.value.scrollTop = pageBackgroundElement.scrollTop;
+
+    selectedWorkspaceValue.value = value;
+    selectedWorkspace.value.commandService.notify();
+    save(false);
+
+    // Scroll to the new workspace's saved scroll position
+    // Use nextTick to scroll after the DOM has refreshed
+    nextTick(() => {
+      pageBackgroundElement.scrollTo(
+        selectedWorkspace.value.scrollLeft,
+        selectedWorkspace.value.scrollTop,
+      );
+
+      calculatePageNumber();
+    });
+
+    stopAudio();
+  },
+});
+
+const score = computed(() => {
+  return selectedWorkspace.value.score;
+});
+
+const elements = computed(() => {
+  return score.value?.staff.elements ?? [];
+});
+
+const resizableRichTextBoxElements = computed(() => {
+  return elements.value.filter(
+    (x) =>
+      x.elementType === ElementType.RichTextBox &&
+      !(x as RichTextBoxElement).inline,
+  );
+});
+
+const resizableTextBoxElements = computed(() => {
+  return elements.value.filter(
+    (x) =>
+      x.elementType === ElementType.TextBox && !(x as TextBoxElement).inline,
+  );
+});
+
+const lyrics = computed({
+  get: () => {
+    return score.value?.staff.lyrics.text ?? '';
+  },
+  set: (value: string) => {
+    score.value.staff.lyrics.text = value;
+  },
+});
+
+const lyricsLocked = computed({
+  get: () => {
+    return score.value?.staff.lyrics.locked ?? false;
+  },
+  set: (value: boolean) => {
+    score.value.staff.lyrics.locked = value;
+  },
+});
+
+const lyricManagerIsOpen = computed({
+  get: () => {
+    return selectedWorkspace.value.lyricManagerIsOpen;
+  },
+  set: (value: boolean) => {
+    selectedWorkspace.value.lyricManagerIsOpen = value;
+  },
+});
+
+const pageCount = computed(() => {
+  return pages.value.length;
+});
+
+const commandService = computed(() => {
+  return selectedWorkspace.value.commandService;
+});
+
+const selectedElementIndex = computed(() => {
+  return selectedElement.value != null
+    ? elements.value.indexOf(selectedElement.value)
+    : -1;
+});
+
+const windowTitle = computed(() => {
+  return `${getFileName(selectedWorkspace.value)} - ${
+    import.meta.env.VITE_TITLE
+  }`;
+});
+
+const selectedElement = computed({
+  get: () => {
+    return selectedWorkspace.value.selectedElement;
+  },
+  set: (element: ScoreElement | null) => {
+    if (element != null) {
+      selectedLyrics.value = null;
+      selectionRange.value = null;
+      selectedHeaderFooterElement.value = null;
+      toolbarInnerNeume.value = 'Primary';
+
+      if (audioService.state === AudioState.Playing) {
+        const event = playbackEvents.value.find(
+          (x) => x.elementIndex === getElementIndex(element),
+        );
+
+        if (event) {
+          audioService.jumpToEvent(event);
+          selectedWorkspace.value.playbackTime = event.absoluteTime;
+        }
+      } else if (audioService.state === AudioState.Paused) {
+        stopAudio();
+      }
+    }
+
+    if (
+      selectedWorkspace.value.selectedAlternateLineElement != null &&
+      selectedWorkspace.value.selectedAlternateLineElement.elements.length === 0
+    ) {
+      removeAlternateLine(
+        selectedElement.value as NoteElement,
+        selectedWorkspace.value.selectedAlternateLineElement,
+        true,
+      );
+    }
+
+    selectedWorkspace.value.selectedElement = element;
+    selectedWorkspace.value.selectedAnnotationElement = null;
+    selectedWorkspace.value.selectedAlternateLineElement = null;
+  },
+});
+
+const selectedElementForNeumeToolbar = computed(() => {
+  if (
+    selectedWorkspace.value.selectedAlternateLineElement != null &&
+    selectedWorkspace.value.selectedAlternateLineElement.elements.length > 0
+  ) {
+    return selectedWorkspace.value.selectedAlternateLineElement.elements[
+      selectedWorkspace.value.selectedAlternateLineElement.elements.length - 1
+    ];
+  }
+  return selectedWorkspace.value.selectedElement;
+});
+
+const previousElementOnLine = computed(() => {
+  const index = selectedElementIndex.value;
+
+  if (index - 1 < 0) {
+    return null;
+  }
+
+  return elements.value[index - 1].line === selectedElement.value?.line
+    ? elements.value[index - 1]
+    : null;
+});
+
+const nextElementOnLine = computed(() => {
+  const index = selectedElementIndex.value;
+
+  if (index + 1 >= elements.value.length - 1) {
+    return null;
+  }
+
+  return elements.value[index + 1].line === selectedElement.value?.line
+    ? elements.value[index + 1]
+    : null;
+});
+
+const selectedLyrics = computed({
+  get: () => {
+    return selectedWorkspace.value.selectedLyrics;
+  },
+  set: (element: NoteElement | null) => {
+    if (element != null) {
+      selectedElement.value = null;
+      selectedHeaderFooterElement.value = null;
+      selectionRange.value = null;
+    }
+
+    selectedWorkspace.value.selectedLyrics = element;
+  },
+});
+
+const selectedHeaderFooterElement = computed({
+  get: () => {
+    return selectedWorkspace.value.selectedHeaderFooterElement;
+  },
+  set: (element: ScoreElement | null) => {
+    if (element != null) {
+      selectedElement.value = null;
+      selectedLyrics.value = null;
+      selectionRange.value = null;
+    }
+
+    selectedWorkspace.value.selectedHeaderFooterElement = element;
+  },
+});
+
+const selectedTextBoxElement = computed(() => {
+  const currentSelectedElement =
+    selectedElement.value || selectedHeaderFooterElement.value;
+
+  return currentSelectedElement != null &&
+    isTextBoxElement(currentSelectedElement)
+    ? (currentSelectedElement as TextBoxElement)
+    : null;
+});
+
+const selectedRichTextBoxElement = computed(() => {
+  const currentSelectedElement =
+    selectedElement.value || selectedHeaderFooterElement.value;
+
+  return currentSelectedElement != null &&
+    isRichTextBoxElement(currentSelectedElement)
+    ? (currentSelectedElement as RichTextBoxElement)
+    : null;
+});
+
+const selectionRange = computed({
+  get: () => {
+    return selectedWorkspace.value.selectionRange;
+  },
+  set: (value: ScoreElementSelectionRange | null) => {
+    selectedWorkspace.value.selectionRange = value;
+  },
+});
+
+const zoom = computed({
+  get: () => {
+    return selectedWorkspace.value.zoom;
+  },
+  set: (zoom: number) => {
+    selectedWorkspace.value.zoom = zoom;
+  },
+});
+
+const zoomToFit = computed({
+  get: () => {
+    return selectedWorkspace.value.zoomToFit;
+  },
+  set: (value: boolean) => {
+    selectedWorkspace.value.zoomToFit = value;
+  },
+});
+
+const entryMode = computed({
+  get: () => {
+    return selectedWorkspace.value.entryMode;
+  },
+  set: (value: EntryMode) => {
+    selectedWorkspace.value.entryMode = value;
+  },
+});
+
+const currentFilePath = computed({
+  get: () => {
+    return selectedWorkspace.value.filePath;
+  },
+  set: (path: string | null) => {
+    selectedWorkspace.value.filePath = path;
+  },
+});
+
+const hasUnsavedChanges = computed({
+  get: () => {
+    return selectedWorkspace.value.hasUnsavedChanges;
+  },
+  set: (hasUnsavedChanges: boolean) => {
+    selectedWorkspace.value.hasUnsavedChanges = hasUnsavedChanges;
+  },
+});
+
+const pageStyle = computed(() => {
+  return {
+    minWidth: withZoom(score.value.pageSetup.pageWidth),
+    maxWidth: withZoom(score.value.pageSetup.pageWidth),
+    width: withZoom(score.value.pageSetup.pageWidth),
+    height: withZoom(score.value.pageSetup.pageHeight),
+    minHeight: withZoom(score.value.pageSetup.pageHeight),
+    maxHeight: withZoom(score.value.pageSetup.pageHeight),
+  } as StyleValue;
+});
+
+const headerStyle = computed(() => {
+  return {
+    left: withZoom(score.value.pageSetup.leftMargin),
+    top: withZoom(score.value.pageSetup.headerMargin),
+  } as StyleValue;
+});
+
+const footerStyle = computed(() => {
+  return {
+    left: withZoom(score.value.pageSetup.leftMargin),
+    bottom: withZoom(score.value.pageSetup.footerMargin),
+  } as StyleValue;
+});
+
+const guideStyleLeft = computed(() => {
+  return {
+    left: withZoom(score.value.pageSetup.leftMargin - 1),
+    height: withZoom(score.value.pageSetup.pageHeight),
+  } as StyleValue;
+});
+
+const guideStyleRight = computed(() => {
+  return {
+    right: withZoom(score.value.pageSetup.rightMargin - 1),
+    height: withZoom(score.value.pageSetup.pageHeight),
+  } as StyleValue;
+});
+
+const guideStyleTop = computed(() => {
+  return {
+    top: withZoom(score.value.pageSetup.topMargin - 1),
+    width: withZoom(score.value.pageSetup.pageWidth),
+  } as StyleValue;
+});
+
+const guideStyleBottom = computed(() => {
+  return {
+    bottom: withZoom(score.value.pageSetup.bottomMargin - 1),
+    width: withZoom(score.value.pageSetup.pageWidth),
+  } as StyleValue;
+});
+
+const pageVisibilityIntersection = computed(() => {
+  // look ahead/behind 1 page
+  const margin = score.value.pageSetup.pageHeight * zoom.value;
+
+  return {
+    root: pageBackgroundRef.value,
+    rootMargin: `${margin}px 0px ${margin}px 0px`,
+  } as IntersectionObserver;
+});
+
+const dialogOpen = computed(() => {
+  return (
+    modeKeyDialogIsOpen.value ||
+    pageSetupDialogIsOpen.value ||
+    playbackSettingsDialogIsOpen.value ||
+    syllablePositioningDialogIsOpen.value ||
+    editorPreferencesDialogIsOpen.value
+  );
+});
+
+const filteredPages = computed(() => {
+  return printMode.value ? pages.value.filter((x) => !x.isEmpty) : pages.value;
+});
+
+provide(
+  editorPreferencesKey,
+  computed(() => editorPreferences.value),
+);
+
+const throttled = {
+  assignLyrics: throttle(keydownThrottleIntervalMs, assignLyrics),
+  moveToPreviousLyricBox: throttle(
+    keydownThrottleIntervalMs,
+    moveToPreviousLyricBox,
+  ),
+  moveToNextLyricBox: throttle(keydownThrottleIntervalMs, moveToNextLyricBox),
+  moveLeft: throttle(keydownThrottleIntervalMs, moveLeft),
+  moveRight: throttle(keydownThrottleIntervalMs, moveRight),
+  moveSelectionLeft: throttle(keydownThrottleIntervalMs, moveSelectionLeft),
+  moveSelectionRight: throttle(keydownThrottleIntervalMs, moveSelectionRight),
+  deleteSelectedElement: throttle(
+    keydownThrottleIntervalMs,
+    deleteSelectedElement,
+  ),
+  deletePreviousElement: throttle(
+    keydownThrottleIntervalMs,
+    deletePreviousElement,
+  ),
+  onFileMenuUndo: throttle(keydownThrottleIntervalMs, onFileMenuUndo),
+  onFileMenuRedo: throttle(keydownThrottleIntervalMs, onFileMenuRedo),
+  onCutScoreElements: throttle(keydownThrottleIntervalMs, onCutScoreElements),
+  onCopyScoreElements: throttle(keydownThrottleIntervalMs, onCopyScoreElements),
+  onFileMenuCopyAsHtml: throttle(
+    keydownThrottleIntervalMs,
+    onFileMenuCopyAsHtml,
+  ),
+  onPasteScoreElements: throttle(
+    keydownThrottleIntervalMs,
+    onPasteScoreElements,
+  ),
+  addQuantitativeNeume: throttle(
+    keydownThrottleIntervalMs,
+    addQuantitativeNeume,
+  ),
+  addTempo: throttle(keydownThrottleIntervalMs, addTempo),
+  addAutoMartyria: throttle(keydownThrottleIntervalMs, addAutoMartyria),
+  updateNoteAndSave: throttle(keydownThrottleIntervalMs, updateNoteAndSave),
+  setKlasma: throttle(keydownThrottleIntervalMs, setKlasma),
+  setGorgon: throttle(keydownThrottleIntervalMs, setGorgon),
+  setFthoraNote: throttle(keydownThrottleIntervalMs, setFthoraNote),
+  setFthoraMartyria: throttle(keydownThrottleIntervalMs, setFthoraMartyria),
+  setMartyriaTempo: throttle(keydownThrottleIntervalMs, setMartyriaTempo),
+  setAccidental: throttle(keydownThrottleIntervalMs, setAccidental),
+  setTimeNeume: throttle(keydownThrottleIntervalMs, setTimeNeume),
+  setMeasureNumber: throttle(keydownThrottleIntervalMs, setMeasureNumber),
+  setMeasureBarNote: throttle(keydownThrottleIntervalMs, setMeasureBarNote),
+  setMeasureBarMartyria: throttle(
+    keydownThrottleIntervalMs,
+    setMeasureBarMartyria,
+  ),
+  setIson: throttle(keydownThrottleIntervalMs, setIson),
+  setTie: throttle(keydownThrottleIntervalMs, setTie),
+  setVocalExpression: throttle(keydownThrottleIntervalMs, setVocalExpression),
+  updateMartyria: throttle(keydownThrottleIntervalMs, updateMartyria),
+  onWindowResize: throttle(250, onWindowResize),
+  onScroll: throttle(250, onScroll),
+};
+const saveDebounced = debounce(250, save);
+
+if (isDevelopment.value) {
+  for (const [key, val] of Object.entries(throttled)) {
+    if (val == null) {
+      throw new Error(`Missing initialization for throttled method '${key}'`);
+    }
+  }
+}
+
+watch(zoom, () => {
+  document.documentElement.style.setProperty('--zoom', zoom.value.toString());
+});
+
+watch(currentFilePath, () => {
+  window.document.title = windowTitle.value;
+});
+
+watch(selectedWorkspaceId, () => {
+  window.document.title = windowTitle.value;
+});
+
+watch(hasUnsavedChanges, () => {
+  window.document.title = windowTitle.value;
+});
+
+onMounted(() => {
+  const savedAudioOptions = localStorage.getItem('audioOptionsDefault');
+
+  if (savedAudioOptions != null) {
+    Object.assign(audioOptions, JSON.parse(savedAudioOptions));
+
+    // -Infinity is not valid JSON, so it is serialized as null.
+    // Deserialize as -Infinity
+    audioOptions.volumeIson = audioOptions.volumeIson ?? -Infinity;
+    audioOptions.volumeMelody = audioOptions.volumeMelody ?? -Infinity;
+  }
+
+  const savedEditorPreferences = localStorage.getItem('editorPreferences');
+
+  if (savedEditorPreferences != null) {
+    editorPreferences.value = EditorPreferences.createFrom(
+      JSON.parse(savedEditorPreferences),
+    );
+  }
+
+  window.addEventListener('keydown', onKeydown);
+  window.addEventListener('keyup', onKeyup);
+  window.addEventListener('resize', throttled.onWindowResize);
+
+  EventBus.$on(IpcMainChannels.CloseWorkspaces, onCloseWorkspaces);
+  EventBus.$on(IpcMainChannels.CloseApplication, onCloseApplication);
+
+  EventBus.$on(IpcMainChannels.FileMenuNewScore, onFileMenuNewScore);
+  EventBus.$on(IpcMainChannels.FileMenuOpenScore, onFileMenuOpenScore);
+  EventBus.$on(IpcMainChannels.FileMenuPrint, onFileMenuPrint);
+  EventBus.$on(IpcMainChannels.FileMenuSave, onFileMenuSave);
+  EventBus.$on(IpcMainChannels.FileMenuSaveAs, onFileMenuSaveAs);
+  EventBus.$on(IpcMainChannels.FileMenuPageSetup, onFileMenuPageSetup);
+  EventBus.$on(IpcMainChannels.FileMenuImportOcr, onFileMenuImportOcr);
+  EventBus.$on(IpcMainChannels.FileMenuExportAsPdf, onFileMenuExportAsPdf);
+  EventBus.$on(IpcMainChannels.FileMenuExportAsHtml, onFileMenuExportAsHtml);
+  EventBus.$on(
+    IpcMainChannels.FileMenuExportAsMusicXml,
+    onFileMenuExportAsMusicXml,
+  );
+  EventBus.$on(IpcMainChannels.FileMenuExportAsLatex, onFileMenuExportAsLatex);
+  EventBus.$on(IpcMainChannels.FileMenuExportAsImage, onFileMenuExportAsImage);
+  EventBus.$on(IpcMainChannels.FileMenuUndo, onFileMenuUndo);
+  EventBus.$on(IpcMainChannels.FileMenuRedo, onFileMenuRedo);
+  EventBus.$on(IpcMainChannels.FileMenuCut, onFileMenuCut);
+  EventBus.$on(IpcMainChannels.FileMenuCopy, onFileMenuCopy);
+  EventBus.$on(IpcMainChannels.FileMenuCopyAsHtml, onFileMenuCopyAsHtml);
+  EventBus.$on(IpcMainChannels.FileMenuCopyFormat, onFileMenuCopyFormat);
+  EventBus.$on(IpcMainChannels.FileMenuPaste, onFileMenuPaste);
+  EventBus.$on(
+    IpcMainChannels.FileMenuPasteWithLyrics,
+    onFileMenuPasteWithLyrics,
+  );
+  EventBus.$on(IpcMainChannels.FileMenuPasteFormat, onFileMenuPasteFormat);
+  EventBus.$on(IpcMainChannels.FileMenuFind, onFileMenuFind);
+  EventBus.$on(IpcMainChannels.FileMenuLyrics, onFileMenuLyrics);
+  EventBus.$on(IpcMainChannels.FileMenuPreferences, onFileMenuPreferences);
+  EventBus.$on(
+    IpcMainChannels.FileMenuInsertAnnotation,
+    onFileMenuInsertAnnotation,
+  );
+  EventBus.$on(
+    IpcMainChannels.FileMenuInsertAlternateLine,
+    onFileMenuInsertAlternateLine,
+  );
+  EventBus.$on(IpcMainChannels.FileMenuInsertTextBox, onFileMenuInsertTextBox);
+  EventBus.$on(
+    IpcMainChannels.FileMenuInsertRichTextBox,
+    onFileMenuInsertRichTextBox,
+  );
+  EventBus.$on(IpcMainChannels.FileMenuInsertModeKey, onFileMenuInsertModeKey);
+  EventBus.$on(
+    IpcMainChannels.FileMenuInsertDropCapBefore,
+    onFileMenuInsertDropCapBefore,
+  );
+  EventBus.$on(
+    IpcMainChannels.FileMenuInsertDropCapAfter,
+    onFileMenuInsertDropCapAfter,
+  );
+  EventBus.$on(IpcMainChannels.FileMenuInsertImage, onFileMenuInsertImage);
+  EventBus.$on(IpcMainChannels.FileMenuInsertHeader, onFileMenuInsertHeader);
+  EventBus.$on(IpcMainChannels.FileMenuInsertFooter, onFileMenuInsertFooter);
+  EventBus.$on(
+    IpcMainChannels.FileMenuToolsCopyElementLink,
+    onFileMenuToolsCopyElementLink,
+  );
+  EventBus.$on(
+    IpcMainChannels.FileMenuGenerateTestFile,
+    onFileMenuGenerateTestFile,
+  );
+
+  EventBus.$on(AudioServiceEventNames.EventPlay, onAudioServiceEventPlay);
+
+  EventBus.$on(AudioServiceEventNames.Stop, onAudioServiceStop);
+});
+
+onBeforeUnmount(() => {
+  // Remove the debugging variable from window
+  (window as any)._editor = undefined;
+
+  window.removeEventListener('keydown', onKeydown);
+  window.removeEventListener('keyup', onKeyup);
+  window.removeEventListener('resize', throttled.onWindowResize);
+
+  EventBus.$off(IpcMainChannels.CloseWorkspaces, onCloseWorkspaces);
+  EventBus.$off(IpcMainChannels.CloseApplication, onCloseApplication);
+
+  EventBus.$off(IpcMainChannels.FileMenuNewScore, onFileMenuNewScore);
+  EventBus.$off(IpcMainChannels.FileMenuOpenScore, onFileMenuOpenScore);
+  EventBus.$off(IpcMainChannels.FileMenuPrint, onFileMenuPrint);
+  EventBus.$off(IpcMainChannels.FileMenuSave, onFileMenuSave);
+  EventBus.$off(IpcMainChannels.FileMenuSaveAs, onFileMenuSaveAs);
+  EventBus.$off(IpcMainChannels.FileMenuPageSetup, onFileMenuPageSetup);
+  EventBus.$off(IpcMainChannels.FileMenuExportAsPdf, onFileMenuExportAsPdf);
+  EventBus.$off(IpcMainChannels.FileMenuExportAsHtml, onFileMenuExportAsHtml);
+  EventBus.$off(
+    IpcMainChannels.FileMenuExportAsMusicXml,
+    onFileMenuExportAsMusicXml,
+  );
+  EventBus.$off(IpcMainChannels.FileMenuExportAsLatex, onFileMenuExportAsLatex);
+  EventBus.$off(IpcMainChannels.FileMenuExportAsImage, onFileMenuExportAsImage);
+  EventBus.$off(IpcMainChannels.FileMenuUndo, onFileMenuUndo);
+  EventBus.$off(IpcMainChannels.FileMenuRedo, onFileMenuRedo);
+  EventBus.$off(IpcMainChannels.FileMenuCut, onFileMenuCut);
+  EventBus.$off(IpcMainChannels.FileMenuCopy, onFileMenuCopy);
+  EventBus.$off(IpcMainChannels.FileMenuCopyAsHtml, onFileMenuCopyAsHtml);
+  EventBus.$off(IpcMainChannels.FileMenuCopyFormat, onFileMenuCopyFormat);
+  EventBus.$off(IpcMainChannels.FileMenuPaste, onFileMenuPaste);
+  EventBus.$off(
+    IpcMainChannels.FileMenuPasteWithLyrics,
+    onFileMenuPasteWithLyrics,
+  );
+  EventBus.$off(IpcMainChannels.FileMenuPasteFormat, onFileMenuPasteFormat);
+  EventBus.$off(IpcMainChannels.FileMenuFind, onFileMenuFind);
+  EventBus.$off(IpcMainChannels.FileMenuLyrics, onFileMenuLyrics);
+  EventBus.$off(IpcMainChannels.FileMenuPreferences, onFileMenuPreferences);
+  EventBus.$off(
+    IpcMainChannels.FileMenuInsertAnnotation,
+    onFileMenuInsertAnnotation,
+  );
+  EventBus.$off(
+    IpcMainChannels.FileMenuInsertAlternateLine,
+    onFileMenuInsertAlternateLine,
+  );
+  EventBus.$off(IpcMainChannels.FileMenuInsertTextBox, onFileMenuInsertTextBox);
+  EventBus.$off(
+    IpcMainChannels.FileMenuInsertRichTextBox,
+    onFileMenuInsertRichTextBox,
+  );
+  EventBus.$off(IpcMainChannels.FileMenuInsertModeKey, onFileMenuInsertModeKey);
+  EventBus.$off(
+    IpcMainChannels.FileMenuInsertDropCapBefore,
+    onFileMenuInsertDropCapBefore,
+  );
+  EventBus.$off(
+    IpcMainChannels.FileMenuInsertDropCapAfter,
+    onFileMenuInsertDropCapAfter,
+  );
+  EventBus.$off(IpcMainChannels.FileMenuInsertImage, onFileMenuInsertImage);
+  EventBus.$off(IpcMainChannels.FileMenuInsertHeader, onFileMenuInsertHeader);
+  EventBus.$off(IpcMainChannels.FileMenuInsertFooter, onFileMenuInsertFooter);
+  EventBus.$off(
+    IpcMainChannels.FileMenuToolsCopyElementLink,
+    onFileMenuToolsCopyElementLink,
+  );
+  EventBus.$off(
+    IpcMainChannels.FileMenuGenerateTestFile,
+    onFileMenuGenerateTestFile,
+  );
+
+  EventBus.$off(AudioServiceEventNames.EventPlay, onAudioServiceEventPlay);
+
+  EventBus.$off(AudioServiceEventNames.Stop, onAudioServiceStop);
+
+  audioService.dispose();
+});
+
+async function initialize() {
+  // Attach the editor component to the window variable
+  // so that it can be used for debugging
+  (window as any)._editor = componentInstance?.proxy;
+
+  try {
+    const fontLoader = (document as any).fonts;
+
+    const loadSystemFontsPromise = ipcService
+      .getSystemFonts()
+      .then((systemFonts) => (fonts.value = systemFonts));
+
+    // Must load all fonts before loading any documents,
+    // otherwise the text measurements will be wrong
+    await Promise.all([
+      loadSystemFontsPromise,
+      fontLoader.load('1rem "GFS Didot"'),
+      fontLoader.load('1rem Neanes'),
+      fontLoader.load('1rem NeanesStathisSeries'),
+      fontLoader.load('1rem NeanesRTL'),
+      fontLoader.load('1rem "Noto Naskh Arabic"'),
+      fontLoader.load('1rem "Old Standard"'),
+      fontLoader.load('1rem "Source Serif"'),
+      fontLoader.ready,
+    ]);
+
+    await load();
+  } catch (error) {
+    console.error(error);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+void initialize();
+
+function getHeaderHorizontalRuleStyle(headerHeight: number) {
+  return {
+    left: withZoom(score.value.pageSetup.leftMargin),
+    top: withZoom(
+      score.value.pageSetup.headerMargin +
+        headerHeight +
+        score.value.pageSetup.headerHorizontalRuleMarginTop,
+    ),
+    color: score.value.pageSetup.headerHorizontalRuleColor,
+    borderTopWidth: withZoom(
+      score.value.pageSetup.headerHorizontalRuleThickness,
+    ),
+    width: withZoom(score.value.pageSetup.innerPageWidth),
+  } as StyleValue;
+}
+
+function getFooterHorizontalRuleStyle(footerHeight: number) {
+  return {
+    left: withZoom(score.value.pageSetup.leftMargin),
+    bottom: withZoom(
+      score.value.pageSetup.footerMargin +
+        footerHeight +
+        score.value.pageSetup.footerHorizontalRuleMarginBottom,
+    ),
+    color: score.value.pageSetup.footerHorizontalRuleColor,
+    borderTopWidth: withZoom(
+      score.value.pageSetup.footerHorizontalRuleThickness,
+    ),
+    width: withZoom(score.value.pageSetup.innerPageWidth),
+  } as StyleValue;
+}
+
+function getLyricStyle(element: NoteElement) {
+  return {
+    top: withZoom(element.lyricsVerticalOffset),
+    paddingLeft:
+      (!element.isFullMelisma ||
+        (element.melismaText && !element.melismaText.endsWith(TATWEEL))) &&
+      element.lyricsHorizontalOffset > 0
+        ? withZoom(element.lyricsHorizontalOffset)
+        : undefined,
+    paddingRight:
+      (!element.isFullMelisma ||
+        (element.melismaText && !element.melismaText.endsWith(TATWEEL))) &&
+      element.lyricsHorizontalOffset < 0
+        ? withZoom(-element.lyricsHorizontalOffset)
+        : undefined,
+    fontSize: element.lyricsUseDefaultStyle
+      ? withZoom(score.value.pageSetup.lyricsDefaultFontSize)
+      : withZoom(element.lyricsFontSize),
+    fontFamily: element.lyricsUseDefaultStyle
+      ? getFontFamilyWithFallback(
+          score.value.pageSetup.lyricsDefaultFontFamily,
+          score.value.pageSetup.neumeDefaultFontFamily,
+        )
+      : getFontFamilyWithFallback(
+          element.lyricsFontFamily,
+          score.value.pageSetup.neumeDefaultFontFamily,
+        ),
+    fontWeight: element.lyricsUseDefaultStyle
+      ? score.value.pageSetup.lyricsDefaultFontWeight
+      : element.lyricsFontWeight,
+    fontStyle: element.lyricsUseDefaultStyle
+      ? score.value.pageSetup.lyricsDefaultFontStyle
+      : element.lyricsFontStyle,
+    textDecoration: element.lyricsUseDefaultStyle
+      ? undefined
+      : element.lyricsTextDecoration,
+    color: element.lyricsUseDefaultStyle
+      ? score.value.pageSetup.lyricsDefaultColor
+      : element.lyricsColor,
+    webkitTextStrokeWidth: element.lyricsUseDefaultStyle
+      ? withZoom(score.value.pageSetup.lyricsDefaultStrokeWidth)
+      : withZoom(element.lyricsStrokeWidth),
+    lineHeight: withZoom(element.lyricsFontHeight),
+    left: element.alignLeft
+      ? withZoom(Math.min(0, element.lyricsHorizontalOffset))
+      : undefined,
+    textAlign: element.alignLeft ? 'left' : undefined,
+  } as StyleValue;
+}
+
+function getEmptyBoxStyle(element: EmptyElement) {
+  return {
+    width: withZoom(element.width),
+    height: withZoom(element.height),
+  } as StyleValue;
+}
+
+function getElementStyle(element: ScoreElement) {
+  return {
+    left: !rtl.value ? withZoom(element.x) : undefined,
+    right: rtl.value ? withZoom(element.x) : undefined,
+    top: withZoom(element.y),
+  } as StyleValue;
+}
+
+function getAdjustmentRatioStyle(line: Line) {
+  const fontSize = score.value.pageSetup.lyricsDefaultFontSize * 0.8;
+  const gap = fontSize * 0.5;
+  return {
+    position: 'absolute',
+    left: withZoom(
+      rtl.value
+        ? score.value.pageSetup.leftMargin - gap - fontSize * 3
+        : score.value.pageSetup.pageWidth -
+            score.value.pageSetup.rightMargin +
+            gap,
+    ),
+    width: withZoom(fontSize * 3),
+    textAlign: 'right',
+    top: withZoom(
+      line.elements[0].y + score.value.pageSetup.lineHeight / 3 - fontSize / 2,
+    ),
+    fontSize: withZoom(fontSize),
+    fontFamily: score.value.pageSetup.lyricsDefaultFontFamily,
+    color: score.value.pageSetup.gorgonDefaultColor,
+  } as StyleValue;
+}
+
+function getMelismaStyle(element: NoteElement) {
+  return {
+    width: withZoom(element.melismaWidth),
+    minHeight: element.lyricsUseDefaultStyle
+      ? withZoom(score.value.pageSetup.lyricsDefaultFontSize)
+      : withZoom(element.lyricsFontSize),
+  } as StyleValue;
+}
+
+function getMelismaUnderscoreStyleOuter(element: NoteElement) {
+  return {
+    top: withZoom(element.melismaOffsetTop),
+    height: withZoom(element.lyricsFontHeight),
+    width: withZoom(element.melismaWidth),
+  };
+}
+
+function getMelismaUnderscoreStyleInner(element: NoteElement) {
+  const thickness = score.value.pageSetup.lyricsMelismaThickness;
+
+  const spacing = !element.isFullMelisma
+    ? score.value.pageSetup.lyricsMelismaSpacing
+    : 0;
+
+  return {
+    borderBottom: `${withZoom(thickness)} solid ${
+      element.lyricsUseDefaultStyle
+        ? score.value.pageSetup.lyricsDefaultColor
+        : element.lyricsColor
+    }`,
+    left: withZoom(spacing),
+    width: `calc(100% - ${withZoom(spacing)})`,
+  };
+}
+
+function getMelismaHyphenStyle(element: NoteElement, index: number) {
+  return {
+    left: withZoom(element.hyphenOffsets[index]),
+  } as StyleValue;
+}
+
+function getTempFilename() {
+  return `Untitled-${untitledIndex++}`;
+}
+
+function getFileName(workspace: Workspace, showUnsavedChanges: boolean = true) {
+  const unsavedChangesMarker =
+    workspace.hasUnsavedChanges && showUnsavedChanges ? '*' : '';
+
+  if (workspace.filePath != null) {
+    const fileName = getFileNameFromPath(workspace.filePath);
+    return `${unsavedChangesMarker}${fileName}`;
+  } else {
+    return `${unsavedChangesMarker}${workspace.tempFileName}`;
+  }
+}
+
+function getHeaderForPageIndex(pageIndex: number) {
+  const pageNumber = pageIndex + 1;
+
+  const header = score.value.getHeaderForPage(pageNumber);
+
+  // Currently, headers only support a single text box element.
+  return header.elements[0] as TextBoxElement | RichTextBoxElement;
+}
+
+function getFooterForPageIndex(pageIndex: number) {
+  const pageNumber = pageIndex + 1;
+
+  const footer = score.value.getFooterForPage(pageNumber);
+
+  // Currently, footers only support a single text box element.
+  return footer.elements[0] as TextBoxElement | RichTextBoxElement;
+}
+
+function shouldShowHeaderForPageIndex(pageIndex: number) {
+  const pageNumber = pageIndex + 1;
+
+  return score.value.shouldShowHeaderOnPage(pageNumber);
+}
+
+function shouldShowFooterForPageIndex(pageIndex: number) {
+  const pageNumber = pageIndex + 1;
+
+  return score.value.shouldShowFooterOnPage(pageNumber);
+}
+
+function getTokenMetadata(pageIndex: number): TokenMetadata {
+  return {
+    pageNumber: pageIndex + score.value.pageSetup.firstPageNumber,
+    numberOfPages: pageCount.value + score.value.pageSetup.firstPageNumber - 1,
+    fileName:
+      selectedWorkspace.value.filePath != null
+        ? getFileNameFromPath(selectedWorkspace.value.filePath)
+        : selectedWorkspace.value.tempFileName,
+    filePath: currentFilePath.value || '',
+  };
+}
+
+function getElementIndex(element: ScoreElement) {
+  return element.index;
+}
+
+function setSelectionRange(element: ScoreElement) {
+  const elementIndex = getElementIndex(element);
+
+  if (selectedElement.value != null) {
+    selectionRange.value = {
+      start: selectedElementIndex.value,
+      end: elementIndex,
     };
-  },
-  emits: [],
-  setup() {
-    return useEditorServices();
-  },
-  data() {
-    return {
-      searchTextQuery: '',
-      searchTextPanelIsOpen: false,
 
-      showFileMenuBar: !isElectron(),
+    selectedElement.value = null;
+  } else if (selectionRange.value != null) {
+    selectionRange.value.end = elementIndex;
+  }
+}
 
-      LineBreakType,
+function getNormalizedSelectionRange() {
+  if (selectionRange.value == null) {
+    return null;
+  }
 
-      isDevelopment: import.meta.env.DEV,
+  const start = Math.min(selectionRange.value.start, selectionRange.value.end);
+  const end = Math.max(selectionRange.value.start, selectionRange.value.end);
 
-      isBrowser: !isElectron(),
+  return {
+    start,
+    end,
+  } as ScoreElementSelectionRange;
+}
 
-      isLoading: true,
+function isSelected(element: ScoreElement) {
+  if (selectedElement.value === element) {
+    return true;
+  }
+  if (selectionRange.value != null) {
+    const start = Math.min(
+      selectionRange.value.start,
+      selectionRange.value.end,
+    );
+    const end = Math.max(selectionRange.value.start, selectionRange.value.end);
 
-      printMode: false,
+    return start <= getElementIndex(element) && getElementIndex(element) <= end;
+  }
 
-      showGuides: false,
-      showAdjustmentRatios: false,
+  return false;
+}
 
-      workspaces: [] as Workspace[],
-      selectedWorkspaceValue: new Workspace(),
+function setSelectedAnnotation(
+  parent: ScoreElement | null,
+  annotation: AnnotationElement,
+) {
+  selectedElement.value = parent;
+  selectedWorkspace.value.selectedAnnotationElement = annotation;
+}
 
-      tabs: [] as Tab[],
+function setSelectedAlternateLine(
+  parent: ScoreElement | null,
+  alternateLine: AlternateLineElement,
+) {
+  selectedElement.value = parent;
+  selectedWorkspace.value.selectedAlternateLineElement = alternateLine;
+}
 
-      pages: [] as Page[],
+function isAudioSelected(element: ScoreElement) {
+  return audioElement.value === element;
+}
 
-      currentPageNumber: 0,
+function isMelisma(element: NoteElement) {
+  return element.melismaWidth > 0;
+}
 
-      modeKeyDialogIsOpen: false,
-      syllablePositioningDialogIsOpen: false,
-      playbackSettingsDialogIsOpen: false,
-      pageSetupDialogIsOpen: false,
-      editorPreferencesDialogIsOpen: false,
-      exportDialogIsOpen: false,
+function openModeKeyDialog() {
+  modeKeyDialogIsOpen.value = true;
+}
 
-      neumeComboPanelIsExpanded: false,
+function closeModeKeyDialog() {
+  modeKeyDialogIsOpen.value = false;
+}
 
-      exportFormat: ExportFormat.PNG,
+function openSyllablePositioningDialog() {
+  syllablePositioningDialogIsOpen.value = true;
+}
 
-      clipboard: [] as ScoreElement[],
-      formatType: null as ElementType | null,
-      textBoxFormat: null as Partial<TextBoxElement> | null,
-      noteFormat: null as Partial<NoteElement> | null,
-      richTextBoxCalculation: false,
-      richTextBoxCalculationCount: 0,
-      textBoxCalculation: false,
-      textBoxCalculationCount: 0,
+function closeSyllablePositioningDialog() {
+  syllablePositioningDialogIsOpen.value = false;
+}
 
-      fonts: [] as string[],
+function openPlaybackSettingsDialog() {
+  playbackSettingsDialogIsOpen.value = true;
 
-      toolbarInnerNeume: 'Primary',
+  stopAudio();
+}
 
-      keyboardModifier: null as string | null,
+function closePlaybackSettingsDialog() {
+  playbackSettingsDialogIsOpen.value = false;
 
-      audioElement: null as ScoreElement | null,
-      playbackEvents: [] as PlaybackSequenceEvent[],
-      playbackTimeInterval: null as ReturnType<typeof setInterval> | null,
-      audioOptions: {
-        useLegetos: false,
-        useDefaultAttractionZo: true,
-        frequencyDi: 196,
-        speed: 1,
+  saveAudioOptions();
+}
 
-        diatonicIntervals: [12, 10, 8],
-        hardChromaticIntervals: [6, 20, 4],
-        softChromaticIntervals: [8, 14, 8],
-        legetosIntervals: [8, 10, 12],
-        zygosIntervals: [18, 4, 16, 4],
-        zygosLegetosIntervals: [18, 4, 20, 4],
-        spathiIntervals: [20, 4, 4, 14],
-        klitonIntervals: [14, 12, 4],
+function closePageSetupDialog() {
+  pageSetupDialogIsOpen.value = false;
+}
 
-        defaultAttractionZoMoria: -4,
-        defaultAttractionKeMoria: 5,
+function closeExportDialog() {
+  exportDialogIsOpen.value = false;
+}
 
-        volumeIson: -4,
-        volumeMelody: 0,
+function openLyricManager() {
+  lyricManagerIsOpen.value = true;
+  refreshStaffLyrics();
+}
 
-        alterationMultipliers: [0.5, 0.25, 0.75],
+function closeLyricManager() {
+  lyricManagerIsOpen.value = false;
+}
 
-        alterationMoriaMap: {
-          [Accidental.Flat_2_Right]: -2,
-          [Accidental.Flat_4_Right]: -4,
-          [Accidental.Flat_6_Right]: -6,
-          [Accidental.Flat_8_Right]: -8,
-          [Accidental.Sharp_2_Left]: 2,
-          [Accidental.Sharp_4_Left]: 4,
-          [Accidental.Sharp_6_Left]: 6,
-          [Accidental.Sharp_8_Left]: 8,
-        },
-      } as PlaybackOptions,
+function updateEditorPreferences(form: EditorPreferences) {
+  const languageChanged = editorPreferences.value.language !== form.language;
 
-      editorPreferences: new EditorPreferences(),
+  Object.assign(editorPreferences.value, form);
 
-      byzHtmlExporter: new ByzHtmlExporter(),
+  saveEditorPreferences();
 
-      exportInProgress: false,
+  if (languageChanged) {
+    // An empty string means "fall back to the auto-detected locale".
+    i18next.changeLanguage(
+      resolveLanguagePreference(form.language, navigator.language),
+    );
+    EventBus.$emit(IpcRendererChannels.SetLanguage, form.language);
+  }
 
-      throttled: {
-        assignLyrics: null! as () => void,
-        moveToPreviousLyricBox: null! as () => void,
-        moveToNextLyricBox: null! as (clearMelisma?: boolean) => void,
-        moveLeft: null! as () => void,
-        moveRight: null! as () => void,
-        moveSelectionLeft: null! as () => void,
-        moveSelectionRight: null! as () => void,
-        deleteSelectedElement: null! as () => void,
-        deletePreviousElement: null! as () => void,
-        onFileMenuUndo: null! as () => void,
-        onFileMenuRedo: null! as () => void,
-        onCutScoreElements: null! as () => void,
-        onCopyScoreElements: null! as () => void,
-        onFileMenuCopyAsHtml: null! as () => void,
-        onPasteScoreElements: null! as (includeLyrics: boolean) => void,
-        addQuantitativeNeume: null! as (
-          quantitativeNeume: QuantitativeNeume,
-          secondaryGorgonNeume?: GorgonNeume,
-        ) => void,
-        addTempo: null! as (neume: TempoSign) => void,
-        addAutoMartyria: null! as (alignRight?: boolean, note?: Note) => void,
-        updateNoteAndSave: null! as (
-          element: NoteElement,
-          values: Partial<NoteElement>,
-        ) => void,
-        setKlasma: null! as (element: NoteElement) => void,
-        setGorgon: null! as (
-          element: NoteElement,
-          neumes: GorgonNeume | GorgonNeume[],
-        ) => void,
-        setFthoraNote: null! as (
-          element: NoteElement,
-          neumes: Fthora[],
-        ) => void,
-        setFthoraMartyria: null! as (
-          element: MartyriaElement,
-          neume: Fthora,
-        ) => void,
-        setMartyriaTempo: null! as (
-          element: MartyriaElement,
-          neume: TempoSign,
-        ) => void,
-        setAccidental: null! as (
-          element: NoteElement,
-          neume: Accidental,
-        ) => void,
-        setTimeNeume: null! as (element: NoteElement, neume: TimeNeume) => void,
-        setMeasureNumber: null! as (
-          element: NoteElement,
-          neume: MeasureNumber,
-        ) => void,
-        setMeasureBarNote: null! as (
-          element: NoteElement,
-          neume: MeasureBar,
-        ) => void,
-        setMeasureBarMartyria: null! as (
-          element: MartyriaElement,
-          neume: MeasureBar,
-        ) => void,
-        setIson: null! as (element: NoteElement, neume: Ison) => void,
-        setTie: null! as (element: NoteElement, neumes: Tie[]) => void,
-        setVocalExpression: null! as (
-          element: NoteElement,
-          neume: VocalExpressionNeume,
-        ) => void,
-        updateMartyria: null! as (
-          element: MartyriaElement,
-          values: Partial<MartyriaElement>,
-        ) => void,
-        onWindowResize: null! as () => void,
-        onScroll: null! as () => void,
-      },
-      saveDebounced: null! as (markUnsavedChanges?: boolean) => void,
-    };
-  },
-  computed: {
-    selectedWorkspaceId: {
-      get() {
-        return this.selectedWorkspace.id;
-      },
+  editorPreferencesDialogIsOpen.value = false;
+}
 
-      set(value: string) {
-        this.selectedWorkspace =
-          (this.workspaces.find((x) => x.id === value) as Workspace) ??
-          new Workspace();
-      },
-    },
+function closeEditorPreferencesDialog() {
+  editorPreferencesDialogIsOpen.value = false;
+}
 
-    rtl() {
-      return this.score.pageSetup.melkiteRtl;
-    },
+function saveEditorPreferences() {
+  localStorage.setItem(
+    'editorPreferences',
+    JSON.stringify(editorPreferences.value),
+  );
+}
 
-    selectedWorkspace: {
-      get() {
-        return this.selectedWorkspaceValue as Workspace;
-      },
+function isLastElement(element: ScoreElement) {
+  return elements.value.indexOf(element) === elements.value.length - 1;
+}
 
-      set(value: Workspace) {
-        // Save the scroll position
-        const pageBackgroundElement = this.$refs[
-          'page-background'
-        ] as HTMLElement;
-        this.selectedWorkspace.scrollLeft = pageBackgroundElement.scrollLeft;
-        this.selectedWorkspace.scrollTop = pageBackgroundElement.scrollTop;
+function insertPelastikon() {
+  document.execCommand('insertText', false, PELASTIKON);
+}
 
-        this.selectedWorkspaceValue = value;
-        this.selectedWorkspace.commandService.notify();
-        this.save(false);
+function insertGorthmikon() {
+  document.execCommand('insertText', false, GORTHMIKON);
+}
 
-        // Scroll to the new workspace's saved scroll position
-        // Use nextTick to scroll after the DOM has refreshed
-        nextTick(() => {
-          pageBackgroundElement.scrollTo(
-            this.selectedWorkspace.scrollLeft,
-            this.selectedWorkspace.scrollTop,
-          );
+function insertSpecialCharacter(character: string) {
+  document.execCommand('insertText', false, character);
+}
 
-          this.calculatePageNumber();
-        });
+function addQuantitativeNeume(
+  quantitativeNeume: QuantitativeNeume,
+  secondaryGorgonNeume: GorgonNeume | null = null,
+) {
+  if (selectedElement.value == null) {
+    return;
+  }
 
-        this.stopAudio();
-      },
-    },
+  const element = new NoteElement();
+  element.lyricsColor = score.value.pageSetup.lyricsDefaultColor;
+  element.lyricsFontFamily = score.value.pageSetup.lyricsDefaultFontFamily;
+  element.lyricsFontSize = score.value.pageSetup.lyricsDefaultFontSize;
+  element.lyricsFontStyle = score.value.pageSetup.lyricsDefaultFontStyle;
+  element.lyricsFontWeight = score.value.pageSetup.lyricsDefaultFontWeight;
+  element.lyricsStrokeWidth = score.value.pageSetup.lyricsDefaultStrokeWidth;
 
-    score() {
-      return this.selectedWorkspace.score;
-    },
+  element.quantitativeNeume = quantitativeNeume;
+  // Special case for neumes with secondary gorgon
+  if (getSecondaryNeume(quantitativeNeume) != null) {
+    element.secondaryGorgonNeume = secondaryGorgonNeume;
+  }
 
-    elements() {
-      return this.score?.staff.elements ?? [];
-    },
+  // If the selected element is an alternate line element,
+  // add the new element to the alternate line's elements
+  // and return immediately. Alternate lines do not support
+  // different entry modes.
+  if (selectedWorkspace.value.selectedAlternateLineElement != null) {
+    addScoreElement(
+      element,
+      selectedWorkspace.value.selectedAlternateLineElement.elements.length,
+      selectedWorkspace.value.selectedAlternateLineElement.elements,
+    );
+    save();
+    return;
+  }
 
-    resizableRichTextBoxElements() {
-      return this.elements.filter(
-        (x) =>
-          x.elementType === ElementType.RichTextBox &&
-          !(x as RichTextBoxElement).inline,
-      );
-    },
-
-    resizableTextBoxElements() {
-      return this.elements.filter(
-        (x) =>
-          x.elementType === ElementType.TextBox &&
-          !(x as TextBoxElement).inline,
-      );
-    },
-
-    lyrics: {
-      get() {
-        return this.score?.staff.lyrics.text ?? '';
-      },
-
-      set(value: string) {
-        this.score.staff.lyrics.text = value;
-      },
-    },
-
-    lyricsLocked: {
-      get() {
-        return this.score?.staff.lyrics.locked ?? false;
-      },
-
-      set(value: boolean) {
-        this.score.staff.lyrics.locked = value;
-      },
-    },
-
-    lyricManagerIsOpen: {
-      get() {
-        return this.selectedWorkspace.lyricManagerIsOpen;
-      },
-
-      set(value: boolean) {
-        this.selectedWorkspace.lyricManagerIsOpen = value;
-      },
-    },
-
-    pageCount() {
-      return this.pages.length;
-    },
-
-    commandService() {
-      return this.selectedWorkspace.commandService;
-    },
-
-    selectedElementIndex() {
-      return this.selectedElement != null
-        ? this.elements.indexOf(this.selectedElement)
-        : -1;
-    },
-
-    windowTitle() {
-      return `${this.getFileName(this.selectedWorkspace)} - ${
-        import.meta.env.VITE_TITLE
-      }`;
-    },
-
-    selectedElement: {
-      get() {
-        return this.selectedWorkspace.selectedElement;
-      },
-
-      set(element: ScoreElement | null) {
-        if (element != null) {
-          this.selectedLyrics = null;
-          this.selectionRange = null;
-          this.selectedHeaderFooterElement = null;
-          this.toolbarInnerNeume = 'Primary';
-
-          if (this.audioService.state === AudioState.Playing) {
-            const event = this.playbackEvents.find(
-              (x) => x.elementIndex === this.getElementIndex(element),
-            );
-
-            if (event) {
-              this.audioService.jumpToEvent(event);
-              this.selectedWorkspace.playbackTime = event.absoluteTime;
-            }
-          } else if (this.audioService.state === AudioState.Paused) {
-            this.stopAudio();
-          }
-        }
-
-        if (
-          this.selectedWorkspace.selectedAlternateLineElement != null &&
-          this.selectedWorkspace.selectedAlternateLineElement.elements
-            .length === 0
-        ) {
-          this.removeAlternateLine(
-            this.selectedElement as NoteElement,
-            this.selectedWorkspace.selectedAlternateLineElement,
-            true,
-          );
-        }
-
-        this.selectedWorkspace.selectedElement = element;
-        this.selectedWorkspace.selectedAnnotationElement = null;
-        this.selectedWorkspace.selectedAlternateLineElement = null;
-      },
-    },
-
-    selectedElementForNeumeToolbar() {
-      if (
-        this.selectedWorkspace.selectedAlternateLineElement != null &&
-        this.selectedWorkspace.selectedAlternateLineElement.elements.length > 0
-      ) {
-        return this.selectedWorkspace.selectedAlternateLineElement.elements[
-          this.selectedWorkspace.selectedAlternateLineElement.elements.length -
-            1
-        ];
-      }
-      return this.selectedWorkspace.selectedElement;
-    },
-
-    previousElementOnLine() {
-      const index = this.selectedElementIndex;
-
-      if (index - 1 < 0) {
-        return null;
+  switch (entryMode.value) {
+    case EntryMode.Auto:
+      if (!isLastElement(selectedElement.value) && !moveRight()) {
+        return;
       }
 
-      return this.elements[index - 1].line === this.selectedElement?.line
-        ? this.elements[index - 1]
-        : null;
-    },
-
-    nextElementOnLine() {
-      const index = this.selectedElementIndex;
-
-      if (index + 1 >= this.elements.length - 1) {
-        return null;
-      }
-
-      return this.elements[index + 1].line === this.selectedElement?.line
-        ? this.elements[index + 1]
-        : null;
-    },
-
-    selectedLyrics: {
-      get() {
-        return this.selectedWorkspace.selectedLyrics;
-      },
-
-      set(element: NoteElement | null) {
-        if (element != null) {
-          this.selectedElement = null;
-          this.selectedHeaderFooterElement = null;
-          this.selectionRange = null;
-        }
-
-        this.selectedWorkspace.selectedLyrics = element;
-      },
-    },
-
-    selectedHeaderFooterElement: {
-      get() {
-        return this.selectedWorkspace.selectedHeaderFooterElement;
-      },
-
-      set(element: ScoreElement | null) {
-        if (element != null) {
-          this.selectedElement = null;
-          this.selectedLyrics = null;
-          this.selectionRange = null;
-        }
-
-        this.selectedWorkspace.selectedHeaderFooterElement = element;
-      },
-    },
-
-    selectedTextBoxElement() {
-      const selectedElement =
-        this.selectedElement || this.selectedHeaderFooterElement;
-
-      return selectedElement != null && this.isTextBoxElement(selectedElement)
-        ? (selectedElement as TextBoxElement)
-        : null;
-    },
-
-    selectedRichTextBoxElement() {
-      const selectedElement =
-        this.selectedElement || this.selectedHeaderFooterElement;
-
-      return selectedElement != null &&
-        this.isRichTextBoxElement(selectedElement)
-        ? (selectedElement as RichTextBoxElement)
-        : null;
-    },
-
-    selectionRange: {
-      get() {
-        return this.selectedWorkspace.selectionRange;
-      },
-
-      set(value: ScoreElementSelectionRange | null) {
-        this.selectedWorkspace.selectionRange = value;
-      },
-    },
-
-    zoom: {
-      get() {
-        return this.selectedWorkspace.zoom;
-      },
-
-      set(zoom: number) {
-        this.selectedWorkspace.zoom = zoom;
-      },
-    },
-
-    zoomToFit: {
-      get() {
-        return this.selectedWorkspace.zoomToFit;
-      },
-
-      set(value: boolean) {
-        this.selectedWorkspace.zoomToFit = value;
-      },
-    },
-
-    entryMode: {
-      get() {
-        return this.selectedWorkspace.entryMode;
-      },
-
-      set(value: EntryMode) {
-        this.selectedWorkspace.entryMode = value;
-      },
-    },
-
-    currentFilePath: {
-      get() {
-        return this.selectedWorkspace.filePath;
-      },
-
-      set(path: string | null) {
-        this.selectedWorkspace.filePath = path;
-      },
-    },
-
-    hasUnsavedChanges: {
-      get() {
-        return this.selectedWorkspace.hasUnsavedChanges;
-      },
-
-      set(hasUnsavedChanges: boolean) {
-        this.selectedWorkspace.hasUnsavedChanges = hasUnsavedChanges;
-      },
-    },
-
-    pageStyle() {
-      return {
-        minWidth: withZoom(this.score.pageSetup.pageWidth),
-        maxWidth: withZoom(this.score.pageSetup.pageWidth),
-        width: withZoom(this.score.pageSetup.pageWidth),
-        height: withZoom(this.score.pageSetup.pageHeight),
-        minHeight: withZoom(this.score.pageSetup.pageHeight),
-        maxHeight: withZoom(this.score.pageSetup.pageHeight),
-      } as StyleValue;
-    },
-
-    headerStyle() {
-      return {
-        left: withZoom(this.score.pageSetup.leftMargin),
-        top: withZoom(this.score.pageSetup.headerMargin),
-      } as StyleValue;
-    },
-
-    footerStyle() {
-      return {
-        left: withZoom(this.score.pageSetup.leftMargin),
-        bottom: withZoom(this.score.pageSetup.footerMargin),
-      } as StyleValue;
-    },
-
-    guideStyleLeft() {
-      return {
-        left: withZoom(this.score.pageSetup.leftMargin - 1),
-        height: withZoom(this.score.pageSetup.pageHeight),
-      } as StyleValue;
-    },
-
-    guideStyleRight() {
-      return {
-        right: withZoom(this.score.pageSetup.rightMargin - 1),
-        height: withZoom(this.score.pageSetup.pageHeight),
-      } as StyleValue;
-    },
-
-    guideStyleTop() {
-      return {
-        top: withZoom(this.score.pageSetup.topMargin - 1),
-        width: withZoom(this.score.pageSetup.pageWidth),
-      } as StyleValue;
-    },
-
-    guideStyleBottom() {
-      return {
-        bottom: withZoom(this.score.pageSetup.bottomMargin - 1),
-        width: withZoom(this.score.pageSetup.pageWidth),
-      } as StyleValue;
-    },
-
-    pageVisibilityIntersection() {
-      // look ahead/behind 1 page
-      const margin = this.score.pageSetup.pageHeight * this.zoom;
-
-      return {
-        root: this.$refs['page-background'],
-        rootMargin: `${margin}px 0px ${margin}px 0px`,
-      } as IntersectionObserver;
-    },
-
-    dialogOpen() {
-      return (
-        this.modeKeyDialogIsOpen ||
-        this.pageSetupDialogIsOpen ||
-        this.playbackSettingsDialogIsOpen ||
-        this.syllablePositioningDialogIsOpen ||
-        this.editorPreferencesDialogIsOpen
-      );
-    },
-
-    filteredPages() {
-      return this.printMode ? this.pages.filter((x) => !x.isEmpty) : this.pages;
-    },
-  },
-
-  watch: {
-    zoom() {
-      document.documentElement.style.setProperty(
-        '--zoom',
-        this.zoom.toString(),
-      );
-    },
-
-    currentFilePath() {
-      window.document.title = this.windowTitle;
-    },
-
-    selectedWorkspaceId() {
-      window.document.title = this.windowTitle;
-    },
-
-    hasUnsavedChanges() {
-      window.document.title = this.windowTitle;
-    },
-  },
-
-  async created() {
-    // Attach the editor component to the window variable
-    // so that it can be used for debugging
-    (window as any)._editor = this;
-
-    this.createThrottledMethods();
-
-    try {
-      const fontLoader = (document as any).fonts;
-
-      const loadSystemFontsPromise = this.ipcService
-        .getSystemFonts()
-        .then((fonts) => (this.fonts = fonts));
-
-      // Must load all fonts before loading any documents,
-      // otherwise the text measurements will be wrong
-      await Promise.all([
-        loadSystemFontsPromise,
-        fontLoader.load('1rem "GFS Didot"'),
-        fontLoader.load('1rem Neanes'),
-        fontLoader.load('1rem NeanesStathisSeries'),
-        fontLoader.load('1rem NeanesRTL'),
-        fontLoader.load('1rem "Noto Naskh Arabic"'),
-        fontLoader.load('1rem "Old Standard"'),
-        fontLoader.load('1rem "Source Serif"'),
-        fontLoader.ready,
-      ]);
-
-      await this.load();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      this.isLoading = false;
-    }
-  },
-
-  mounted() {
-    const savedAudioOptions = localStorage.getItem('audioOptionsDefault');
-
-    if (savedAudioOptions != null) {
-      Object.assign(this.audioOptions, JSON.parse(savedAudioOptions));
-
-      // -Infinity is not valid JSON, so it is serialized as null.
-      // Deserialize as -Infinity
-      this.audioOptions.volumeIson = this.audioOptions.volumeIson ?? -Infinity;
-      this.audioOptions.volumeMelody =
-        this.audioOptions.volumeMelody ?? -Infinity;
-    }
-
-    const savedEditorPreferences = localStorage.getItem('editorPreferences');
-
-    if (savedEditorPreferences != null) {
-      this.editorPreferences = EditorPreferences.createFrom(
-        JSON.parse(savedEditorPreferences),
-      );
-    }
-
-    window.addEventListener('keydown', this.onKeydown);
-    window.addEventListener('keyup', this.onKeyup);
-    window.addEventListener('resize', this.throttled.onWindowResize);
-
-    EventBus.$on(IpcMainChannels.CloseWorkspaces, this.onCloseWorkspaces);
-    EventBus.$on(IpcMainChannels.CloseApplication, this.onCloseApplication);
-
-    EventBus.$on(IpcMainChannels.FileMenuNewScore, this.onFileMenuNewScore);
-    EventBus.$on(IpcMainChannels.FileMenuOpenScore, this.onFileMenuOpenScore);
-    EventBus.$on(IpcMainChannels.FileMenuPrint, this.onFileMenuPrint);
-    EventBus.$on(IpcMainChannels.FileMenuSave, this.onFileMenuSave);
-    EventBus.$on(IpcMainChannels.FileMenuSaveAs, this.onFileMenuSaveAs);
-    EventBus.$on(IpcMainChannels.FileMenuPageSetup, this.onFileMenuPageSetup);
-    EventBus.$on(IpcMainChannels.FileMenuImportOcr, this.onFileMenuImportOcr);
-    EventBus.$on(
-      IpcMainChannels.FileMenuExportAsPdf,
-      this.onFileMenuExportAsPdf,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuExportAsHtml,
-      this.onFileMenuExportAsHtml,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuExportAsMusicXml,
-      this.onFileMenuExportAsMusicXml,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuExportAsLatex,
-      this.onFileMenuExportAsLatex,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuExportAsImage,
-      this.onFileMenuExportAsImage,
-    );
-    EventBus.$on(IpcMainChannels.FileMenuUndo, this.onFileMenuUndo);
-    EventBus.$on(IpcMainChannels.FileMenuRedo, this.onFileMenuRedo);
-    EventBus.$on(IpcMainChannels.FileMenuCut, this.onFileMenuCut);
-    EventBus.$on(IpcMainChannels.FileMenuCopy, this.onFileMenuCopy);
-    EventBus.$on(IpcMainChannels.FileMenuCopyAsHtml, this.onFileMenuCopyAsHtml);
-    EventBus.$on(IpcMainChannels.FileMenuCopyFormat, this.onFileMenuCopyFormat);
-    EventBus.$on(IpcMainChannels.FileMenuPaste, this.onFileMenuPaste);
-    EventBus.$on(
-      IpcMainChannels.FileMenuPasteWithLyrics,
-      this.onFileMenuPasteWithLyrics,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuPasteFormat,
-      this.onFileMenuPasteFormat,
-    );
-    EventBus.$on(IpcMainChannels.FileMenuFind, this.onFileMenuFind);
-    EventBus.$on(IpcMainChannels.FileMenuLyrics, this.onFileMenuLyrics);
-    EventBus.$on(
-      IpcMainChannels.FileMenuPreferences,
-      this.onFileMenuPreferences,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertAnnotation,
-      this.onFileMenuInsertAnnotation,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertAlternateLine,
-      this.onFileMenuInsertAlternateLine,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertTextBox,
-      this.onFileMenuInsertTextBox,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertRichTextBox,
-      this.onFileMenuInsertRichTextBox,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertModeKey,
-      this.onFileMenuInsertModeKey,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertDropCapBefore,
-      this.onFileMenuInsertDropCapBefore,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertDropCapAfter,
-      this.onFileMenuInsertDropCapAfter,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertImage,
-      this.onFileMenuInsertImage,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertHeader,
-      this.onFileMenuInsertHeader,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuInsertFooter,
-      this.onFileMenuInsertFooter,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuToolsCopyElementLink,
-      this.onFileMenuToolsCopyElementLink,
-    );
-    EventBus.$on(
-      IpcMainChannels.FileMenuGenerateTestFile,
-      this.onFileMenuGenerateTestFile,
-    );
-
-    EventBus.$on(
-      AudioServiceEventNames.EventPlay,
-      this.onAudioServiceEventPlay,
-    );
-
-    EventBus.$on(AudioServiceEventNames.Stop, this.onAudioServiceStop);
-  },
-
-  beforeUnmount() {
-    // Remove the debugging variable from window
-    (window as any)._editor = undefined;
-
-    window.removeEventListener('keydown', this.onKeydown);
-    window.removeEventListener('keyup', this.onKeyup);
-    window.removeEventListener('resize', this.throttled.onWindowResize);
-
-    EventBus.$off(IpcMainChannels.CloseWorkspaces, this.onCloseWorkspaces);
-    EventBus.$off(IpcMainChannels.CloseApplication, this.onCloseApplication);
-
-    EventBus.$off(IpcMainChannels.FileMenuNewScore, this.onFileMenuNewScore);
-    EventBus.$off(IpcMainChannels.FileMenuOpenScore, this.onFileMenuOpenScore);
-    EventBus.$off(IpcMainChannels.FileMenuPrint, this.onFileMenuPrint);
-    EventBus.$off(IpcMainChannels.FileMenuSave, this.onFileMenuSave);
-    EventBus.$off(IpcMainChannels.FileMenuSaveAs, this.onFileMenuSaveAs);
-    EventBus.$off(IpcMainChannels.FileMenuPageSetup, this.onFileMenuPageSetup);
-    EventBus.$off(
-      IpcMainChannels.FileMenuExportAsPdf,
-      this.onFileMenuExportAsPdf,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuExportAsHtml,
-      this.onFileMenuExportAsHtml,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuExportAsMusicXml,
-      this.onFileMenuExportAsMusicXml,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuExportAsLatex,
-      this.onFileMenuExportAsLatex,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuExportAsImage,
-      this.onFileMenuExportAsImage,
-    );
-    EventBus.$off(IpcMainChannels.FileMenuUndo, this.onFileMenuUndo);
-    EventBus.$off(IpcMainChannels.FileMenuRedo, this.onFileMenuRedo);
-    EventBus.$off(IpcMainChannels.FileMenuCut, this.onFileMenuCut);
-    EventBus.$off(IpcMainChannels.FileMenuCopy, this.onFileMenuCopy);
-    EventBus.$off(
-      IpcMainChannels.FileMenuCopyAsHtml,
-      this.onFileMenuCopyAsHtml,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuCopyFormat,
-      this.onFileMenuCopyFormat,
-    );
-    EventBus.$off(IpcMainChannels.FileMenuPaste, this.onFileMenuPaste);
-    EventBus.$off(
-      IpcMainChannels.FileMenuPasteWithLyrics,
-      this.onFileMenuPasteWithLyrics,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuPasteFormat,
-      this.onFileMenuPasteFormat,
-    );
-    EventBus.$off(IpcMainChannels.FileMenuFind, this.onFileMenuFind);
-    EventBus.$off(IpcMainChannels.FileMenuLyrics, this.onFileMenuLyrics);
-    EventBus.$off(
-      IpcMainChannels.FileMenuPreferences,
-      this.onFileMenuPreferences,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertAnnotation,
-      this.onFileMenuInsertAnnotation,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertAlternateLine,
-      this.onFileMenuInsertAlternateLine,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertTextBox,
-      this.onFileMenuInsertTextBox,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertRichTextBox,
-      this.onFileMenuInsertRichTextBox,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertModeKey,
-      this.onFileMenuInsertModeKey,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertDropCapBefore,
-      this.onFileMenuInsertDropCapBefore,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertDropCapAfter,
-      this.onFileMenuInsertDropCapAfter,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertImage,
-      this.onFileMenuInsertImage,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertHeader,
-      this.onFileMenuInsertHeader,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuInsertFooter,
-      this.onFileMenuInsertFooter,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuToolsCopyElementLink,
-      this.onFileMenuToolsCopyElementLink,
-    );
-    EventBus.$off(
-      IpcMainChannels.FileMenuGenerateTestFile,
-      this.onFileMenuGenerateTestFile,
-    );
-
-    EventBus.$off(
-      AudioServiceEventNames.EventPlay,
-      this.onAudioServiceEventPlay,
-    );
-
-    EventBus.$off(AudioServiceEventNames.Stop, this.onAudioServiceStop);
-
-    this.audioService.dispose();
-  },
-
-  methods: {
-    createThrottledMethods() {
-      this.throttled.assignLyrics = throttle(
-        keydownThrottleIntervalMs,
-        this.assignLyrics,
-      );
-
-      this.throttled.moveToPreviousLyricBox = throttle(
-        keydownThrottleIntervalMs,
-        this.moveToPreviousLyricBox,
-      );
-
-      this.throttled.moveToNextLyricBox = throttle(
-        keydownThrottleIntervalMs,
-        this.moveToNextLyricBox,
-      );
-
-      this.throttled.moveLeft = throttle(
-        keydownThrottleIntervalMs,
-        this.moveLeft,
-      );
-
-      this.throttled.moveRight = throttle(
-        keydownThrottleIntervalMs,
-        this.moveRight,
-      );
-
-      this.throttled.moveSelectionLeft = throttle(
-        keydownThrottleIntervalMs,
-        this.moveSelectionLeft,
-      );
-
-      this.throttled.moveSelectionRight = throttle(
-        keydownThrottleIntervalMs,
-        this.moveSelectionRight,
-      );
-
-      this.throttled.deleteSelectedElement = throttle(
-        keydownThrottleIntervalMs,
-        this.deleteSelectedElement,
-      );
-
-      this.throttled.deletePreviousElement = throttle(
-        keydownThrottleIntervalMs,
-        this.deletePreviousElement,
-      );
-
-      this.throttled.onFileMenuUndo = throttle(
-        keydownThrottleIntervalMs,
-        this.onFileMenuUndo,
-      );
-
-      this.throttled.onFileMenuRedo = throttle(
-        keydownThrottleIntervalMs,
-        this.onFileMenuRedo,
-      );
-
-      this.throttled.onCutScoreElements = throttle(
-        keydownThrottleIntervalMs,
-        this.onCutScoreElements,
-      );
-
-      this.throttled.onCopyScoreElements = throttle(
-        keydownThrottleIntervalMs,
-        this.onCopyScoreElements,
-      );
-
-      this.throttled.onFileMenuCopyAsHtml = throttle(
-        keydownThrottleIntervalMs,
-        this.onFileMenuCopyAsHtml,
-      );
-
-      this.throttled.onPasteScoreElements = throttle(
-        keydownThrottleIntervalMs,
-        this.onPasteScoreElements,
-      );
-
-      this.throttled.addQuantitativeNeume = throttle(
-        keydownThrottleIntervalMs,
-        this.addQuantitativeNeume,
-      );
-
-      this.throttled.addTempo = throttle(
-        keydownThrottleIntervalMs,
-        this.addTempo,
-      );
-
-      this.throttled.addAutoMartyria = throttle(
-        keydownThrottleIntervalMs,
-        this.addAutoMartyria,
-      );
-
-      this.throttled.updateNoteAndSave = throttle(
-        keydownThrottleIntervalMs,
-        this.updateNoteAndSave,
-      );
-
-      this.throttled.updateMartyria = throttle(
-        keydownThrottleIntervalMs,
-        this.updateMartyria,
-      );
-
-      this.throttled.setKlasma = throttle(
-        keydownThrottleIntervalMs,
-        this.setKlasma,
-      );
-      this.throttled.setGorgon = throttle(
-        keydownThrottleIntervalMs,
-        this.setGorgon,
-      );
-      this.throttled.setFthoraNote = throttle(
-        keydownThrottleIntervalMs,
-        this.setFthoraNote,
-      );
-      this.throttled.setFthoraMartyria = throttle(
-        keydownThrottleIntervalMs,
-        this.setFthoraMartyria,
-      );
-      this.throttled.setMartyriaTempo = throttle(
-        keydownThrottleIntervalMs,
-        this.setMartyriaTempo,
-      );
-      this.throttled.setAccidental = throttle(
-        keydownThrottleIntervalMs,
-        this.setAccidental,
-      );
-      this.throttled.setTimeNeume = throttle(
-        keydownThrottleIntervalMs,
-        this.setTimeNeume,
-      );
-      this.throttled.setMeasureNumber = throttle(
-        keydownThrottleIntervalMs,
-        this.setMeasureNumber,
-      );
-      this.throttled.setMeasureBarNote = throttle(
-        keydownThrottleIntervalMs,
-        this.setMeasureBarNote,
-      );
-      this.throttled.setMeasureBarMartyria = throttle(
-        keydownThrottleIntervalMs,
-        this.setMeasureBarMartyria,
-      );
-      this.throttled.setIson = throttle(
-        keydownThrottleIntervalMs,
-        this.setIson,
-      );
-      this.throttled.setTie = throttle(keydownThrottleIntervalMs, this.setTie);
-      this.throttled.setVocalExpression = throttle(
-        keydownThrottleIntervalMs,
-        this.setVocalExpression,
-      );
-
-      this.throttled.onWindowResize = throttle(250, this.onWindowResize);
-      this.throttled.onScroll = throttle(250, this.onScroll);
-
-      this.saveDebounced = debounce(250, this.save);
-
-      // Make sure we initialized all the throttled methods
-      if (this.isDevelopment) {
-        for (const [key, val] of Object.entries(this.throttled)) {
-          if (val == null) {
-            throw new Error(
-              `Missing initialization for throttled method '${key}'`,
-            );
-          }
-        }
-      }
-    },
-    getHeaderHorizontalRuleStyle(headerHeight: number) {
-      return {
-        left: withZoom(this.score.pageSetup.leftMargin),
-        top: withZoom(
-          this.score.pageSetup.headerMargin +
-            headerHeight +
-            this.score.pageSetup.headerHorizontalRuleMarginTop,
-        ),
-        color: this.score.pageSetup.headerHorizontalRuleColor,
-        borderTopWidth: withZoom(
-          this.score.pageSetup.headerHorizontalRuleThickness,
-        ),
-        width: withZoom(this.score.pageSetup.innerPageWidth),
-      } as StyleValue;
-    },
-
-    getFooterHorizontalRuleStyle(footerHeight: number) {
-      return {
-        left: withZoom(this.score.pageSetup.leftMargin),
-        bottom: withZoom(
-          this.score.pageSetup.footerMargin +
-            footerHeight +
-            this.score.pageSetup.footerHorizontalRuleMarginBottom,
-        ),
-        color: this.score.pageSetup.footerHorizontalRuleColor,
-        borderTopWidth: withZoom(
-          this.score.pageSetup.footerHorizontalRuleThickness,
-        ),
-        width: withZoom(this.score.pageSetup.innerPageWidth),
-      } as StyleValue;
-    },
-
-    getLyricStyle(element: NoteElement) {
-      return {
-        top: withZoom(element.lyricsVerticalOffset),
-        paddingLeft:
-          (!element.isFullMelisma ||
-            (element.melismaText && !element.melismaText.endsWith(TATWEEL))) &&
-          element.lyricsHorizontalOffset > 0
-            ? withZoom(element.lyricsHorizontalOffset)
-            : undefined,
-        paddingRight:
-          (!element.isFullMelisma ||
-            (element.melismaText && !element.melismaText.endsWith(TATWEEL))) &&
-          element.lyricsHorizontalOffset < 0
-            ? withZoom(-element.lyricsHorizontalOffset)
-            : undefined,
-        fontSize: element.lyricsUseDefaultStyle
-          ? withZoom(this.score.pageSetup.lyricsDefaultFontSize)
-          : withZoom(element.lyricsFontSize),
-        fontFamily: element.lyricsUseDefaultStyle
-          ? getFontFamilyWithFallback(
-              this.score.pageSetup.lyricsDefaultFontFamily,
-              this.score.pageSetup.neumeDefaultFontFamily,
-            )
-          : getFontFamilyWithFallback(
-              element.lyricsFontFamily,
-              this.score.pageSetup.neumeDefaultFontFamily,
-            ),
-        fontWeight: element.lyricsUseDefaultStyle
-          ? this.score.pageSetup.lyricsDefaultFontWeight
-          : element.lyricsFontWeight,
-        fontStyle: element.lyricsUseDefaultStyle
-          ? this.score.pageSetup.lyricsDefaultFontStyle
-          : element.lyricsFontStyle,
-        textDecoration: element.lyricsUseDefaultStyle
-          ? undefined
-          : element.lyricsTextDecoration,
-        color: element.lyricsUseDefaultStyle
-          ? this.score.pageSetup.lyricsDefaultColor
-          : element.lyricsColor,
-        webkitTextStrokeWidth: element.lyricsUseDefaultStyle
-          ? withZoom(this.score.pageSetup.lyricsDefaultStrokeWidth)
-          : withZoom(element.lyricsStrokeWidth),
-        lineHeight: withZoom(element.lyricsFontHeight),
-        left: element.alignLeft
-          ? withZoom(Math.min(0, element.lyricsHorizontalOffset))
-          : undefined,
-        textAlign: element.alignLeft ? 'left' : undefined,
-      } as StyleValue;
-    },
-
-    getEmptyBoxStyle(element: EmptyElement) {
-      return {
-        width: withZoom(element.width),
-        height: withZoom(element.height),
-      } as StyleValue;
-    },
-
-    getElementStyle(element: ScoreElement) {
-      return {
-        left: !this.rtl ? withZoom(element.x) : undefined,
-        right: this.rtl ? withZoom(element.x) : undefined,
-        top: withZoom(element.y),
-      } as StyleValue;
-    },
-
-    getAdjustmentRatioStyle(line: Line) {
-      const fontSize = this.score.pageSetup.lyricsDefaultFontSize * 0.8;
-      const gap = fontSize * 0.5;
-      return {
-        position: 'absolute',
-        left: withZoom(
-          this.rtl
-            ? this.score.pageSetup.leftMargin - gap - fontSize * 3
-            : this.score.pageSetup.pageWidth -
-                this.score.pageSetup.rightMargin +
-                gap,
-        ),
-        width: withZoom(fontSize * 3),
-        textAlign: 'right',
-        top: withZoom(
-          line.elements[0].y +
-            this.score.pageSetup.lineHeight / 3 -
-            fontSize / 2,
-        ),
-        fontSize: withZoom(fontSize),
-        fontFamily: this.score.pageSetup.lyricsDefaultFontFamily,
-        color: this.score.pageSetup.gorgonDefaultColor,
-      } as StyleValue;
-    },
-
-    getMelismaStyle(element: NoteElement) {
-      return {
-        width: withZoom(element.melismaWidth),
-        minHeight: element.lyricsUseDefaultStyle
-          ? withZoom(this.score.pageSetup.lyricsDefaultFontSize)
-          : withZoom(element.lyricsFontSize),
-      } as StyleValue;
-    },
-
-    getMelismaUnderscoreStyleOuter(element: NoteElement) {
-      return {
-        top: withZoom(element.melismaOffsetTop),
-        height: withZoom(element.lyricsFontHeight),
-        width: withZoom(element.melismaWidth),
-      };
-    },
-
-    getMelismaUnderscoreStyleInner(element: NoteElement) {
-      const thickness = this.score.pageSetup.lyricsMelismaThickness;
-
-      const spacing = !element.isFullMelisma
-        ? this.score.pageSetup.lyricsMelismaSpacing
-        : 0;
-
-      return {
-        borderBottom: `${withZoom(thickness)} solid ${
-          element.lyricsUseDefaultStyle
-            ? this.score.pageSetup.lyricsDefaultColor
-            : element.lyricsColor
-        }`,
-        left: withZoom(spacing),
-        width: `calc(100% - ${withZoom(spacing)})`,
-      };
-    },
-
-    getMelismaHyphenStyle(element: NoteElement, index: number) {
-      return {
-        left: withZoom(element.hyphenOffsets[index]),
-      } as StyleValue;
-    },
-
-    getTempFilename() {
-      return `Untitled-${untitledIndex++}`;
-    },
-
-    getFileName(workspace: Workspace, showUnsavedChanges: boolean = true) {
-      const unsavedChangesMarker =
-        workspace.hasUnsavedChanges && showUnsavedChanges ? '*' : '';
-
-      if (workspace.filePath != null) {
-        const fileName = getFileNameFromPath(workspace.filePath);
-        return `${unsavedChangesMarker}${fileName}`;
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+        selectedElement.value = element;
       } else {
-        return `${unsavedChangesMarker}${workspace.tempFileName}`;
-      }
-    },
-
-    getHeaderForPageIndex(pageIndex: number) {
-      const pageNumber = pageIndex + 1;
-
-      const header = this.score.getHeaderForPage(pageNumber);
-
-      // Currently, headers only support a single text box element.
-      return header.elements[0] as TextBoxElement | RichTextBoxElement;
-    },
-
-    getFooterForPageIndex(pageIndex: number) {
-      const pageNumber = pageIndex + 1;
-
-      const footer = this.score.getFooterForPage(pageNumber);
-
-      // Currently, footers only support a single text box element.
-      return footer.elements[0] as TextBoxElement | RichTextBoxElement;
-    },
-
-    shouldShowHeaderForPageIndex(pageIndex: number) {
-      const pageNumber = pageIndex + 1;
-
-      return this.score.shouldShowHeaderOnPage(pageNumber);
-    },
-
-    shouldShowFooterForPageIndex(pageIndex: number) {
-      const pageNumber = pageIndex + 1;
-
-      return this.score.shouldShowFooterOnPage(pageNumber);
-    },
-
-    getTokenMetadata(pageIndex: number): TokenMetadata {
-      return {
-        pageNumber: pageIndex + this.score.pageSetup.firstPageNumber,
-        numberOfPages:
-          this.pageCount + this.score.pageSetup.firstPageNumber - 1,
-        fileName:
-          this.selectedWorkspace.filePath != null
-            ? getFileNameFromPath(this.selectedWorkspace.filePath)
-            : this.selectedWorkspace.tempFileName,
-        filePath: this.currentFilePath || '',
-      };
-    },
-
-    getElementIndex(element: ScoreElement) {
-      return element.index;
-    },
-
-    setSelectionRange(element: ScoreElement) {
-      const elementIndex = this.getElementIndex(element);
-
-      if (this.selectedElement != null) {
-        this.selectionRange = {
-          start: this.selectedElementIndex,
-          end: elementIndex,
-        };
-
-        this.selectedElement = null;
-      } else if (this.selectionRange != null) {
-        this.selectionRange.end = elementIndex;
-      }
-    },
-
-    getNormalizedSelectionRange() {
-      if (this.selectionRange == null) {
-        return null;
-      }
-
-      const start = Math.min(
-        this.selectionRange.start,
-        this.selectionRange.end,
-      );
-      const end = Math.max(this.selectionRange.start, this.selectionRange.end);
-
-      return {
-        start,
-        end,
-      } as ScoreElementSelectionRange;
-    },
-
-    isSelected(element: ScoreElement) {
-      if (this.selectedElement === element) {
-        return true;
-      }
-      if (this.selectionRange != null) {
-        const start = Math.min(
-          this.selectionRange.start,
-          this.selectionRange.end,
-        );
-        const end = Math.max(
-          this.selectionRange.start,
-          this.selectionRange.end,
-        );
-
-        return (
-          start <= this.getElementIndex(element) &&
-          this.getElementIndex(element) <= end
-        );
-      }
-
-      return false;
-    },
-
-    setSelectedAnnotation(
-      parent: ScoreElement | null,
-      annotation: AnnotationElement,
-    ) {
-      this.selectedElement = parent;
-      this.selectedWorkspace.selectedAnnotationElement = annotation;
-    },
-
-    setSelectedAlternateLine(
-      parent: ScoreElement | null,
-      alternateLine: AlternateLineElement,
-    ) {
-      this.selectedElement = parent;
-      this.selectedWorkspace.selectedAlternateLineElement = alternateLine;
-    },
-
-    isAudioSelected(element: ScoreElement) {
-      return this.audioElement === element;
-    },
-
-    isMelisma(element: NoteElement) {
-      return element.melismaWidth > 0;
-    },
-
-    openModeKeyDialog() {
-      this.modeKeyDialogIsOpen = true;
-    },
-
-    closeModeKeyDialog() {
-      this.modeKeyDialogIsOpen = false;
-    },
-
-    openSyllablePositioningDialog() {
-      this.syllablePositioningDialogIsOpen = true;
-    },
-
-    closeSyllablePositioningDialog() {
-      this.syllablePositioningDialogIsOpen = false;
-    },
-
-    openPlaybackSettingsDialog() {
-      this.playbackSettingsDialogIsOpen = true;
-
-      this.stopAudio();
-    },
-
-    closePlaybackSettingsDialog() {
-      this.playbackSettingsDialogIsOpen = false;
-
-      this.saveAudioOptions();
-    },
-
-    closePageSetupDialog() {
-      this.pageSetupDialogIsOpen = false;
-    },
-
-    closeExportDialog() {
-      this.exportDialogIsOpen = false;
-    },
-
-    openLyricManager() {
-      this.lyricManagerIsOpen = true;
-      this.refreshStaffLyrics();
-    },
-
-    closeLyricManager() {
-      this.lyricManagerIsOpen = false;
-    },
-
-    updateEditorPreferences(form: EditorPreferences) {
-      const languageChanged = this.editorPreferences.language !== form.language;
-
-      Object.assign(this.editorPreferences, form);
-
-      this.saveEditorPreferences();
-
-      if (languageChanged) {
-        // An empty string means "fall back to the auto-detected locale".
-        i18next.changeLanguage(
-          resolveLanguagePreference(form.language, navigator.language),
-        );
-        EventBus.$emit(IpcRendererChannels.SetLanguage, form.language);
-      }
-
-      this.editorPreferencesDialogIsOpen = false;
-    },
-
-    closeEditorPreferencesDialog() {
-      this.editorPreferencesDialogIsOpen = false;
-    },
-
-    saveEditorPreferences() {
-      localStorage.setItem(
-        'editorPreferences',
-        JSON.stringify(this.editorPreferences),
-      );
-    },
-
-    isLastElement(element: ScoreElement) {
-      return this.elements.indexOf(element) === this.elements.length - 1;
-    },
-
-    insertPelastikon() {
-      document.execCommand('insertText', false, PELASTIKON);
-    },
-
-    insertGorthmikon() {
-      document.execCommand('insertText', false, GORTHMIKON);
-    },
-
-    insertSpecialCharacter(character: string) {
-      document.execCommand('insertText', false, character);
-    },
-
-    addQuantitativeNeume(
-      quantitativeNeume: QuantitativeNeume,
-      secondaryGorgonNeume: GorgonNeume | null = null,
-    ) {
-      if (this.selectedElement == null) {
-        return;
-      }
-
-      const element = new NoteElement();
-      element.lyricsColor = this.score.pageSetup.lyricsDefaultColor;
-      element.lyricsFontFamily = this.score.pageSetup.lyricsDefaultFontFamily;
-      element.lyricsFontSize = this.score.pageSetup.lyricsDefaultFontSize;
-      element.lyricsFontStyle = this.score.pageSetup.lyricsDefaultFontStyle;
-      element.lyricsFontWeight = this.score.pageSetup.lyricsDefaultFontWeight;
-      element.lyricsStrokeWidth = this.score.pageSetup.lyricsDefaultStrokeWidth;
-
-      element.quantitativeNeume = quantitativeNeume;
-      // Special case for neumes with secondary gorgon
-      if (getSecondaryNeume(quantitativeNeume) != null) {
-        element.secondaryGorgonNeume = secondaryGorgonNeume;
-      }
-
-      // If the selected element is an alternate line element,
-      // add the new element to the alternate line's elements
-      // and return immediately. Alternate lines do not support
-      // different entry modes.
-      if (this.selectedWorkspace.selectedAlternateLineElement != null) {
-        this.addScoreElement(
-          element,
-          this.selectedWorkspace.selectedAlternateLineElement.elements.length,
-          this.selectedWorkspace.selectedAlternateLineElement.elements,
-        );
-        this.save();
-        return;
-      }
-
-      switch (this.entryMode) {
-        case EntryMode.Auto:
-          if (!this.isLastElement(this.selectedElement) && !this.moveRight()) {
-            return;
-          }
-
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-            this.selectedElement = element;
-          } else {
-            if (this.selectedElement.elementType === ElementType.Note) {
-              if (
-                (this.selectedElement as NoteElement).quantitativeNeume !==
-                quantitativeNeume
-              ) {
-                this.updateNote(this.selectedElement as NoteElement, {
-                  quantitativeNeume,
-                  secondaryGorgonNeume,
-                });
-              } else if (
-                (this.selectedElement as NoteElement).secondaryGorgonNeume !==
-                secondaryGorgonNeume
-              ) {
-                // Special case for hyporoe gorgon
-                this.updateNote(this.selectedElement as NoteElement, {
-                  secondaryGorgonNeume,
-                });
-              }
-            } else {
-              this.selectedElement = this.switchToSyllable(
-                this.selectedElement,
-                element,
-              );
-            }
-          }
-          break;
-        case EntryMode.Insert:
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-          } else {
-            if (this.selectedElement.elementType === ElementType.Note) {
-              const selectedElementAsNote = this.selectedElement as NoteElement;
-
-              element.isMelisma = selectedElementAsNote.isMelisma;
-              element.isHyphen = selectedElementAsNote.isHyphen;
-            }
-
-            this.addScoreElement(element, this.selectedElementIndex + 1);
-          }
-          this.selectedElement = element;
-          break;
-
-        case EntryMode.Edit:
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-          } else if (this.selectedElement.elementType === ElementType.Note) {
-            if (
-              (this.selectedElement as NoteElement).quantitativeNeume !==
-              quantitativeNeume
-            ) {
-              this.updateNote(this.selectedElement as NoteElement, {
-                quantitativeNeume,
-                secondaryGorgonNeume,
-              });
-            } else if (
-              (this.selectedElement as NoteElement).secondaryGorgonNeume !==
-              secondaryGorgonNeume
-            ) {
-              // Special case for hyporoe gorgon
-              this.updateNote(this.selectedElement as NoteElement, {
-                secondaryGorgonNeume,
-              });
-            }
-          } else if (
-            navigableElements.includes(this.selectedElement.elementType)
-          ) {
-            this.selectedElement = this.switchToSyllable(
-              this.selectedElement,
-              element,
-            );
-          }
-          break;
-      }
-
-      this.save();
-    },
-
-    addNeumeCombination(combo: NeumeCombination) {
-      const backup = this.clipboard.slice();
-      this.clipboard = combo.elements;
-      this.onPasteScoreElements(false);
-
-      this.clipboard = backup;
-    },
-
-    addAutoMartyria(alignRight?: boolean, note?: Note) {
-      if (this.selectedElement == null) {
-        return;
-      }
-
-      const element = new MartyriaElement();
-      element.alignRight = alignRight === true;
-
-      if (note != null) {
-        element.note = note;
-        element.auto = false;
-      }
-
-      switch (this.entryMode) {
-        case EntryMode.Auto:
-          this.moveRight();
-
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-            this.selectedElement = element;
-          } else {
-            if (this.selectedElement.elementType != ElementType.Martyria) {
-              this.selectedElement = this.switchToMartyria(
-                this.selectedElement,
-              );
-            }
-          }
-          break;
-        case EntryMode.Insert:
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-          } else {
-            this.addScoreElement(element, this.selectedElementIndex + 1);
-          }
-          this.selectedElement = element;
-          break;
-        case EntryMode.Edit:
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-          } else if (this.selectedElement.elementType != ElementType.Martyria) {
-            this.selectedElement = this.switchToMartyria(this.selectedElement);
-          }
-          break;
-      }
-
-      this.save();
-    },
-
-    addTempo(neume: TempoSign) {
-      if (this.selectedElement == null) {
-        return;
-      }
-
-      const element = new TempoElement();
-      element.neume = neume;
-      element.bpm =
-        this.editorPreferences.getDefaultTempo(neume) ??
-        TempoElement.getDefaultBpm(neume);
-
-      switch (this.entryMode) {
-        case EntryMode.Auto:
-          this.moveRight();
-
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-            this.selectedElement = element;
-          } else {
-            if (this.selectedElement.elementType === ElementType.Tempo) {
-              if ((this.selectedElement as TempoElement).neume !== neume) {
-                this.updateTempo(this.selectedElement as TempoElement, {
-                  neume,
-                });
-              }
-            } else {
-              this.selectedElement = this.switchToTempo(
-                this.selectedElement,
-                element,
-              );
-            }
-          }
-          break;
-        case EntryMode.Insert:
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-          } else {
-            this.addScoreElement(element, this.selectedElementIndex + 1);
-          }
-          this.selectedElement = element;
-          break;
-        case EntryMode.Edit:
-          if (this.isLastElement(this.selectedElement)) {
-            this.addScoreElement(element, this.selectedElementIndex);
-          } else if (this.selectedElement.elementType === ElementType.Tempo) {
-            if ((this.selectedElement as TempoElement).neume !== neume) {
-              this.updateTempo(this.selectedElement as TempoElement, {
-                neume,
-              });
-            }
-          } else {
-            this.selectedElement = this.switchToTempo(
-              this.selectedElement,
-              element,
-            );
-          }
-          break;
-      }
-
-      this.save();
-    },
-
-    addDropCap(after: boolean) {
-      if (this.selectedElement == null) {
-        return;
-      }
-
-      const element = new DropCapElement();
-
-      element.color = this.score.pageSetup.dropCapDefaultColor;
-      element.fontFamily = this.score.pageSetup.dropCapDefaultFontFamily;
-      element.fontSize = this.score.pageSetup.dropCapDefaultFontSize;
-      element.strokeWidth = this.score.pageSetup.dropCapDefaultStrokeWidth;
-      element.fontWeight = this.score.pageSetup.dropCapDefaultFontWeight;
-      element.fontStyle = this.score.pageSetup.dropCapDefaultFontStyle;
-      element.lineHeight = this.score.pageSetup.dropCapDefaultLineHeight;
-      element.lineSpan = this.score.pageSetup.dropCapDefaultLineSpan;
-
-      if (after && !this.isLastElement(this.selectedElement)) {
-        this.addScoreElement(element, this.selectedElementIndex + 1);
-      } else {
-        this.addScoreElement(element, this.selectedElementIndex);
-      }
-
-      this.selectedElement = element;
-      this.save();
-
-      nextTick(() => {
-        const index = this.elements.indexOf(element);
-
-        (this.$refs[`element-${index}`] as any)[0].focus();
-      });
-    },
-
-    onClickAddImage() {
-      EventBus.$emit(IpcRendererChannels.OpenImageDialog);
-    },
-
-    togglePageBreak() {
-      if (this.selectedElement && !this.isLastElement(this.selectedElement)) {
-        this.commandService.execute(
-          scoreElementCommandFactory.create('update-properties', {
-            target: this.selectedElement,
-            newValues: {
-              pageBreak: !this.selectedElement.pageBreak,
-              lineBreak: false,
-            },
-          }),
-        );
-
-        this.save();
-      }
-    },
-
-    toggleLineBreak(lineBreakType: LineBreakType | null) {
-      if (this.selectedElement && !this.isLastElement(this.selectedElement)) {
-        let lineBreak = !this.selectedElement.lineBreak;
-
-        if (lineBreakType != this.selectedElement.lineBreakType) {
-          lineBreak = true;
-        }
-
-        if (!lineBreak) {
-          lineBreakType = null;
-        }
-
-        this.commandService.execute(
-          scoreElementCommandFactory.create('update-properties', {
-            target: this.selectedElement,
-            newValues: {
-              lineBreak,
-              pageBreak: false,
-              lineBreakType,
-            },
-          }),
-        );
-
-        this.save();
-      }
-    },
-
-    updateScoreElementSectionName(
-      element: ScoreElement,
-      sectionName: string | null,
-    ) {
-      if (sectionName != null && sectionName.trim() == '') {
-        sectionName = null;
-      }
-
-      this.commandService.execute(
-        scoreElementCommandFactory.create('update-properties', {
-          target: element,
-          newValues: {
-            sectionName,
-          },
-        }),
-      );
-
-      this.save();
-    },
-
-    switchToMartyria(element: ScoreElement) {
-      const index = this.elements.indexOf(element);
-
-      const newElement = new MartyriaElement();
-      newElement.pageBreak = element.pageBreak;
-      newElement.lineBreak = element.lineBreak;
-
-      this.replaceScoreElement(newElement, index);
-
-      return newElement;
-    },
-
-    switchToTempo(oldElement: ScoreElement, newElement: TempoElement) {
-      const index = this.elements.indexOf(oldElement);
-
-      newElement.pageBreak = oldElement.pageBreak;
-      newElement.lineBreak = oldElement.lineBreak;
-
-      this.replaceScoreElement(newElement, index);
-
-      return newElement;
-    },
-
-    switchToSyllable(oldElement: ScoreElement, newElement: NoteElement) {
-      const index = this.elements.indexOf(oldElement);
-
-      newElement.pageBreak = oldElement.pageBreak;
-      newElement.lineBreak = oldElement.lineBreak;
-
-      this.replaceScoreElement(newElement, index);
-
-      return newElement;
-    },
-
-    focusLyrics(index: number, selectAll: boolean = false) {
-      (
-        this.$refs[`lyrics-${index}`] as InstanceType<typeof ContentEditable>[]
-      )[0].focus(selectAll);
-    },
-
-    setLyrics(index: number, lyrics: string) {
-      const elements = this.$refs[`lyrics-${index}`] as InstanceType<
-        typeof ContentEditable
-      >[];
-
-      if (elements?.length > 0) {
-        elements[0].setInnerText(lyrics);
-      }
-    },
-
-    isSyllableElement(element: ScoreElement) {
-      return element.elementType == ElementType.Note;
-    },
-
-    isMartyriaElement(element: ScoreElement) {
-      return element.elementType == ElementType.Martyria;
-    },
-
-    isTempoElement(element: ScoreElement) {
-      return element.elementType == ElementType.Tempo;
-    },
-
-    isEmptyElement(element: ScoreElement) {
-      return element.elementType == ElementType.Empty;
-    },
-
-    isTextBoxElement(element: ScoreElement) {
-      return element.elementType == ElementType.TextBox;
-    },
-
-    isRichTextBoxElement(element: ScoreElement) {
-      return element.elementType == ElementType.RichTextBox;
-    },
-
-    isDropCapElement(element: ScoreElement) {
-      return element.elementType == ElementType.DropCap;
-    },
-
-    isModeKeyElement(element: ScoreElement) {
-      return element.elementType == ElementType.ModeKey;
-    },
-
-    isImageBoxElement(element: ScoreElement) {
-      return element.elementType == ElementType.ImageBox;
-    },
-
-    isTextInputFocused() {
-      return (
-        document.activeElement instanceof HTMLInputElement ||
-        document.activeElement instanceof HTMLTextAreaElement ||
-        (document.activeElement instanceof HTMLElement &&
-          document.activeElement.isContentEditable)
-      );
-    },
-
-    onWindowResize() {
-      if (this.zoomToFit) {
-        this.performZoomToFit();
-      }
-    },
-
-    onScroll() {
-      this.calculatePageNumber();
-    },
-
-    onKeydown(event: KeyboardEvent) {
-      // Handle undo / redo
-      // See https://github.com/electron/electron/issues/3682.
-      if (
-        (event.ctrlKey || event.metaKey) &&
-        !this.isTextInputFocused() &&
-        !this.dialogOpen
-      ) {
-        if (event.code === 'KeyZ') {
-          if (this.platformService.isMac && event.shiftKey) {
-            this.throttled.onFileMenuRedo();
-          } else {
-            this.throttled.onFileMenuUndo();
-          }
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyY') {
-          this.throttled.onFileMenuRedo();
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyX') {
-          this.throttled.onCutScoreElements();
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyC') {
-          if (event.shiftKey) {
-            this.throttled.onFileMenuCopyAsHtml();
-          } else {
-            this.throttled.onCopyScoreElements();
-          }
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyV') {
-          const includeLyrics = event.shiftKey;
-          this.throttled.onPasteScoreElements(includeLyrics);
-          event.preventDefault();
-          return;
-        } else if (event.code === 'KeyI' && !event.shiftKey) {
-          switch (this.entryMode) {
-            case EntryMode.Auto:
-              this.updateEntryMode(EntryMode.Insert);
-              break;
-            case EntryMode.Insert:
-              this.updateEntryMode(EntryMode.Edit);
-              break;
-            case EntryMode.Edit:
-              this.updateEntryMode(EntryMode.Auto);
-              break;
-          }
-          return;
-        } else if (event.code === 'KeyU' && !event.shiftKey) {
-          switch (this.entryMode) {
-            case EntryMode.Auto:
-              this.updateEntryMode(EntryMode.Edit);
-              break;
-            case EntryMode.Edit:
-              this.updateEntryMode(EntryMode.Insert);
-              break;
-            case EntryMode.Insert:
-              this.updateEntryMode(EntryMode.Auto);
-              break;
-          }
-          return;
-        }
-      }
-
-      if (
-        this.platformService.isMac &&
-        this.isTextInputFocused() &&
-        !this.dialogOpen
-      ) {
-        this.onKeydownMac(event);
-      }
-
-      if (this.selectedLyrics != null) {
-        return this.onKeydownLyrics(event);
-      }
-
-      if (this.selectedElement?.elementType === ElementType.DropCap) {
-        return this.onKeydownDropCap(event);
-      }
-
-      if (this.selectedElement?.elementType === ElementType.TextBox) {
-        return this.onKeydownTextBox(event);
-      }
-
-      if (!this.isTextInputFocused() && !this.dialogOpen) {
-        return this.onKeydownNeume(event);
-      }
-    },
-
-    onKeydownNeume(event: KeyboardEvent) {
-      let handled = false;
-
-      if (event.shiftKey) {
-        switch (event.code) {
-          case 'ArrowLeft':
-            this.throttled.moveSelectionLeft();
-            handled = true;
-            break;
-          case 'ArrowRight':
-            this.throttled.moveSelectionRight();
-            handled = true;
-            break;
-        }
-      } else {
-        switch (event.code) {
-          case 'ArrowLeft':
-            if (!this.rtl) {
-              this.throttled.moveLeft();
-            } else {
-              this.throttled.moveRight();
-            }
-            handled = true;
-            break;
-          case 'ArrowRight':
-            if (!this.rtl) {
-              this.throttled.moveRight();
-            } else {
-              this.throttled.moveLeft();
-            }
-            handled = true;
-            break;
-          case 'ArrowDown':
-            if (
-              (event.ctrlKey || event.metaKey) &&
-              this.selectedElement?.elementType === ElementType.Note
-            ) {
-              const index = this.selectedElementIndex;
-
-              this.focusLyrics(index, true);
-
-              // Select All doesn't work until after the lyrics have been selected,
-              // hence we call focus lyrics twice
-              nextTick(() => {
-                this.focusLyrics(index, true);
-              });
-
-              handled = true;
-            }
-            break;
-          case 'Space':
-            if (!event.repeat) {
-              if (
-                this.audioService.state === AudioState.Stopped ||
-                event.ctrlKey
-              ) {
-                this.playAudio();
-              } else {
-                this.pauseAudio();
-              }
-              handled = true;
-            }
-            break;
-          case 'Backspace':
-            handled = true;
-            this.throttled.deletePreviousElement();
-            break;
-          case 'Delete':
-            handled = true;
-            this.throttled.deleteSelectedElement();
-            break;
-        }
-      }
-
-      if (
-        this.selectedElement != null &&
-        !event.ctrlKey &&
-        !event.metaKey &&
-        !event.altKey
-      ) {
-        if (this.neumeKeyboard.isModifier(event.code)) {
-          this.keyboardModifier = event.code;
-          handled = true;
-        }
-
-        const quantitativeMapping = this.neumeKeyboard.findQuantitativeMapping(
-          event,
-          this.keyboardModifier,
-        );
-
-        if (quantitativeMapping != null) {
-          handled = true;
-
-          if (quantitativeMapping.acceptsLyricsOption != null) {
-            if (this.selectedElement.elementType === ElementType.Note) {
-              this.throttled.updateNoteAndSave(
-                this.selectedElement as NoteElement,
-                {
-                  acceptsLyrics: quantitativeMapping.acceptsLyricsOption,
-                },
-              );
-            }
-          } else {
-            this.throttled.addQuantitativeNeume(
-              quantitativeMapping.neume as QuantitativeNeume,
-            );
-          }
-        }
-
-        const tempoMapping = this.neumeKeyboard.findTempoMapping(
-          event,
-          this.keyboardModifier,
-        );
-
-        if (tempoMapping != null) {
-          handled = true;
-          this.throttled.addTempo(tempoMapping.neume as TempoSign);
-        }
-
-        if (
-          this.keyboardModifier == null &&
-          this.neumeKeyboard.isMartyria(event.code)
-        ) {
-          handled = true;
-          this.throttled.addAutoMartyria(event.shiftKey);
-        }
-
-        const martyriaConfigMapping =
-          this.neumeKeyboard.findMartyriaConfigMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-        if (martyriaConfigMapping != null) {
-          if (martyriaConfigMapping.note != null) {
-            handled = true;
-
-            this.throttled.addAutoMartyria(
-              martyriaConfigMapping.martyriaAlignmentToggle,
-              martyriaConfigMapping.note,
-            );
-          }
-        }
-
-        if (
-          this.selectedElement.elementType === ElementType.Note &&
-          !event.repeat
-        ) {
-          const noteElement = this.selectedElement as NoteElement;
-
-          const gorgonMapping = this.neumeKeyboard.findGorgonMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (gorgonMapping != null) {
-            handled = true;
-            this.throttled.setGorgon(
-              noteElement,
-              gorgonMapping.neumes as GorgonNeume[],
-            );
-          }
-
-          const vocalExpressionMapping =
-            this.neumeKeyboard.findVocalExpressionMapping(
-              event,
-              this.keyboardModifier,
-            );
-
-          if (vocalExpressionMapping != null) {
-            handled = true;
-
-            if (vocalExpressionMapping.neume === VocalExpressionNeume.Vareia) {
-              this.throttled.updateNoteAndSave(noteElement, {
-                vareia: !noteElement.vareia,
-              });
-            } else {
-              this.throttled.setVocalExpression(
-                noteElement,
-                vocalExpressionMapping.neume as VocalExpressionNeume,
-              );
-            }
-          }
-
-          const tieMapping = this.neumeKeyboard.findTieMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (tieMapping != null) {
-            handled = true;
-
-            this.throttled.setTie(noteElement, tieMapping.neumes as Tie[]);
-          }
-
-          const fthoraMapping = this.neumeKeyboard.findFthoraMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (fthoraMapping != null) {
-            handled = true;
-            this.throttled.setFthoraNote(
-              noteElement,
-              fthoraMapping.neumes as Fthora[],
-            );
-          }
-
-          const accidentalMapping = this.neumeKeyboard.findAccidentalMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (accidentalMapping != null) {
-            handled = true;
-            this.throttled.setAccidental(
-              noteElement,
-              accidentalMapping.neume as Accidental,
-            );
-          }
-
-          const hapliMapping = this.neumeKeyboard.findHapliMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (hapliMapping != null) {
-            handled = true;
-
-            if (hapliMapping.neume === TimeNeume.Koronis) {
-              this.throttled.updateNoteAndSave(noteElement, {
-                koronis: !noteElement.koronis,
-              });
-            } else {
-              this.throttled.setTimeNeume(
-                noteElement,
-                hapliMapping.neume as TimeNeume,
-              );
-            }
-          }
-
-          const measureNumberMapping =
-            this.neumeKeyboard.findMeasureNumberMapping(
-              event,
-              this.keyboardModifier,
-            );
-
-          if (measureNumberMapping != null) {
-            handled = true;
-            this.throttled.setMeasureNumber(
-              noteElement,
-              measureNumberMapping.neume as MeasureNumber,
-            );
-          }
-
-          const measureBarMapping = this.neumeKeyboard.findMeasureBarMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (measureBarMapping != null) {
-            handled = true;
-            this.throttled.setMeasureBarNote(
-              noteElement,
-              measureBarMapping.neume as MeasureBar,
-            );
-          }
-
-          const isonMapping = this.neumeKeyboard.findIsonMapping(
-            event,
-            this.keyboardModifier,
-          );
-
-          if (isonMapping != null) {
-            handled = true;
-            this.throttled.setIson(noteElement, isonMapping.neume as Ison);
-          }
-
+        if (selectedElement.value.elementType === ElementType.Note) {
           if (
-            this.keyboardModifier == null &&
-            this.neumeKeyboard.isMartyria(event.code)
+            (selectedElement.value as NoteElement).quantitativeNeume !==
+            quantitativeNeume
           ) {
-            this.throttled.addAutoMartyria();
+            updateNote(selectedElement.value as NoteElement, {
+              quantitativeNeume,
+              secondaryGorgonNeume,
+            });
           } else if (
-            this.keyboardModifier == null &&
-            this.neumeKeyboard.isKlasma(event.code)
+            (selectedElement.value as NoteElement).secondaryGorgonNeume !==
+            secondaryGorgonNeume
           ) {
-            this.throttled.setKlasma(noteElement);
-          } else if (
-            this.keyboardModifier == null &&
-            this.neumeKeyboard.isNoteIndicator(event.code)
-          ) {
-            this.throttled.updateNoteAndSave(noteElement, {
-              noteIndicator: !noteElement.noteIndicator,
+            // Special case for hyporoe gorgon
+            updateNote(selectedElement.value as NoteElement, {
+              secondaryGorgonNeume,
             });
           }
-        } else if (
-          this.selectedElement.elementType === ElementType.Martyria &&
-          !event.repeat
+        } else {
+          selectedElement.value = switchToSyllable(
+            selectedElement.value,
+            element,
+          );
+        }
+      }
+      break;
+    case EntryMode.Insert:
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+      } else {
+        if (selectedElement.value.elementType === ElementType.Note) {
+          const selectedElementAsNote = selectedElement.value as NoteElement;
+
+          element.isMelisma = selectedElementAsNote.isMelisma;
+          element.isHyphen = selectedElementAsNote.isHyphen;
+        }
+
+        addScoreElement(element, selectedElementIndex.value + 1);
+      }
+      selectedElement.value = element;
+      break;
+
+    case EntryMode.Edit:
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+      } else if (selectedElement.value.elementType === ElementType.Note) {
+        if (
+          (selectedElement.value as NoteElement).quantitativeNeume !==
+          quantitativeNeume
         ) {
-          const martyriaElement = this.selectedElement as MartyriaElement;
+          updateNote(selectedElement.value as NoteElement, {
+            quantitativeNeume,
+            secondaryGorgonNeume,
+          });
+        } else if (
+          (selectedElement.value as NoteElement).secondaryGorgonNeume !==
+          secondaryGorgonNeume
+        ) {
+          // Special case for hyporoe gorgon
+          updateNote(selectedElement.value as NoteElement, {
+            secondaryGorgonNeume,
+          });
+        }
+      } else if (
+        navigableElements.includes(selectedElement.value.elementType)
+      ) {
+        selectedElement.value = switchToSyllable(
+          selectedElement.value,
+          element,
+        );
+      }
+      break;
+  }
 
-          const fthoraMapping = this.neumeKeyboard.findFthoraMapping(
-            event,
-            this.keyboardModifier,
-          );
+  save();
+}
 
-          if (fthoraMapping != null) {
-            handled = true;
-            this.throttled.setFthoraMartyria(
-              martyriaElement,
-              fthoraMapping.neumes![0] as Fthora,
-            );
-          }
+function addNeumeCombination(combo: NeumeCombination) {
+  const backup = clipboard.value.slice();
+  clipboard.value = combo.elements;
+  onPasteScoreElements(false);
 
-          const tempoMapping = this.neumeKeyboard.findMartyriaTempoMapping(
-            event,
-            this.keyboardModifier,
-          );
+  clipboard.value = backup;
+}
 
-          if (tempoMapping != null) {
-            handled = true;
-            this.throttled.setMartyriaTempo(
-              martyriaElement,
-              tempoMapping.neume as TempoSign,
-            );
-          }
+function addAutoMartyria(alignRight?: boolean, note?: Note) {
+  if (selectedElement.value == null) {
+    return;
+  }
 
-          const measureBarMapping = this.neumeKeyboard.findMeasureBarMapping(
-            event,
-            this.keyboardModifier,
-          );
+  const element = new MartyriaElement();
+  element.alignRight = alignRight === true;
 
-          if (measureBarMapping != null) {
-            handled = true;
-            this.throttled.setMeasureBarMartyria(
-              martyriaElement,
-              measureBarMapping.neume as MeasureBar,
-            );
-          }
+  if (note != null) {
+    element.note = note;
+    element.auto = false;
+  }
 
-          const martyriaConfigMapping =
-            this.neumeKeyboard.findMartyriaConfigMapping(
-              event,
-              this.keyboardModifier,
-            );
+  switch (entryMode.value) {
+    case EntryMode.Auto:
+      moveRight();
 
-          if (martyriaConfigMapping != null) {
-            handled = true;
-
-            if (martyriaConfigMapping.note != null) {
-              // This case will not currently happen
-              // because no keyboard mapping exist for it
-              this.throttled.updateMartyria(martyriaElement, {
-                note: martyriaConfigMapping.note,
-              });
-            } else if (martyriaConfigMapping.scale != null) {
-              this.throttled.updateMartyria(martyriaElement, {
-                scale: martyriaConfigMapping.scale,
-              });
-            } else if (martyriaConfigMapping.martyriaAlignmentToggle === true) {
-              this.throttled.updateMartyria(martyriaElement, {
-                alignRight: !martyriaElement.alignRight,
-              });
-            } else if (martyriaConfigMapping.martyriaAutoToggle === true) {
-              this.throttled.updateMartyria(martyriaElement, {
-                auto: !martyriaElement.auto,
-              });
-            }
-          }
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+        selectedElement.value = element;
+      } else {
+        if (selectedElement.value.elementType != ElementType.Martyria) {
+          selectedElement.value = switchToMartyria(selectedElement.value);
         }
       }
-      if (handled) {
-        event.preventDefault();
+      break;
+    case EntryMode.Insert:
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+      } else {
+        addScoreElement(element, selectedElementIndex.value + 1);
       }
-    },
+      selectedElement.value = element;
+      break;
+    case EntryMode.Edit:
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+      } else if (selectedElement.value.elementType != ElementType.Martyria) {
+        selectedElement.value = switchToMartyria(selectedElement.value);
+      }
+      break;
+  }
 
-    onKeydownLyrics(event: KeyboardEvent) {
-      let handled = false;
+  save();
+}
 
-      // Do not allow enter key in lyrics
-      if (event.code === 'Enter') {
-        event.preventDefault();
+function addTempo(neume: TempoSign) {
+  if (selectedElement.value == null) {
+    return;
+  }
+
+  const element = new TempoElement();
+  element.neume = neume;
+  element.bpm =
+    editorPreferences.value.getDefaultTempo(neume) ??
+    TempoElement.getDefaultBpm(neume);
+
+  switch (entryMode.value) {
+    case EntryMode.Auto:
+      moveRight();
+
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+        selectedElement.value = element;
+      } else {
+        if (selectedElement.value.elementType === ElementType.Tempo) {
+          if ((selectedElement.value as TempoElement).neume !== neume) {
+            updateTempo(selectedElement.value as TempoElement, {
+              neume,
+            });
+          }
+        } else {
+          selectedElement.value = switchToTempo(selectedElement.value, element);
+        }
+      }
+      break;
+    case EntryMode.Insert:
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+      } else {
+        addScoreElement(element, selectedElementIndex.value + 1);
+      }
+      selectedElement.value = element;
+      break;
+    case EntryMode.Edit:
+      if (isLastElement(selectedElement.value)) {
+        addScoreElement(element, selectedElementIndex.value);
+      } else if (selectedElement.value.elementType === ElementType.Tempo) {
+        if ((selectedElement.value as TempoElement).neume !== neume) {
+          updateTempo(selectedElement.value as TempoElement, {
+            neume,
+          });
+        }
+      } else {
+        selectedElement.value = switchToTempo(selectedElement.value, element);
+      }
+      break;
+  }
+
+  save();
+}
+
+function addDropCap(after: boolean) {
+  if (selectedElement.value == null) {
+    return;
+  }
+
+  const element = new DropCapElement();
+
+  element.color = score.value.pageSetup.dropCapDefaultColor;
+  element.fontFamily = score.value.pageSetup.dropCapDefaultFontFamily;
+  element.fontSize = score.value.pageSetup.dropCapDefaultFontSize;
+  element.strokeWidth = score.value.pageSetup.dropCapDefaultStrokeWidth;
+  element.fontWeight = score.value.pageSetup.dropCapDefaultFontWeight;
+  element.fontStyle = score.value.pageSetup.dropCapDefaultFontStyle;
+  element.lineHeight = score.value.pageSetup.dropCapDefaultLineHeight;
+  element.lineSpan = score.value.pageSetup.dropCapDefaultLineSpan;
+
+  if (after && !isLastElement(selectedElement.value)) {
+    addScoreElement(element, selectedElementIndex.value + 1);
+  } else {
+    addScoreElement(element, selectedElementIndex.value);
+  }
+
+  selectedElement.value = element;
+  save();
+
+  nextTick(() => {
+    const index = elements.value.indexOf(element);
+
+    getTemplateRef<any[]>(`element-${index}`)[0].focus();
+  });
+}
+
+function onClickAddImage() {
+  EventBus.$emit(IpcRendererChannels.OpenImageDialog);
+}
+
+function togglePageBreak() {
+  if (selectedElement.value && !isLastElement(selectedElement.value)) {
+    commandService.value.execute(
+      scoreElementCommandFactory.create('update-properties', {
+        target: selectedElement.value,
+        newValues: {
+          pageBreak: !selectedElement.value.pageBreak,
+          lineBreak: false,
+        },
+      }),
+    );
+
+    save();
+  }
+}
+
+function toggleLineBreak(lineBreakType: LineBreakType | null) {
+  if (selectedElement.value && !isLastElement(selectedElement.value)) {
+    let lineBreak = !selectedElement.value.lineBreak;
+
+    if (lineBreakType != selectedElement.value.lineBreakType) {
+      lineBreak = true;
+    }
+
+    if (!lineBreak) {
+      lineBreakType = null;
+    }
+
+    commandService.value.execute(
+      scoreElementCommandFactory.create('update-properties', {
+        target: selectedElement.value,
+        newValues: {
+          lineBreak,
+          pageBreak: false,
+          lineBreakType,
+        },
+      }),
+    );
+
+    save();
+  }
+}
+
+function updateScoreElementSectionName(
+  element: ScoreElement,
+  sectionName: string | null,
+) {
+  if (sectionName != null && sectionName.trim() == '') {
+    sectionName = null;
+  }
+
+  commandService.value.execute(
+    scoreElementCommandFactory.create('update-properties', {
+      target: element,
+      newValues: {
+        sectionName,
+      },
+    }),
+  );
+
+  save();
+}
+
+function switchToMartyria(element: ScoreElement) {
+  const index = elements.value.indexOf(element);
+
+  const newElement = new MartyriaElement();
+  newElement.pageBreak = element.pageBreak;
+  newElement.lineBreak = element.lineBreak;
+
+  replaceScoreElement(newElement, index);
+
+  return newElement;
+}
+
+function switchToTempo(oldElement: ScoreElement, newElement: TempoElement) {
+  const index = elements.value.indexOf(oldElement);
+
+  newElement.pageBreak = oldElement.pageBreak;
+  newElement.lineBreak = oldElement.lineBreak;
+
+  replaceScoreElement(newElement, index);
+
+  return newElement;
+}
+
+function switchToSyllable(oldElement: ScoreElement, newElement: NoteElement) {
+  const index = elements.value.indexOf(oldElement);
+
+  newElement.pageBreak = oldElement.pageBreak;
+  newElement.lineBreak = oldElement.lineBreak;
+
+  replaceScoreElement(newElement, index);
+
+  return newElement;
+}
+
+function focusLyrics(index: number, selectAll: boolean = false) {
+  getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+    `lyrics-${index}`,
+  )[0].focus(selectAll);
+}
+
+function setLyrics(index: number, lyrics: string) {
+  const elements = getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+    `lyrics-${index}`,
+  );
+
+  if (elements?.length > 0) {
+    elements[0].setInnerText(lyrics);
+  }
+}
+
+function isSyllableElement(element: ScoreElement) {
+  return element.elementType == ElementType.Note;
+}
+
+function isMartyriaElement(element: ScoreElement) {
+  return element.elementType == ElementType.Martyria;
+}
+
+function isTempoElement(element: ScoreElement) {
+  return element.elementType == ElementType.Tempo;
+}
+
+function isEmptyElement(element: ScoreElement) {
+  return element.elementType == ElementType.Empty;
+}
+
+function isTextBoxElement(element: ScoreElement) {
+  return element.elementType == ElementType.TextBox;
+}
+
+function isRichTextBoxElement(element: ScoreElement) {
+  return element.elementType == ElementType.RichTextBox;
+}
+
+function isDropCapElement(element: ScoreElement) {
+  return element.elementType == ElementType.DropCap;
+}
+
+function isModeKeyElement(element: ScoreElement) {
+  return element.elementType == ElementType.ModeKey;
+}
+
+function isImageBoxElement(element: ScoreElement) {
+  return element.elementType == ElementType.ImageBox;
+}
+
+function isTextInputFocused() {
+  return (
+    document.activeElement instanceof HTMLInputElement ||
+    document.activeElement instanceof HTMLTextAreaElement ||
+    (document.activeElement instanceof HTMLElement &&
+      document.activeElement.isContentEditable)
+  );
+}
+
+function onWindowResize() {
+  if (zoomToFit.value) {
+    performZoomToFit();
+  }
+}
+
+function onScroll() {
+  calculatePageNumber();
+}
+
+function onKeydown(event: KeyboardEvent) {
+  // Handle undo / redo
+  // See https://github.com/electron/electron/issues/3682.
+  if (
+    (event.ctrlKey || event.metaKey) &&
+    !isTextInputFocused() &&
+    !dialogOpen.value
+  ) {
+    if (event.code === 'KeyZ') {
+      if (platformService.isMac && event.shiftKey) {
+        throttled.onFileMenuRedo();
+      } else {
+        throttled.onFileMenuUndo();
+      }
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyY') {
+      throttled.onFileMenuRedo();
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyX') {
+      throttled.onCutScoreElements();
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyC') {
+      if (event.shiftKey) {
+        throttled.onFileMenuCopyAsHtml();
+      } else {
+        throttled.onCopyScoreElements();
+      }
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyV') {
+      const includeLyrics = event.shiftKey;
+      throttled.onPasteScoreElements(includeLyrics);
+      event.preventDefault();
+      return;
+    } else if (event.code === 'KeyI' && !event.shiftKey) {
+      switch (entryMode.value) {
+        case EntryMode.Auto:
+          updateEntryMode(EntryMode.Insert);
+          break;
+        case EntryMode.Insert:
+          updateEntryMode(EntryMode.Edit);
+          break;
+        case EntryMode.Edit:
+          updateEntryMode(EntryMode.Auto);
+          break;
+      }
+      return;
+    } else if (event.code === 'KeyU' && !event.shiftKey) {
+      switch (entryMode.value) {
+        case EntryMode.Auto:
+          updateEntryMode(EntryMode.Edit);
+          break;
+        case EntryMode.Edit:
+          updateEntryMode(EntryMode.Insert);
+          break;
+        case EntryMode.Insert:
+          updateEntryMode(EntryMode.Auto);
+          break;
+      }
+      return;
+    }
+  }
+
+  if (platformService.isMac && isTextInputFocused() && !dialogOpen.value) {
+    onKeydownMac(event);
+  }
+
+  if (selectedLyrics.value != null) {
+    return onKeydownLyrics(event);
+  }
+
+  if (selectedElement.value?.elementType === ElementType.DropCap) {
+    return onKeydownDropCap(event);
+  }
+
+  if (selectedElement.value?.elementType === ElementType.TextBox) {
+    return onKeydownTextBox(event);
+  }
+
+  if (!isTextInputFocused() && !dialogOpen.value) {
+    return onKeydownNeume(event);
+  }
+}
+
+function onKeydownNeume(event: KeyboardEvent) {
+  let handled = false;
+
+  if (event.shiftKey) {
+    switch (event.code) {
+      case 'ArrowLeft':
+        throttled.moveSelectionLeft();
+        handled = true;
+        break;
+      case 'ArrowRight':
+        throttled.moveSelectionRight();
+        handled = true;
+        break;
+    }
+  } else {
+    switch (event.code) {
+      case 'ArrowLeft':
+        if (!rtl.value) {
+          throttled.moveLeft();
+        } else {
+          throttled.moveRight();
+        }
+        handled = true;
+        break;
+      case 'ArrowRight':
+        if (!rtl.value) {
+          throttled.moveRight();
+        } else {
+          throttled.moveLeft();
+        }
+        handled = true;
+        break;
+      case 'ArrowDown':
+        if (
+          (event.ctrlKey || event.metaKey) &&
+          selectedElement.value?.elementType === ElementType.Note
+        ) {
+          const index = selectedElementIndex.value;
+
+          focusLyrics(index, true);
+
+          // Select All doesn't work until after the lyrics have been selected,
+          // hence we call focus lyrics twice
+          nextTick(() => {
+            focusLyrics(index, true);
+          });
+
+          handled = true;
+        }
+        break;
+      case 'Space':
+        if (!event.repeat) {
+          if (audioService.state === AudioState.Stopped || event.ctrlKey) {
+            playAudio();
+          } else {
+            pauseAudio();
+          }
+          handled = true;
+        }
+        break;
+      case 'Backspace':
+        handled = true;
+        throttled.deletePreviousElement();
+        break;
+      case 'Delete':
+        handled = true;
+        throttled.deleteSelectedElement();
+        break;
+    }
+  }
+
+  if (
+    selectedElement.value != null &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey
+  ) {
+    if (neumeKeyboard.isModifier(event.code)) {
+      keyboardModifier.value = event.code;
+      handled = true;
+    }
+
+    const quantitativeMapping = neumeKeyboard.findQuantitativeMapping(
+      event,
+      keyboardModifier.value,
+    );
+
+    if (quantitativeMapping != null) {
+      handled = true;
+
+      if (quantitativeMapping.acceptsLyricsOption != null) {
+        if (selectedElement.value.elementType === ElementType.Note) {
+          throttled.updateNoteAndSave(selectedElement.value as NoteElement, {
+            acceptsLyrics: quantitativeMapping.acceptsLyricsOption,
+          });
+        }
+      } else {
+        throttled.addQuantitativeNeume(
+          quantitativeMapping.neume as QuantitativeNeume,
+        );
+      }
+    }
+
+    const tempoMapping = neumeKeyboard.findTempoMapping(
+      event,
+      keyboardModifier.value,
+    );
+
+    if (tempoMapping != null) {
+      handled = true;
+      throttled.addTempo(tempoMapping.neume as TempoSign);
+    }
+
+    if (
+      keyboardModifier.value == null &&
+      neumeKeyboard.isMartyria(event.code)
+    ) {
+      handled = true;
+      throttled.addAutoMartyria(event.shiftKey);
+    }
+
+    const martyriaConfigMapping = neumeKeyboard.findMartyriaConfigMapping(
+      event,
+      keyboardModifier.value,
+    );
+
+    if (martyriaConfigMapping != null) {
+      if (martyriaConfigMapping.note != null) {
+        handled = true;
+
+        throttled.addAutoMartyria(
+          martyriaConfigMapping.martyriaAlignmentToggle,
+          martyriaConfigMapping.note,
+        );
+      }
+    }
+
+    if (
+      selectedElement.value.elementType === ElementType.Note &&
+      !event.repeat
+    ) {
+      const noteElement = selectedElement.value as NoteElement;
+
+      const gorgonMapping = neumeKeyboard.findGorgonMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (gorgonMapping != null) {
+        handled = true;
+        throttled.setGorgon(noteElement, gorgonMapping.neumes as GorgonNeume[]);
+      }
+
+      const vocalExpressionMapping = neumeKeyboard.findVocalExpressionMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (vocalExpressionMapping != null) {
+        handled = true;
+
+        if (vocalExpressionMapping.neume === VocalExpressionNeume.Vareia) {
+          throttled.updateNoteAndSave(noteElement, {
+            vareia: !noteElement.vareia,
+          });
+        } else {
+          throttled.setVocalExpression(
+            noteElement,
+            vocalExpressionMapping.neume as VocalExpressionNeume,
+          );
+        }
+      }
+
+      const tieMapping = neumeKeyboard.findTieMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (tieMapping != null) {
+        handled = true;
+
+        throttled.setTie(noteElement, tieMapping.neumes as Tie[]);
+      }
+
+      const fthoraMapping = neumeKeyboard.findFthoraMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (fthoraMapping != null) {
+        handled = true;
+        throttled.setFthoraNote(noteElement, fthoraMapping.neumes as Fthora[]);
+      }
+
+      const accidentalMapping = neumeKeyboard.findAccidentalMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (accidentalMapping != null) {
+        handled = true;
+        throttled.setAccidental(
+          noteElement,
+          accidentalMapping.neume as Accidental,
+        );
+      }
+
+      const hapliMapping = neumeKeyboard.findHapliMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (hapliMapping != null) {
+        handled = true;
+
+        if (hapliMapping.neume === TimeNeume.Koronis) {
+          throttled.updateNoteAndSave(noteElement, {
+            koronis: !noteElement.koronis,
+          });
+        } else {
+          throttled.setTimeNeume(noteElement, hapliMapping.neume as TimeNeume);
+        }
+      }
+
+      const measureNumberMapping = neumeKeyboard.findMeasureNumberMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (measureNumberMapping != null) {
+        handled = true;
+        throttled.setMeasureNumber(
+          noteElement,
+          measureNumberMapping.neume as MeasureNumber,
+        );
+      }
+
+      const measureBarMapping = neumeKeyboard.findMeasureBarMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (measureBarMapping != null) {
+        handled = true;
+        throttled.setMeasureBarNote(
+          noteElement,
+          measureBarMapping.neume as MeasureBar,
+        );
+      }
+
+      const isonMapping = neumeKeyboard.findIsonMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (isonMapping != null) {
+        handled = true;
+        throttled.setIson(noteElement, isonMapping.neume as Ison);
+      }
+
+      if (
+        keyboardModifier.value == null &&
+        neumeKeyboard.isMartyria(event.code)
+      ) {
+        throttled.addAutoMartyria();
+      } else if (
+        keyboardModifier.value == null &&
+        neumeKeyboard.isKlasma(event.code)
+      ) {
+        throttled.setKlasma(noteElement);
+      } else if (
+        keyboardModifier.value == null &&
+        neumeKeyboard.isNoteIndicator(event.code)
+      ) {
+        throttled.updateNoteAndSave(noteElement, {
+          noteIndicator: !noteElement.noteIndicator,
+        });
+      }
+    } else if (
+      selectedElement.value.elementType === ElementType.Martyria &&
+      !event.repeat
+    ) {
+      const martyriaElement = selectedElement.value as MartyriaElement;
+
+      const fthoraMapping = neumeKeyboard.findFthoraMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (fthoraMapping != null) {
+        handled = true;
+        throttled.setFthoraMartyria(
+          martyriaElement,
+          fthoraMapping.neumes![0] as Fthora,
+        );
+      }
+
+      const tempoMapping = neumeKeyboard.findMartyriaTempoMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (tempoMapping != null) {
+        handled = true;
+        throttled.setMartyriaTempo(
+          martyriaElement,
+          tempoMapping.neume as TempoSign,
+        );
+      }
+
+      const measureBarMapping = neumeKeyboard.findMeasureBarMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (measureBarMapping != null) {
+        handled = true;
+        throttled.setMeasureBarMartyria(
+          martyriaElement,
+          measureBarMapping.neume as MeasureBar,
+        );
+      }
+
+      const martyriaConfigMapping = neumeKeyboard.findMartyriaConfigMapping(
+        event,
+        keyboardModifier.value,
+      );
+
+      if (martyriaConfigMapping != null) {
+        handled = true;
+
+        if (martyriaConfigMapping.note != null) {
+          // This case will not currently happen
+          // because no keyboard mapping exist for it
+          throttled.updateMartyria(martyriaElement, {
+            note: martyriaConfigMapping.note,
+          });
+        } else if (martyriaConfigMapping.scale != null) {
+          throttled.updateMartyria(martyriaElement, {
+            scale: martyriaConfigMapping.scale,
+          });
+        } else if (martyriaConfigMapping.martyriaAlignmentToggle === true) {
+          throttled.updateMartyria(martyriaElement, {
+            alignRight: !martyriaElement.alignRight,
+          });
+        } else if (martyriaConfigMapping.martyriaAutoToggle === true) {
+          throttled.updateMartyria(martyriaElement, {
+            auto: !martyriaElement.auto,
+          });
+        }
+      }
+    }
+  }
+  if (handled) {
+    event.preventDefault();
+  }
+}
+
+function onKeydownLyrics(event: KeyboardEvent) {
+  let handled = false;
+
+  // Do not allow enter key in lyrics
+  if (event.code === 'Enter') {
+    event.preventDefault();
+    return;
+  }
+
+  switch (event.code) {
+    case 'ArrowRight':
+      if (event.shiftKey) {
         return;
       }
 
-      switch (event.code) {
-        case 'ArrowRight':
-          if (event.shiftKey) {
-            return;
-          }
-
-          if (event.ctrlKey || event.metaKey) {
-            if (!this.rtl) {
-              this.throttled.moveToNextLyricBox();
-            } else {
-              this.throttled.moveToPreviousLyricBox();
-            }
-            handled = true;
-          } else if (
-            !this.rtl &&
-            getCursorPosition() === this.getLyricLength(this.selectedLyrics!)
-          ) {
-            this.throttled.moveToNextLyricBox();
-            handled = true;
-          } else if (this.rtl && getCursorPosition() === 0) {
-            this.throttled.moveToPreviousLyricBox();
-            handled = true;
-          }
-          break;
-        case 'ArrowLeft':
-          if (event.shiftKey) {
-            return;
-          }
-
-          if (event.ctrlKey || event.metaKey) {
-            if (!this.rtl) {
-              this.throttled.moveToPreviousLyricBox();
-            } else {
-              this.throttled.moveToNextLyricBox();
-            }
-            handled = true;
-          } else if (!this.rtl && getCursorPosition() === 0) {
-            this.throttled.moveToPreviousLyricBox();
-            handled = true;
-          } else if (
-            this.rtl &&
-            getCursorPosition() === this.getLyricLength(this.selectedLyrics!)
-          ) {
-            this.throttled.moveToNextLyricBox();
-            handled = true;
-          }
-          break;
-        case 'ArrowUp':
-          if (event.shiftKey) {
-            return;
-          }
-
-          if (event.ctrlKey || event.metaKey) {
-            this.selectedElement = this.selectedLyrics;
-            this.blurActiveElement();
-            window.getSelection()?.removeAllRanges();
-            handled = true;
-          }
-          break;
-        case 'Space':
-          // Ctrl + Space should add a normal space character
-          if (event.ctrlKey || event.metaKey) {
-            document.execCommand('insertText', false, ' ');
-          } else {
-            this.throttled.moveToNextLyricBox(true);
-          }
-          handled = true;
-          break;
-        case 'Minus': {
-          if (event.shiftKey) {
-            document.execCommand('insertText', false, '_');
-          } else {
-            document.execCommand('insertText', false, '-');
-          }
-
-          // Ctrl key overrides the "go to next lyrics" (Alt key for mac)
-          const overridden =
-            (this.platformService.isMac && event.altKey) ||
-            (!this.platformService.isMac && event.ctrlKey);
-
-          if (
-            !overridden &&
-            getCursorPosition() === this.getLyricLength(this.selectedLyrics!)
-          ) {
-            if (this.getNextLyricBoxIndex() >= 0) {
-              this.throttled.moveToNextLyricBox();
-            } else {
-              // If this is the last lyric box, blur
-              // so that the melisma is registered and
-              // the user doesn't accidentally type more
-              // characters into box
-              const index = this.elements.indexOf(this.selectedLyrics!);
-              (
-                this.$refs[`lyrics-${index}`] as InstanceType<
-                  typeof ContentEditable
-                >[]
-              )[0].blur();
-            }
-          }
-
-          handled = true;
-          break;
+      if (event.ctrlKey || event.metaKey) {
+        if (!rtl.value) {
+          throttled.moveToNextLyricBox();
+        } else {
+          throttled.moveToPreviousLyricBox();
         }
-        case 'KeyJ': {
-          if (!this.rtl) {
-            return;
-          }
-          if (event.shiftKey) {
-            document.execCommand('insertText', false, TATWEEL);
-          } else {
-            return;
-          }
-
-          // Ctrl key overrides the "go to next lyrics" (Alt key for mac)
-          const overridden =
-            (this.platformService.isMac && event.altKey) ||
-            (!this.platformService.isMac && event.ctrlKey);
-
-          if (
-            !overridden &&
-            getCursorPosition() === this.getLyricLength(this.selectedLyrics!)
-          ) {
-            if (this.getNextLyricBoxIndex() >= 0) {
-              this.throttled.moveToNextLyricBox();
-            } else {
-              // If this is the last lyric box, blur
-              // so that the melisma is registered and
-              // the user doesn't accidentally type more
-              // characters into box
-              const index = this.elements.indexOf(this.selectedLyrics!);
-              (
-                this.$refs[`lyrics-${index}`] as InstanceType<
-                  typeof ContentEditable
-                >[]
-              )[0].blur();
-            }
-          }
-
-          handled = true;
-          break;
-        }
-      }
-
-      if (handled) {
-        event.preventDefault();
-      }
-    },
-
-    onKeydownDropCap(event: KeyboardEvent) {
-      let handled = false;
-
-      const index = this.elements.indexOf(this.selectedElement!);
-      const htmlElement = (
-        this.$refs[`element-${index}`] as InstanceType<typeof DropCap>[]
-      )[0];
-
-      switch (event.code) {
-        case 'Enter':
-          // Do not allow enter key in drop caps
-          handled = true;
-          break;
-        case 'Tab':
-          this.throttled.moveRight();
-          handled = true;
-          break;
-        case 'ArrowLeft':
-          if (!this.rtl && getCursorPosition() === 0) {
-            this.throttled.moveLeft();
-            handled = true;
-          } else if (
-            this.rtl &&
-            getCursorPosition() ===
-              htmlElement.textElement.getInnerText().length
-          ) {
-            this.throttled.moveRight();
-            handled = true;
-          }
-          break;
-        case 'ArrowRight':
-          if (
-            !this.rtl &&
-            getCursorPosition() ===
-              htmlElement.textElement.getInnerText().length
-          ) {
-            this.throttled.moveRight();
-            handled = true;
-          } else if (this.rtl && getCursorPosition() === 0) {
-            this.throttled.moveLeft();
-            handled = true;
-          }
-          break;
-      }
-
-      if (handled) {
-        event.preventDefault();
-      }
-    },
-
-    onKeydownTextBox(event: KeyboardEvent) {
-      let handled = false;
-
-      const index = this.elements.indexOf(this.selectedElement!);
-      const htmlElement = (
-        this.$refs[`element-${index}`] as InstanceType<typeof TextBox>[]
-      )[0];
-
-      switch (event.code) {
-        case 'Tab':
-          this.throttled.moveRight();
-          handled = true;
-          break;
-        case 'ArrowLeft':
-          if (!this.rtl && getCursorPosition() === 0) {
-            this.throttled.moveLeft();
-            handled = true;
-          } else if (
-            this.rtl &&
-            getCursorPosition() ===
-              htmlElement.getTextElement().getInnerText().length
-          ) {
-            this.throttled.moveRight();
-            handled = true;
-          }
-          break;
-        case 'ArrowRight':
-          if (
-            !this.rtl &&
-            getCursorPosition() ===
-              htmlElement.getTextElement().getInnerText().length
-          ) {
-            this.throttled.moveRight();
-            handled = true;
-          } else if (this.rtl && getCursorPosition() === 0) {
-            this.throttled.moveLeft();
-            handled = true;
-          }
-          break;
-      }
-
-      if (handled) {
-        event.preventDefault();
-      }
-    },
-
-    /**
-     * Handles text editing functionality for macOS
-     */
-    onKeydownMac(event: KeyboardEvent) {
-      let handled = false;
-
-      if (!event.metaKey) {
-        return;
-      }
-
-      switch (event.code) {
-        case 'KeyA':
-          document.execCommand('selectAll');
-          handled = true;
-          break;
-        case 'KeyC':
-          document.execCommand('copy');
-          handled = true;
-          break;
-        case 'KeyV':
-          this.ipcService.paste();
-          handled = true;
-          break;
-        case 'KeyX':
-          document.execCommand('cut');
-          handled = true;
-          break;
-        case 'KeyZ':
-          if (event.shiftKey) {
-            document.execCommand('redo');
-          } else {
-            document.execCommand('undo');
-          }
-          handled = true;
-          break;
-      }
-
-      if (handled) {
-        event.preventDefault();
-      }
-    },
-
-    onKeyup(event: KeyboardEvent) {
-      let handled = false;
-
-      if (this.keyboardModifier === event.code) {
-        this.keyboardModifier = null;
+        handled = true;
+      } else if (
+        !rtl.value &&
+        getCursorPosition() === getLyricLength(selectedLyrics.value!)
+      ) {
+        throttled.moveToNextLyricBox();
+        handled = true;
+      } else if (rtl.value && getCursorPosition() === 0) {
+        throttled.moveToPreviousLyricBox();
         handled = true;
       }
-
-      if (handled) {
-        event.preventDefault();
-      }
-    },
-
-    onCutScoreElements() {
-      if (this.selectionRange != null) {
-        const start = Math.min(
-          this.selectionRange.start,
-          this.selectionRange.end,
-        );
-
-        const elementsToCut = this.elements.filter(
-          (x) => x.elementType != ElementType.Empty && this.isSelected(x),
-        );
-
-        this.clipboard = elementsToCut.map((x) => x.clone());
-
-        this.commandService.executeAsBatch(
-          elementsToCut.map((element) =>
-            scoreElementCommandFactory.create('remove-from-collection', {
-              element,
-              collection: this.elements,
-            }),
-          ),
-        );
-
-        this.refreshStaffLyrics();
-
-        this.selectedElement =
-          this.elements[Math.min(start, this.elements.length - 1)];
-
-        this.save();
-      } else if (
-        this.selectedElement != null &&
-        this.selectedElement.elementType !== ElementType.Empty
-      ) {
-        const currentIndex = this.selectedElementIndex;
-
-        this.clipboard = [this.selectedElement.clone()];
-
-        this.removeScoreElement(this.selectedElement);
-
-        this.selectedElement =
-          this.elements[Math.min(currentIndex, this.elements.length - 1)];
-
-        this.save();
-      }
-    },
-
-    onCopyScoreElements() {
-      if (this.selectionRange != null) {
-        this.clipboard = this.elements
-          .filter(
-            (x) => x.elementType != ElementType.Empty && this.isSelected(x),
-          )
-          .map((x) => x.clone());
-      } else if (
-        this.selectedElement != null &&
-        this.selectedElement.elementType !== ElementType.Empty
-      ) {
-        this.clipboard = [this.selectedElement.clone()];
-      }
-    },
-
-    onPasteScoreElements(includeLyrics: boolean) {
-      if (this.clipboard.length > 0 && this.selectedElement != null) {
-        switch (this.entryMode) {
-          case EntryMode.Insert:
-            this.onPasteScoreElementsInsert(includeLyrics);
-            break;
-          case EntryMode.Auto:
-            this.onPasteScoreElementsAuto(includeLyrics);
-            break;
-          case EntryMode.Edit:
-            this.onPasteScoreElementsEdit(includeLyrics);
-            break;
-        }
-      }
-    },
-
-    onPasteScoreElementsInsert(includeLyrics: boolean) {
-      if (this.selectedElement == null || this.clipboard.length === 0) {
+      break;
+    case 'ArrowLeft':
+      if (event.shiftKey) {
         return;
       }
 
-      const insertAtIndex = this.isLastElement(this.selectedElement)
-        ? this.selectedElementIndex
-        : this.selectedElementIndex + 1;
-
-      const newElements = this.clipboard.map((x) => x.clone({ includeLyrics }));
-
-      this.addScoreElements(newElements, insertAtIndex);
-
-      this.selectedElement = newElements.at(-1)!;
-      this.save();
-    },
-
-    onPasteScoreElementsEdit(includeLyrics: boolean) {
-      if (this.selectedElement == null || this.clipboard.length === 0) {
-        return;
-      }
-
-      const commands: Command[] = [];
-
-      let currentIndex = this.selectedElementIndex;
-
-      for (const clipboardElement of this.clipboard) {
-        const currentElement = this.elements[currentIndex];
-
-        if (currentIndex >= this.elements.length - 1) {
-          commands.push(
-            scoreElementCommandFactory.create('add-to-collection', {
-              elements: [clipboardElement.clone({ includeLyrics })],
-              collection: this.elements,
-              insertAtIndex: currentIndex,
-            }),
-          );
+      if (event.ctrlKey || event.metaKey) {
+        if (!rtl.value) {
+          throttled.moveToPreviousLyricBox();
         } else {
-          if (currentElement.elementType === clipboardElement.elementType) {
-            switch (currentElement.elementType) {
-              case ElementType.Note:
-                if (
-                  !shallowEquals(
-                    (currentElement as NoteElement).getClipboardProperties(
-                      includeLyrics,
-                    ),
-                    (clipboardElement as NoteElement).getClipboardProperties(
-                      includeLyrics,
-                    ),
-                  )
-                ) {
-                  commands.push(
-                    noteElementCommandFactory.create('update-properties', {
-                      target: currentElement as NoteElement,
-                      newValues: (
-                        clipboardElement as NoteElement
-                      ).getClipboardProperties(includeLyrics),
-                    }),
-                  );
-                }
-                break;
-              case ElementType.Tempo:
-                if (
-                  !shallowEquals(
-                    (currentElement as TempoElement).getClipboardProperties(),
-                    (clipboardElement as TempoElement).getClipboardProperties(),
-                  )
-                ) {
-                  commands.push(
-                    tempoCommandFactory.create('update-properties', {
-                      target: currentElement as TempoElement,
-                      newValues: (
-                        clipboardElement as TempoElement
-                      ).getClipboardProperties(),
-                    }),
-                  );
-                }
-                break;
-              case ElementType.Martyria:
-                if (
-                  !shallowEquals(
-                    (
-                      currentElement as MartyriaElement
-                    ).getClipboardProperties(),
-                    (
-                      clipboardElement as MartyriaElement
-                    ).getClipboardProperties(),
-                  )
-                ) {
-                  commands.push(
-                    martyriaCommandFactory.create('update-properties', {
-                      target: currentElement as MartyriaElement,
-                      newValues: (
-                        clipboardElement as MartyriaElement
-                      ).getClipboardProperties(),
-                    }),
-                  );
-                }
-                break;
-              case ElementType.DropCap:
-                if (
-                  !shallowEquals(
-                    (currentElement as DropCapElement).getClipboardProperties(),
-                    (
-                      clipboardElement as DropCapElement
-                    ).getClipboardProperties(),
-                  )
-                ) {
-                  commands.push(
-                    dropCapCommandFactory.create('update-properties', {
-                      target: currentElement as DropCapElement,
-                      newValues: (
-                        clipboardElement as DropCapElement
-                      ).getClipboardProperties(),
-                    }),
-                  );
-                }
-                break;
-              case ElementType.ModeKey:
-                if (
-                  !shallowEquals(
-                    (currentElement as ModeKeyElement).getClipboardProperties(),
-                    (
-                      clipboardElement as ModeKeyElement
-                    ).getClipboardProperties(),
-                  )
-                ) {
-                  commands.push(
-                    modeKeyCommandFactory.create('update-properties', {
-                      target: currentElement as ModeKeyElement,
-                      newValues: (
-                        clipboardElement as ModeKeyElement
-                      ).getClipboardProperties(),
-                    }),
-                  );
-                }
-                break;
-              case ElementType.TextBox:
-                if (
-                  !shallowEquals(
-                    (currentElement as TextBoxElement).getClipboardProperties(),
-                    (
-                      clipboardElement as TextBoxElement
-                    ).getClipboardProperties(),
-                  )
-                ) {
-                  commands.push(
-                    textBoxCommandFactory.create('update-properties', {
-                      target: currentElement as TextBoxElement,
-                      newValues: (
-                        clipboardElement as TextBoxElement
-                      ).getClipboardProperties(),
-                    }),
-                  );
-                }
-                break;
-            }
-          } else {
-            commands.push(
-              scoreElementCommandFactory.create(
-                'replace-element-in-collection',
-                {
-                  element: clipboardElement.clone(),
-                  collection: this.elements,
-                  replaceAtIndex: currentIndex,
-                },
-              ),
-            );
-          }
+          throttled.moveToNextLyricBox();
         }
-
-        currentIndex++;
+        handled = true;
+      } else if (!rtl.value && getCursorPosition() === 0) {
+        throttled.moveToPreviousLyricBox();
+        handled = true;
+      } else if (
+        rtl.value &&
+        getCursorPosition() === getLyricLength(selectedLyrics.value!)
+      ) {
+        throttled.moveToNextLyricBox();
+        handled = true;
+      }
+      break;
+    case 'ArrowUp':
+      if (event.shiftKey) {
+        return;
       }
 
-      if (commands.length > 1) {
-        this.commandService.executeAsBatch(commands);
-        this.refreshStaffLyrics();
-      } else if (commands.length === 1) {
-        this.commandService.execute(commands[0]);
-        this.refreshStaffLyrics();
+      if (event.ctrlKey || event.metaKey) {
+        selectedElement.value = selectedLyrics.value;
+        blurActiveElement();
+        window.getSelection()?.removeAllRanges();
+        handled = true;
+      }
+      break;
+    case 'Space':
+      // Ctrl + Space should add a normal space character
+      if (event.ctrlKey || event.metaKey) {
+        document.execCommand('insertText', false, ' ');
+      } else {
+        throttled.moveToNextLyricBox(true);
+      }
+      handled = true;
+      break;
+    case 'Minus': {
+      if (event.shiftKey) {
+        document.execCommand('insertText', false, '_');
+      } else {
+        document.execCommand('insertText', false, '-');
       }
 
-      this.save();
-    },
-
-    onPasteScoreElementsAuto(includeLyrics: boolean) {
-      this.moveRight();
-      const currentIndex = this.selectedElementIndex;
-
-      this.onPasteScoreElementsEdit(includeLyrics);
-
-      // Set the selected element to the last element that was pasted
-      this.selectedElement =
-        this.elements[currentIndex + this.clipboard.length - 1];
-    },
-
-    getLyricLength(element: NoteElement) {
-      return (
-        this.$refs[`lyrics-${this.elements.indexOf(element)}`] as InstanceType<
-          typeof ContentEditable
-        >[]
-      )[0].getInnerText().length;
-    },
-
-    moveLeft() {
-      let index = -1;
-
-      if (this.selectedElement) {
-        index = this.elements.indexOf(this.selectedElement);
-      } else if (this.selectionRange) {
-        index = this.selectionRange.end;
-      }
+      // Ctrl key overrides the "go to next lyrics" (Alt key for mac)
+      const overridden =
+        (platformService.isMac && event.altKey) ||
+        (!platformService.isMac && event.ctrlKey);
 
       if (
-        index - 1 >= 0 &&
-        navigableElements.includes(this.elements[index - 1].elementType)
+        !overridden &&
+        getCursorPosition() === getLyricLength(selectedLyrics.value!)
       ) {
-        // If the currently selected element is a drop cap or text box, blur it first
-        if (this.selectedElement?.elementType === ElementType.DropCap) {
-          (
-            this.$refs[`element-${index}`] as InstanceType<typeof DropCap>[]
-          )[0].blur();
-        } else if (this.selectedElement?.elementType === ElementType.TextBox) {
-          (
-            this.$refs[`element-${index}`] as InstanceType<typeof TextBox>[]
+        if (getNextLyricBoxIndex() >= 0) {
+          throttled.moveToNextLyricBox();
+        } else {
+          // If this is the last lyric box, blur
+          // so that the melisma is registered and
+          // the user doesn't accidentally type more
+          // characters into box
+          const index = elements.value.indexOf(selectedLyrics.value!);
+          getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+            `lyrics-${index}`,
           )[0].blur();
         }
-
-        this.selectedElement = this.elements[index - 1];
-
-        // If the newly selected element is a drop cap or text box, focus it
-        if (this.selectedElement.elementType === ElementType.DropCap) {
-          (
-            this.$refs[`element-${index - 1}`] as InstanceType<typeof DropCap>[]
-          )[0].focus();
-        } else if (this.selectedElement.elementType === ElementType.TextBox) {
-          (
-            this.$refs[`element-${index - 1}`] as InstanceType<typeof TextBox>[]
-          )[0].focus();
-        }
-
-        return true;
       }
 
-      return false;
-    },
-
-    moveRight() {
-      let index = -1;
-
-      if (this.selectedElement) {
-        index = this.elements.indexOf(this.selectedElement);
-      } else if (this.selectionRange) {
-        index = this.selectionRange.end;
+      handled = true;
+      break;
+    }
+    case 'KeyJ': {
+      if (!rtl.value) {
+        return;
       }
+      if (event.shiftKey) {
+        document.execCommand('insertText', false, TATWEEL);
+      } else {
+        return;
+      }
+
+      // Ctrl key overrides the "go to next lyrics" (Alt key for mac)
+      const overridden =
+        (platformService.isMac && event.altKey) ||
+        (!platformService.isMac && event.ctrlKey);
 
       if (
-        index >= 0 &&
-        index + 1 < this.elements.length &&
-        navigableElements.includes(this.elements[index + 1].elementType)
+        !overridden &&
+        getCursorPosition() === getLyricLength(selectedLyrics.value!)
       ) {
-        // If the currently selected element is a drop cap, blur it first
-        if (this.selectedElement?.elementType === ElementType.DropCap) {
-          (
-            this.$refs[`element-${index}`] as InstanceType<typeof DropCap>[]
-          )[0].blur();
-        } else if (this.selectedElement?.elementType === ElementType.TextBox) {
-          (
-            this.$refs[`element-${index}`] as InstanceType<typeof TextBox>[]
+        if (getNextLyricBoxIndex() >= 0) {
+          throttled.moveToNextLyricBox();
+        } else {
+          // If this is the last lyric box, blur
+          // so that the melisma is registered and
+          // the user doesn't accidentally type more
+          // characters into box
+          const index = elements.value.indexOf(selectedLyrics.value!);
+          getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+            `lyrics-${index}`,
           )[0].blur();
         }
-
-        this.selectedElement = this.elements[index + 1];
-
-        // If the newly selected element is a drop cap, focus it
-        if (this.selectedElement.elementType === ElementType.DropCap) {
-          (
-            this.$refs[`element-${index + 1}`] as InstanceType<typeof DropCap>[]
-          )[0].focus();
-        } else if (this.selectedElement.elementType === ElementType.TextBox) {
-          (
-            this.$refs[`element-${index + 1}`] as InstanceType<typeof TextBox>[]
-          )[0].focus();
-        }
-
-        return true;
       }
 
-      return false;
-    },
+      handled = true;
+      break;
+    }
+  }
 
-    moveSelectionLeft() {
-      if (this.selectionRange != null) {
-        if (
-          this.selectionRange.end > 0 &&
-          navigableElements.includes(
-            this.elements[this.selectionRange.end - 1].elementType,
-          )
-        ) {
-          this.setSelectionRange(this.elements[this.selectionRange.end - 1]);
-        }
+  if (handled) {
+    event.preventDefault();
+  }
+}
+
+function onKeydownDropCap(event: KeyboardEvent) {
+  let handled = false;
+
+  const index = elements.value.indexOf(selectedElement.value!);
+  const htmlElement = getTemplateRef<InstanceType<typeof DropCap>[]>(
+    `element-${index}`,
+  )[0];
+
+  switch (event.code) {
+    case 'Enter':
+      // Do not allow enter key in drop caps
+      handled = true;
+      break;
+    case 'Tab':
+      throttled.moveRight();
+      handled = true;
+      break;
+    case 'ArrowLeft':
+      if (!rtl.value && getCursorPosition() === 0) {
+        throttled.moveLeft();
+        handled = true;
       } else if (
-        this.selectedElement != null &&
-        this.selectedElementIndex > 0 &&
-        navigableElements.includes(
-          this.elements[this.selectedElementIndex - 1].elementType,
-        )
+        rtl.value &&
+        getCursorPosition() === htmlElement.textElement.getInnerText().length
       ) {
-        this.setSelectionRange(this.elements[this.selectedElementIndex - 1]);
+        throttled.moveRight();
+        handled = true;
       }
-    },
+      break;
+    case 'ArrowRight':
+      if (
+        !rtl.value &&
+        getCursorPosition() === htmlElement.textElement.getInnerText().length
+      ) {
+        throttled.moveRight();
+        handled = true;
+      } else if (rtl.value && getCursorPosition() === 0) {
+        throttled.moveLeft();
+        handled = true;
+      }
+      break;
+  }
 
-    moveSelectionRight() {
-      if (this.selectionRange != null) {
-        if (
-          this.selectionRange.end + 1 < this.elements.length - 1 &&
-          navigableElements.includes(
-            this.elements[this.selectionRange.end + 1].elementType,
-          )
-        ) {
-          this.setSelectionRange(this.elements[this.selectionRange.end + 1]);
-        }
+  if (handled) {
+    event.preventDefault();
+  }
+}
+
+function onKeydownTextBox(event: KeyboardEvent) {
+  let handled = false;
+
+  const index = elements.value.indexOf(selectedElement.value!);
+  const htmlElement = getTemplateRef<InstanceType<typeof TextBox>[]>(
+    `element-${index}`,
+  )[0];
+
+  switch (event.code) {
+    case 'Tab':
+      throttled.moveRight();
+      handled = true;
+      break;
+    case 'ArrowLeft':
+      if (!rtl.value && getCursorPosition() === 0) {
+        throttled.moveLeft();
+        handled = true;
       } else if (
-        this.selectedElement != null &&
-        this.selectedElementIndex + 1 < this.elements.length - 1 &&
-        navigableElements.includes(
-          this.elements[this.selectedElementIndex + 1].elementType,
-        )
+        rtl.value &&
+        getCursorPosition() ===
+          htmlElement.getTextElement().getInnerText().length
       ) {
-        this.setSelectionRange(this.elements[this.selectedElementIndex + 1]);
+        throttled.moveRight();
+        handled = true;
       }
-    },
-
-    getNextLyricBoxIndex() {
-      if (this.selectedLyrics) {
-        const currentIndex = this.elements.indexOf(this.selectedLyrics);
-
-        // Find the index of the next note
-        for (let i = currentIndex + 1; i < this.elements.length; i++) {
-          if (this.elements[i].elementType === ElementType.Note) {
-            return i;
-          }
-        }
-      }
-
-      return -1;
-    },
-
-    moveToNextLyricBox(clearMelisma: boolean = false) {
-      const nextIndex = this.getNextLyricBoxIndex();
-
-      if (nextIndex >= 0) {
-        // If the lyrics for the last neume on the line have been updated to be so long
-        // that the neume is moved to the next line by processPages(), then focusLyrics()
-        // will fail if called on its own. This is because the order of events would
-        // be the following:
-        // focus next element => blur previous element => updateLyrics => processPages
-        // and finally the newly selected element would lose focus because processPages
-        // moves the element to the next line.
-
-        // To prevent this we, preemptively call updateLyrics and then use nextTick
-        // to only focus the next lyrics after the UI has been redrawn.
-
-        const noteElement = this.selectedLyrics!;
-
-        const text = (
-          this.$refs[
-            `lyrics-${this.elements.indexOf(noteElement)}`
-          ] as InstanceType<typeof ContentEditable>[]
-        )[0].getInnerText();
-
-        this.updateLyrics(noteElement, text, clearMelisma);
-
-        nextTick(() => {
-          this.focusLyrics(nextIndex, true);
-        });
-
-        return true;
-      }
-
-      return false;
-    },
-
-    moveToPreviousLyricBox() {
-      if (this.selectedLyrics) {
-        const currentIndex = this.elements.indexOf(this.selectedLyrics);
-        let nextIndex = -1;
-
-        // Find the index of the previous note
-        for (let i = currentIndex - 1; i >= 0; i--) {
-          if (this.elements[i].elementType === ElementType.Note) {
-            nextIndex = i;
-            break;
-          }
-        }
-
-        if (nextIndex >= 0) {
-          this.focusLyrics(nextIndex, true);
-          return true;
-        }
-      }
-
-      return false;
-    },
-
-    calculatePageNumber() {
-      let maxPercentage = 0;
-      let maxPercentageIndex = -1;
-
-      const viewportHeight =
-        window.innerHeight || document.documentElement.clientHeight;
-
-      for (let pageIndex = 0; pageIndex < this.pageCount; pageIndex++) {
-        const rect = (this.$refs.pages as Element[])[
-          pageIndex
-        ].getBoundingClientRect();
-
-        const percentage =
-          Math.max(
-            0,
-            rect.top > 0
-              ? Math.min(rect.height, viewportHeight - rect.top)
-              : rect.bottom < viewportHeight
-                ? rect.bottom
-                : viewportHeight,
-          ) / rect.height;
-
-        if (percentage > maxPercentage) {
-          maxPercentage = percentage;
-          maxPercentageIndex = pageIndex;
-        }
-      }
-
-      if (maxPercentageIndex >= 0) {
-        this.currentPageNumber = maxPercentageIndex + 1;
-      }
-    },
-
-    save(markUnsavedChanges: boolean = true) {
-      if (markUnsavedChanges) {
-        this.hasUnsavedChanges = true;
-      }
-
-      // Save the indexes of the visible pages
-      const visiblePages = this.pages
-        .map((_, i) => i)
-        .filter((i) => this.pages[i].isVisible);
-
-      const pages = LayoutService.processPages(toRaw(this.selectedWorkspace));
-
-      // Set page visibility for the newly processed pages
-      pages.forEach((x, index) => (x.isVisible = visiblePages.includes(index)));
-
-      // Only re-render elements that are visible and that have been updated by processPages
-      pages
-        .filter((x) => x.isVisible)
-        .forEach((page) => {
-          page.lines.forEach((line) =>
-            line.elements
-              .filter((x) => x.updated)
-              .forEach((element) => {
-                element.keyHelper++;
-              }),
-          );
-        });
-
-      // Re-render headers and footers if they changed
-      this.score.headersAndFooters
-        .filter((x) => x.updated)
-        .forEach((element) => {
-          element.keyHelper++;
-        });
-
-      this.pages = pages;
-
-      // If using the browser, save the workspace to local storage
-      if (this.isBrowser) {
-        const workspaceLocalStorage = {
-          id: this.selectedWorkspace.id,
-          score: JSON.stringify(SaveService.SaveScoreToJson(this.score)),
-          filePath: this.currentFilePath,
-          tempFileName: this.selectedWorkspace.tempFileName,
-          hasUnsavedChanges: this.hasUnsavedChanges,
-        } as WorkspaceLocalStorage;
-
-        localStorage.setItem(
-          `workspace-${this.selectedWorkspace.id}`,
-          JSON.stringify(workspaceLocalStorage),
-        );
-      } else if (this.isDevelopment) {
-        localStorage.setItem(
-          'score',
-          JSON.stringify(SaveService.SaveScoreToJson(this.score)),
-        );
-
-        if (this.currentFilePath != null) {
-          localStorage.setItem('filePath', this.currentFilePath);
-        } else {
-          localStorage.removeItem('filePath');
-        }
-
-        localStorage.setItem(
-          'hasUnsavedChanges',
-          this.hasUnsavedChanges.toString(),
-        );
-      }
-    },
-
-    async load() {
-      if (this.isBrowser) {
-        Object.keys(localStorage).forEach((key) => {
-          if (key.startsWith('workspace-')) {
-            try {
-              const localStorageWorkspace: WorkspaceLocalStorage = JSON.parse(
-                localStorage.getItem(key)!,
-              );
-              const workspace = new Workspace();
-              workspace.id = localStorageWorkspace.id;
-              workspace.hasUnsavedChanges =
-                localStorageWorkspace.hasUnsavedChanges;
-              workspace.filePath = localStorageWorkspace.filePath;
-              workspace.tempFileName = localStorageWorkspace.tempFileName;
-              workspace.score = SaveService.LoadScoreFromJson(
-                JSON.parse(localStorageWorkspace.score),
-              );
-
-              this.addWorkspace(workspace);
-            } catch (error) {
-              // We couldn't load this workspace for some reason. Remove it from storage.
-              localStorage.removeItem(key);
-              console.error(error);
-            }
-          }
-        });
-
-        if (this.workspaces.length > 0) {
-          this.selectedWorkspace = this.workspaces[0] as Workspace;
-          return;
-        }
-      }
-
-      // First, try to load files passed in on the command line.
-      // If there are none, then create a default workspace.
-      const openWorkspaceResults =
-        await this.ipcService.openWorkspaceFromArgv();
-
-      if (openWorkspaceResults.silentPdf) {
-        for (const file of openWorkspaceResults.files.filter(
-          (x) => x.success,
-        )) {
-          this.openScore(file);
-          await this.onFileMenuExportAsPdf();
-          this.removeWorkspace(this.selectedWorkspace);
-        }
-      }
-
-      if (openWorkspaceResults.silentHtml) {
-        for (const file of openWorkspaceResults.files.filter(
-          (x) => x.success,
-        )) {
-          this.openScore(file);
-          await this.onFileMenuExportAsHtml();
-          this.removeWorkspace(this.selectedWorkspace);
-        }
-      }
-
-      if (openWorkspaceResults.silentLatex) {
-        for (const file of openWorkspaceResults.files.filter(
-          (x) => x.success,
-        )) {
-          const options = new LatexExporterOptions();
-          options.includeModeKeys =
-            openWorkspaceResults.silentLatexIncludeModeKeys ?? false;
-          options.includeTextBoxes =
-            openWorkspaceResults.silentLatexIncludeTextBoxes ?? false;
-          this.openScore(file);
-          await this.ipcService.exportWorkspaceAsLatex(
-            this.selectedWorkspace,
-            JSON.stringify(
-              this.latexExporter.export(
-                this.pages,
-                this.score.pageSetup,
-                options,
-              ),
-              null,
-              2,
-            ),
-          );
-          this.removeWorkspace(this.selectedWorkspace);
-        }
-      }
-
+      break;
+    case 'ArrowRight':
       if (
-        openWorkspaceResults.silentPdf ||
-        openWorkspaceResults.silentLatex ||
-        openWorkspaceResults.silentHtml
+        !rtl.value &&
+        getCursorPosition() ===
+          htmlElement.getTextElement().getInnerText().length
       ) {
-        await this.ipcService.exitApplication();
+        throttled.moveRight();
+        handled = true;
+      } else if (rtl.value && getCursorPosition() === 0) {
+        throttled.moveLeft();
+        handled = true;
       }
+      break;
+  }
 
-      openWorkspaceResults.files
-        .filter((x) => x.success)
-        .forEach((x) => this.openScore(x));
+  if (handled) {
+    event.preventDefault();
+  }
+}
 
-      if (openWorkspaceResults.files.some((x) => x.success)) {
-        return;
-      }
+function onKeydownMac(event: KeyboardEvent) {
+  let handled = false;
 
-      const workspace = new Workspace();
-      workspace.tempFileName = this.getTempFilename();
-      workspace.score = this.createDefaultScore();
+  if (!event.metaKey) {
+    return;
+  }
 
-      this.addWorkspace(workspace);
-
-      if (this.isDevelopment) {
-        const scoreString = localStorage.getItem('score');
-
-        if (scoreString) {
-          const score: Score = SaveService.LoadScoreFromJson(
-            JSON.parse(scoreString),
-          );
-          this.currentFilePath = localStorage.getItem('filePath');
-          this.hasUnsavedChanges =
-            localStorage.getItem('hasUnsavedChanges') === 'true';
-
-          workspace.score = score;
-        }
-      }
-
-      this.selectedWorkspace = workspace;
-
-      this.selectedElement =
-        this.score.staff.elements[this.score.staff.elements.length - 1];
-
-      this.pages = LayoutService.processPages(this.selectedWorkspace);
-    },
-
-    async saveWorkspace(workspace: Workspace) {
-      if (!this.lyricsLocked) {
-        this.lyrics = this.lyricService.extractLyrics(
-          this.elements,
-          this.score.pageSetup.disableGreekMelismata,
-        );
-      }
-
-      return await this.ipcService.saveWorkspace(workspace);
-    },
-
-    async saveWorkspaceAs(workspace: Workspace) {
-      if (!this.lyricsLocked) {
-        this.lyrics = this.lyricService.extractLyrics(
-          this.elements,
-          this.score.pageSetup.disableGreekMelismata,
-        );
-      }
-
-      return await this.ipcService.saveWorkspaceAs(workspace);
-    },
-
-    async closeWorkspace(workspace: Workspace) {
-      let shouldClose = true;
-
-      if (workspace.hasUnsavedChanges) {
-        const fileName =
-          workspace.filePath != null
-            ? getFileNameFromPath(workspace.filePath)
-            : workspace.tempFileName;
-
-        let dialogResult: ShowMessageBoxReplyArgs;
-
-        if (this.ipcService.isShowMessageBoxSupported()) {
-          dialogResult = await this.ipcService.showMessageBox({
-            title: import.meta.env.VITE_TITLE,
-            message: `Do you want to save the changes you made to ${fileName}?`,
-            detail: "Your changes will be lost if you don't save them.",
-            type: 'warning',
-            buttons: ['Save', "Don't Save", 'Cancel'],
-          });
-        } else {
-          dialogResult = {
-            response: confirm(
-              `${fileName} has unsaved changes. Are you sure you want to close it?`,
-            )
-              ? 1
-              : 2,
-            checkboxChecked: false,
-          };
-        }
-
-        if (dialogResult.response === 0) {
-          // User chose "Save"
-          const saveResult =
-            workspace.filePath != null
-              ? await this.saveWorkspace(workspace)
-              : await this.saveWorkspaceAs(workspace);
-
-          // If they successfully saved, then we can close the workspacce
-          shouldClose = saveResult.success;
-        } else if (dialogResult.response === 2) {
-          // User chose "Cancel", so don't close the workspace.
-          shouldClose = false;
-        }
-      }
-
-      if (shouldClose) {
-        // If using the browser, remove the item from local storage
-        if (this.isBrowser) {
-          localStorage.removeItem(`workspace-${workspace.id}`);
-        }
-
-        // If the last tab has closed, then exit
-        if (this.workspaces.length == 1) {
-          await this.ipcService.exitApplication();
-        }
-
-        this.removeWorkspace(workspace);
-      }
-
-      return shouldClose;
-    },
-
-    async onCloseWorkspaces(args: CloseWorkspacesArgs) {
-      const workspacesToClose: Workspace[] = this.workspaces.filter(
-        (workspace) => {
-          const index: number = this.tabs.findIndex(
-            (x) => x.key === workspace.id,
-          );
-
-          const pivot: number = args.workspaceId
-            ? this.tabs.findIndex((x) => x.key === args.workspaceId)
-            : this.tabs.findIndex((x) => x.key === this.selectedWorkspace.id);
-
-          switch (args.disposition) {
-            case CloseWorkspacesDisposition.SELF:
-              return index === pivot;
-            case CloseWorkspacesDisposition.OTHERS:
-              return index !== pivot;
-            case CloseWorkspacesDisposition.LEFT:
-              return index < pivot;
-            case CloseWorkspacesDisposition.RIGHT:
-              return index > pivot;
-            default:
-              throw new Error(
-                `Error: Unknown disposition ${args.disposition}.`,
-              );
-          }
-        },
-      ) as Workspace[];
-
-      for (const workspaceToClose of workspacesToClose) {
-        if (!(await this.closeWorkspace(workspaceToClose))) {
-          // The user vetoed the operation.
-          break;
-        }
-      }
-    },
-
-    async onCloseApplication() {
-      // Give the user a chance to save their changes before exiting
-      const unsavedWorkspaces = this.workspaces.filter(
-        (x) => x.hasUnsavedChanges,
-      ) as Workspace[];
-
-      for (const workspace of unsavedWorkspaces) {
-        if (!(await this.closeWorkspace(workspace))) {
-          await this.ipcService.cancelExit();
-          return false;
-        }
-      }
-
-      await this.ipcService.exitApplication();
-    },
-
-    setKlasma(element: NoteElement) {
-      if (onlyTakesBottomKlasma(element.quantitativeNeume)) {
-        if (element.timeNeume === TimeNeume.Klasma_Bottom) {
-          this.updateNoteAndSave(element, { timeNeume: null });
-        } else {
-          this.updateNoteAndSave(element, {
-            timeNeume: TimeNeume.Klasma_Bottom,
-          });
-        }
-        return;
-      } else if (onlyTakesTopKlasma(element.quantitativeNeume)) {
-        if (element.timeNeume === TimeNeume.Klasma_Top) {
-          this.updateNoteAndSave(element, { timeNeume: null });
-        } else {
-          this.updateNoteAndSave(element, {
-            timeNeume: TimeNeume.Klasma_Top,
-          });
-        }
-        return;
-      } else if (element.timeNeume == null) {
-        this.updateNoteAndSave(element, {
-          timeNeume: TimeNeume.Klasma_Top,
-        });
-      } else if (element.timeNeume === TimeNeume.Klasma_Top) {
-        this.updateNoteAndSave(element, {
-          timeNeume: TimeNeume.Klasma_Bottom,
-        });
-      } else if (element.timeNeume === TimeNeume.Klasma_Bottom) {
-        this.updateNoteAndSave(element, { timeNeume: null });
-      }
-    },
-
-    setGorgon(element: NoteElement, neumes: GorgonNeume | GorgonNeume[]) {
-      let equivalent = false;
-
-      // Force neumes to be an array if it's not
-      neumes = Array.isArray(neumes) ? neumes : [neumes];
-
-      for (const neume of neumes) {
-        if (
-          neume === GorgonNeume.Gorgon_Bottom &&
-          onlyTakesTopGorgon(element.quantitativeNeume)
-        ) {
-          continue;
-        }
-
-        // If previous neume was matched, set to the next neume in the cycle
-        if (equivalent) {
-          this.updateNoteAndSave(element, { gorgonNeume: neume });
-          return;
-        }
-
-        equivalent = element.gorgonNeume === neume;
-      }
-
-      // We've cycled through all the neumes.
-      // If we got to the end of the cycle, remove all
-      // gorgon neumes. Otherwise set gorgon to the first neume
-      // in the cycle.
-      if (equivalent) {
-        this.updateNoteAndSave(element, { gorgonNeume: null });
+  switch (event.code) {
+    case 'KeyA':
+      document.execCommand('selectAll');
+      handled = true;
+      break;
+    case 'KeyC':
+      document.execCommand('copy');
+      handled = true;
+      break;
+    case 'KeyV':
+      ipcService.paste();
+      handled = true;
+      break;
+    case 'KeyX':
+      document.execCommand('cut');
+      handled = true;
+      break;
+    case 'KeyZ':
+      if (event.shiftKey) {
+        document.execCommand('redo');
       } else {
-        this.updateNoteAndSave(element, { gorgonNeume: neumes[0] });
+        document.execCommand('undo');
       }
-    },
+      handled = true;
+      break;
+  }
 
-    setSecondaryGorgon(element: NoteElement, neume: GorgonNeume) {
-      if (element.secondaryGorgonNeume === neume) {
-        this.updateNoteAndSave(element, { secondaryGorgonNeume: null });
-      } else {
-        this.updateNoteAndSave(element, { secondaryGorgonNeume: neume });
-      }
-    },
+  if (handled) {
+    event.preventDefault();
+  }
+}
 
-    setFthoraNote(element: NoteElement, neumes: Fthora[]) {
-      let equivalent = false;
+function onKeyup(event: KeyboardEvent) {
+  let handled = false;
 
-      for (const neume of neumes) {
-        // If previous neume was matched, set to the next neume in the cycle
-        if (equivalent) {
-          this.updateNoteFthora(element, neume);
-          return;
-        }
+  if (keyboardModifier.value === event.code) {
+    keyboardModifier.value = null;
+    handled = true;
+  }
 
-        equivalent = element.fthora === neume;
-      }
+  if (handled) {
+    event.preventDefault();
+  }
+}
 
-      // We've cycled through all the neumes.
-      // If we got to the end of the cycle, remove all
-      // fthora neumes. Otherwise set fthora to the first neume
-      // in the cycle.
-      if (equivalent) {
-        this.updateNoteFthora(element, null);
-      } else {
-        this.updateNoteFthora(element, neumes[0]);
-      }
-    },
+function onCutScoreElements() {
+  if (selectionRange.value != null) {
+    const start = Math.min(
+      selectionRange.value.start,
+      selectionRange.value.end,
+    );
 
-    setSecondaryFthora(element: NoteElement, neume: Fthora) {
-      if (element.secondaryFthora === neume) {
-        this.updateNoteFthoraSecondary(element, null);
-      } else {
-        this.updateNoteFthoraSecondary(element, neume);
-      }
-    },
+    const elementsToCut = elements.value.filter(
+      (x) => x.elementType != ElementType.Empty && isSelected(x),
+    );
 
-    setTertiaryFthora(element: NoteElement, neume: Fthora) {
-      if (element.tertiaryFthora === neume) {
-        this.updateNoteFthoraTertiary(element, null);
-      } else {
-        this.updateNoteFthoraTertiary(element, neume);
-      }
-    },
+    clipboard.value = elementsToCut.map((x) => x.clone());
 
-    setFthoraMartyria(element: MartyriaElement, neume: Fthora) {
-      if (element.fthora === neume) {
-        this.updateMartyriaFthora(element, null);
-      } else {
-        this.updateMartyriaFthora(element, neume);
-      }
-    },
-
-    setMartyriaTempoLeft(element: MartyriaElement, neume: TempoSign) {
-      if (element.tempoLeft === neume) {
-        this.updateMartyriaTempoLeft(element, null);
-      } else {
-        this.updateMartyriaTempoLeft(element, neume);
-      }
-    },
-
-    setMartyriaTempo(element: MartyriaElement, neume: TempoSign) {
-      if (element.tempo === neume) {
-        this.updateMartyriaTempo(element, null);
-      } else {
-        this.updateMartyriaTempo(element, neume);
-      }
-    },
-
-    setMartyriaTempoRight(element: MartyriaElement, neume: TempoSign) {
-      if (element.tempoRight === neume) {
-        this.updateMartyriaTempoRight(element, null);
-      } else {
-        this.updateMartyriaTempoRight(element, neume);
-      }
-    },
-
-    setMartyriaQuantitativeNeume(
-      element: MartyriaElement,
-      neume: QuantitativeNeume,
-    ) {
-      if (element.quantitativeNeume === neume) {
-        this.updateMartyria(element, { quantitativeNeume: null });
-      } else {
-        this.updateMartyria(element, { quantitativeNeume: neume });
-      }
-    },
-
-    setModeKeyTempo(element: ModeKeyElement, neume: TempoSign) {
-      if (element.tempo === neume) {
-        this.updateModeKeyTempo(element, null);
-      } else {
-        this.updateModeKeyTempo(element, neume);
-      }
-    },
-
-    setAccidental(element: NoteElement, neume: Accidental) {
-      if (element.accidental != null && element.accidental === neume) {
-        this.updateNoteAndSave(element, { accidental: null });
-      } else {
-        this.updateNoteAndSave(element, { accidental: neume });
-      }
-    },
-
-    setSecondaryAccidental(element: NoteElement, neume: Accidental) {
-      if (
-        element.secondaryAccidental != null &&
-        element.secondaryAccidental === neume
-      ) {
-        this.updateNoteAndSave(element, { secondaryAccidental: null });
-      } else {
-        this.updateNoteAndSave(element, { secondaryAccidental: neume });
-      }
-    },
-
-    setTertiaryAccidental(element: NoteElement, neume: Accidental) {
-      if (
-        element.tertiaryAccidental != null &&
-        element.tertiaryAccidental === neume
-      ) {
-        this.updateNoteAndSave(element, { tertiaryAccidental: null });
-      } else {
-        this.updateNoteAndSave(element, { tertiaryAccidental: neume });
-      }
-    },
-
-    setTimeNeume(element: NoteElement, neume: TimeNeume) {
-      if (element.timeNeume === neume) {
-        this.updateNoteAndSave(element, { timeNeume: null });
-      } else {
-        this.updateNoteAndSave(element, { timeNeume: neume });
-      }
-    },
-
-    setMeasureNumber(element: NoteElement, neume: MeasureNumber) {
-      if (neume === element.measureNumber) {
-        this.updateNoteAndSave(element, { measureNumber: null });
-      } else {
-        this.updateNoteAndSave(element, { measureNumber: neume });
-      }
-    },
-
-    setMeasureBarNote(element: NoteElement, neume: MeasureBar) {
-      // Cycle through
-      // Left
-      // Right
-      // Both Sides
-      // None
-      const normalizedMeasureBar = element.measureBarLeft?.endsWith('Above')
-        ? measureBarAboveToLeft.get(element.measureBarLeft)
-        : element.measureBarLeft;
-      if (neume === normalizedMeasureBar && neume === element.measureBarRight) {
-        this.updateNoteAndSave(element, {
-          measureBarLeft: null,
-          measureBarRight: null,
-        });
-      } else if (neume === normalizedMeasureBar) {
-        this.updateNoteAndSave(element, {
-          measureBarLeft: null,
-          measureBarRight: neume,
-        });
-      } else if (neume === element.measureBarRight) {
-        this.updateNoteAndSave(element, {
-          measureBarLeft: neume,
-          measureBarRight: neume,
-        });
-      } else {
-        this.updateNoteAndSave(element, {
-          measureBarLeft: neume,
-          measureBarRight: null,
-        });
-      }
-    },
-
-    setMeasureBarMartyria(element: MartyriaElement, neume: MeasureBar) {
-      // Cycle through
-      // Left
-      // Right
-      // Both Sides
-      // None
-      const normalizedMeasureBar = element.measureBarLeft?.endsWith('Above')
-        ? measureBarAboveToLeft.get(element.measureBarLeft)
-        : element.measureBarLeft;
-      if (neume === normalizedMeasureBar && neume === element.measureBarRight) {
-        this.updateMartyria(element, {
-          measureBarLeft: null,
-          measureBarRight: null,
-        });
-      } else if (neume === normalizedMeasureBar) {
-        this.updateMartyria(element, {
-          measureBarLeft: null,
-          measureBarRight: neume,
-        });
-      } else if (neume === element.measureBarRight) {
-        this.updateMartyria(element, {
-          measureBarLeft: neume,
-          measureBarRight: neume,
-        });
-      } else {
-        this.updateMartyria(element, {
-          measureBarLeft: neume,
-          measureBarRight: null,
-        });
-      }
-    },
-
-    setIson(element: NoteElement, neume: Ison) {
-      if (neume === element.ison) {
-        this.updateNoteAndSave(element, { ison: null });
-      } else {
-        this.updateNoteAndSave(element, { ison: neume });
-      }
-    },
-
-    setVocalExpression(element: NoteElement, neume: VocalExpressionNeume) {
-      if (
-        element.vocalExpressionNeume != null &&
-        areVocalExpressionsEquivalent(neume, element.vocalExpressionNeume)
-      ) {
-        this.updateNoteExpression(element, null);
-      } else {
-        this.updateNoteExpression(element, neume);
-      }
-    },
-
-    setTie(element: NoteElement, neumes: Tie[]) {
-      let equivalent = false;
-
-      for (const neume of neumes) {
-        // If previous neume was matched, set to the next neume in the cycle
-        if (equivalent) {
-          this.updateNoteAndSave(element, { tie: neume });
-          return;
-        }
-
-        equivalent = element.tie === neume;
-      }
-
-      // We've cycled through all the neumes.
-      // If we got to the end of the cycle, remove all
-      // fthora neumes. Otherwise set fthora to the first neume
-      // in the cycle.
-      if (equivalent) {
-        this.updateNoteAndSave(element, { tie: null });
-      } else {
-        this.updateNoteAndSave(element, { tie: neumes[0] });
-      }
-    },
-
-    addScoreElement(
-      element: ScoreElement,
-      insertAtIndex?: number,
-      collection?: ScoreElement[],
-    ) {
-      this.commandService.execute(
-        scoreElementCommandFactory.create('add-to-collection', {
-          elements: [element],
-          collection: collection ?? this.elements,
-          insertAtIndex,
-        }),
-      );
-
-      this.refreshStaffLyrics();
-    },
-
-    addScoreElements(elements: ScoreElement[], insertAtIndex?: number) {
-      this.commandService.execute(
-        scoreElementCommandFactory.create('add-to-collection', {
-          elements,
-          collection: this.elements,
-          insertAtIndex,
-        }),
-      );
-
-      this.refreshStaffLyrics();
-    },
-
-    replaceScoreElement(element: ScoreElement, replaceAtIndex: number) {
-      this.commandService.execute(
-        scoreElementCommandFactory.create('replace-element-in-collection', {
-          element,
-          collection: this.elements,
-          replaceAtIndex,
-        }),
-      );
-
-      this.refreshStaffLyrics();
-    },
-
-    removeScoreElement(element: ScoreElement, collection?: ScoreElement[]) {
-      this.commandService.execute(
+    commandService.value.executeAsBatch(
+      elementsToCut.map((element) =>
         scoreElementCommandFactory.create('remove-from-collection', {
           element,
-          collection: collection ?? this.elements,
+          collection: elements.value,
+        }),
+      ),
+    );
+
+    refreshStaffLyrics();
+
+    selectedElement.value =
+      elements.value[Math.min(start, elements.value.length - 1)];
+
+    save();
+  } else if (
+    selectedElement.value != null &&
+    selectedElement.value.elementType !== ElementType.Empty
+  ) {
+    const currentIndex = selectedElementIndex.value;
+
+    clipboard.value = [selectedElement.value.clone()];
+
+    removeScoreElement(selectedElement.value);
+
+    selectedElement.value =
+      elements.value[Math.min(currentIndex, elements.value.length - 1)];
+
+    save();
+  }
+}
+
+function onCopyScoreElements() {
+  if (selectionRange.value != null) {
+    clipboard.value = elements.value
+      .filter((x) => x.elementType != ElementType.Empty && isSelected(x))
+      .map((x) => x.clone());
+  } else if (
+    selectedElement.value != null &&
+    selectedElement.value.elementType !== ElementType.Empty
+  ) {
+    clipboard.value = [selectedElement.value.clone()];
+  }
+}
+
+function onPasteScoreElements(includeLyrics: boolean) {
+  if (clipboard.value.length > 0 && selectedElement.value != null) {
+    switch (entryMode.value) {
+      case EntryMode.Insert:
+        onPasteScoreElementsInsert(includeLyrics);
+        break;
+      case EntryMode.Auto:
+        onPasteScoreElementsAuto(includeLyrics);
+        break;
+      case EntryMode.Edit:
+        onPasteScoreElementsEdit(includeLyrics);
+        break;
+    }
+  }
+}
+
+function onPasteScoreElementsInsert(includeLyrics: boolean) {
+  if (selectedElement.value == null || clipboard.value.length === 0) {
+    return;
+  }
+
+  const insertAtIndex = isLastElement(selectedElement.value)
+    ? selectedElementIndex.value
+    : selectedElementIndex.value + 1;
+
+  const newElements = clipboard.value.map((x) => x.clone({ includeLyrics }));
+
+  addScoreElements(newElements, insertAtIndex);
+
+  selectedElement.value = newElements.at(-1)!;
+  save();
+}
+
+function onPasteScoreElementsEdit(includeLyrics: boolean) {
+  if (selectedElement.value == null || clipboard.value.length === 0) {
+    return;
+  }
+
+  const commands: Command[] = [];
+
+  let currentIndex = selectedElementIndex.value;
+
+  for (const clipboardElement of clipboard.value) {
+    const currentElement = elements.value[currentIndex];
+
+    if (currentIndex >= elements.value.length - 1) {
+      commands.push(
+        scoreElementCommandFactory.create('add-to-collection', {
+          elements: [clipboardElement.clone({ includeLyrics })],
+          collection: elements.value,
+          insertAtIndex: currentIndex,
         }),
       );
-
-      this.refreshStaffLyrics();
-    },
-
-    updatePageVisibility(page: Page, isVisible: boolean) {
-      page.isVisible = isVisible;
-    },
-
-    updateNoteAndSave(element: NoteElement, newValues: Partial<NoteElement>) {
-      this.updateNote(element, newValues);
-      this.save();
-    },
-
-    updateNote(element: NoteElement, newValues: Partial<NoteElement>) {
-      this.commandService.execute(
-        noteElementCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      // Force the element to update so that the neume toolbar updates
-      element.keyHelper++;
-
-      // If we change certain fields, we need to refresh the staff lyrics
-      if (
-        newValues.quantitativeNeume !== undefined ||
-        newValues.tie !== undefined ||
-        newValues.acceptsLyrics !== undefined
-      ) {
-        this.refreshStaffLyrics();
-      }
-    },
-
-    updateNoteFthora(element: NoteElement, fthora: Fthora | null) {
-      let chromaticFthoraNote: ScaleNote | null = null;
-
-      if (
-        fthora === Fthora.SoftChromaticThi_Top ||
-        fthora === Fthora.SoftChromaticThi_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Thi;
-      } else if (
-        fthora === Fthora.SoftChromaticPa_Top ||
-        fthora === Fthora.SoftChromaticPa_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Ga;
-      } else if (
-        fthora === Fthora.HardChromaticThi_Top ||
-        fthora === Fthora.HardChromaticThi_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Thi;
-      } else if (
-        fthora === Fthora.HardChromaticPa_Top ||
-        fthora === Fthora.HardChromaticPa_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Pa;
-      }
-
-      this.updateNote(element, { fthora, chromaticFthoraNote });
-      this.save();
-    },
-
-    updateNoteFthoraSecondary(
-      element: NoteElement,
-      secondaryFthora: Fthora | null,
-    ) {
-      let secondaryChromaticFthoraNote: ScaleNote | null = null;
-
-      if (secondaryFthora === Fthora.SoftChromaticThi_TopSecondary) {
-        secondaryChromaticFthoraNote = ScaleNote.Thi;
-      } else if (secondaryFthora === Fthora.SoftChromaticPa_TopSecondary) {
-        secondaryChromaticFthoraNote = ScaleNote.Ga;
-      } else if (secondaryFthora === Fthora.HardChromaticThi_TopSecondary) {
-        secondaryChromaticFthoraNote = ScaleNote.Thi;
-      } else if (secondaryFthora === Fthora.HardChromaticPa_TopSecondary) {
-        secondaryChromaticFthoraNote = ScaleNote.Pa;
-      }
-
-      this.updateNote(element, {
-        secondaryFthora,
-        secondaryChromaticFthoraNote,
-      });
-      this.save();
-    },
-
-    updateNoteFthoraTertiary(
-      element: NoteElement,
-      tertiaryFthora: Fthora | null,
-    ) {
-      let tertiaryChromaticFthoraNote: ScaleNote | null = null;
-
-      if (tertiaryFthora === Fthora.SoftChromaticThi_TopTertiary) {
-        tertiaryChromaticFthoraNote = ScaleNote.Thi;
-      } else if (tertiaryFthora === Fthora.SoftChromaticPa_TopTertiary) {
-        tertiaryChromaticFthoraNote = ScaleNote.Ga;
-      } else if (tertiaryFthora === Fthora.HardChromaticThi_TopTertiary) {
-        tertiaryChromaticFthoraNote = ScaleNote.Thi;
-      } else if (tertiaryFthora === Fthora.HardChromaticPa_TopTertiary) {
-        tertiaryChromaticFthoraNote = ScaleNote.Pa;
-      }
-
-      this.updateNote(element, { tertiaryFthora, tertiaryChromaticFthoraNote });
-      this.save();
-    },
-
-    updateNoteExpression(
-      element: NoteElement,
-      vocalExpressionNeume: VocalExpressionNeume | null,
-    ) {
-      // Replace the psifiston with a slanted psifiston if the previous neume
-      // contains a long heteron
-      if (vocalExpressionNeume === VocalExpressionNeume.Psifiston) {
-        const index = this.getElementIndex(element);
-
-        if (index > 0) {
-          const previousElement = this.elements[index - 1];
-
-          if (previousElement.elementType === ElementType.Note) {
-            const previousNote = previousElement as NoteElement;
-
+    } else {
+      if (currentElement.elementType === clipboardElement.elementType) {
+        switch (currentElement.elementType) {
+          case ElementType.Note:
             if (
-              previousNote.vocalExpressionNeume ===
-              VocalExpressionNeume.HeteronConnectingLong
+              !shallowEquals(
+                (currentElement as NoteElement).getClipboardProperties(
+                  includeLyrics,
+                ),
+                (clipboardElement as NoteElement).getClipboardProperties(
+                  includeLyrics,
+                ),
+              )
             ) {
-              vocalExpressionNeume = VocalExpressionNeume.PsifistonSlanted;
+              commands.push(
+                noteElementCommandFactory.create('update-properties', {
+                  target: currentElement as NoteElement,
+                  newValues: (
+                    clipboardElement as NoteElement
+                  ).getClipboardProperties(includeLyrics),
+                }),
+              );
             }
-          }
-        }
-      }
-
-      this.updateNote(element, { vocalExpressionNeume });
-      this.save();
-    },
-
-    updateLyricsLocked(locked: boolean) {
-      this.lyricsLocked = locked;
-      this.hasUnsavedChanges = true;
-    },
-
-    updateStaffLyrics(lyrics: string) {
-      this.lyrics = lyrics;
-      this.throttled.assignLyrics();
-      this.hasUnsavedChanges = true;
-    },
-
-    assignLyrics() {
-      const updateCommands: Command[] = [];
-
-      this.lyricService.assignLyrics(
-        this.lyrics,
-        this.elements,
-        this.rtl,
-        this.score.pageSetup.disableGreekMelismata,
-        (note, lyrics) => this.setLyrics(this.getElementIndex(note), lyrics),
-        (note, newValues) => {
-          note.updated = true;
-          updateCommands.push(
-            noteElementCommandFactory.create('update-properties', {
-              target: note,
-              newValues,
-            }),
-          );
-        },
-        (dropCap, token) => {
-          updateCommands.push(
-            dropCapCommandFactory.create('update-properties', {
-              target: dropCap,
-              newValues: { content: token },
-            }),
-          );
-        },
-      );
-
-      if (updateCommands.length > 0) {
-        this.commandService.executeAsBatch(updateCommands, this.lyricsLocked);
-        this.save();
-      }
-    },
-
-    assignAcceptsLyricsFromCurrentLyrics() {
-      const commands: Command[] = [];
-
-      this.lyricService.assignAcceptsLyricsFromCurrentLyrics(
-        this.elements,
-        this.score.pageSetup.disableGreekMelismata,
-        (note, acceptsLyrics) => {
-          commands.push(
-            noteElementCommandFactory.create('update-properties', {
-              target: note,
-              newValues: {
-                acceptsLyrics,
-              },
-            }),
-          );
-        },
-      );
-
-      if (commands.length > 0) {
-        this.commandService.executeAsBatch(commands);
-        this.refreshStaffLyrics();
-        this.save();
-      }
-    },
-
-    updateLyrics(
-      element: NoteElement,
-      lyrics: string,
-      clearMelisma: boolean = false,
-    ) {
-      const newValues = this.lyricService.getLyricUpdateValues(
-        element,
-        lyrics,
-        this.elements,
-        this.rtl,
-        (note, lyrics) => this.setLyrics(this.getElementIndex(note), lyrics),
-        clearMelisma,
-      );
-
-      if (newValues != null) {
-        this.commandService.execute(
-          noteElementCommandFactory.create('update-properties', {
-            target: element,
-            newValues,
-          }),
-        );
-        this.refreshStaffLyrics();
-        this.save();
-      }
-    },
-
-    refreshStaffLyrics() {
-      if (this.lyricsLocked) {
-        this.assignLyrics();
-      } else if (this.lyricManagerIsOpen) {
-        this.lyrics = this.lyricService.extractLyrics(
-          this.elements,
-          this.score.pageSetup.disableGreekMelismata,
-        );
-      }
-    },
-
-    updateAnnotation(
-      element: AnnotationElement,
-      newValues: Partial<AnnotationElement>,
-    ) {
-      this.commandService.execute(
-        annotationCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    removeAnnotation(
-      note: NoteElement,
-      annotation: AnnotationElement,
-      noHistory: boolean = false,
-    ) {
-      this.commandService.execute(
-        annotationCommandFactory.create('remove-from-collection', {
-          element: annotation,
-          collection: note.annotations,
-        }),
-        noHistory,
-      );
-
-      this.selectedWorkspace.selectedAnnotationElement = null;
-
-      this.save();
-    },
-
-    updateAlternateLine(
-      element: AlternateLineElement,
-      newValues: Partial<AlternateLineElement>,
-    ) {
-      this.commandService.execute(
-        alternateLineCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    removeAlternateLine(
-      note: NoteElement,
-      annotation: AlternateLineElement,
-      noHistory: boolean = false,
-    ) {
-      this.commandService.execute(
-        alternateLineCommandFactory.create('remove-from-collection', {
-          element: annotation,
-          collection: note.alternateLines,
-        }),
-        noHistory,
-      );
-
-      this.selectedWorkspace.selectedAlternateLineElement = null;
-
-      this.save();
-    },
-
-    updateRichTextBox(
-      element: RichTextBoxElement,
-      newValues: Partial<RichTextBoxElement>,
-    ) {
-      if (newValues.rtl != null) {
-        element.keyHelper++;
-      }
-
-      const heightProp: keyof RichTextBoxElement = 'height';
-
-      const noHistory =
-        Object.keys(newValues).length === 1 && heightProp in newValues;
-
-      this.commandService.execute(
-        richTextBoxCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-        noHistory,
-      );
-
-      const modeChangeProp: keyof RichTextBoxElement = 'modeChange';
-
-      if (modeChangeProp in newValues) {
-        this.refreshStaffLyrics();
-      }
-
-      this.save(!noHistory);
-    },
-
-    updateRichTextBoxHeight(element: RichTextBoxElement, height: number) {
-      // The height could be updated by many rich text box elements at once
-      // (e.g. if PageSetup changes) so we debounce the save.
-      element.height = height;
-      this.richTextBoxCalculationCount++;
-      this.saveDebounced(false);
-    },
-
-    updateTextBox(element: TextBoxElement, newValues: Partial<TextBoxElement>) {
-      const noHistory =
-        Object.keys(newValues).length === 1 && 'height' in newValues;
-
-      this.commandService.execute(
-        textBoxCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-        noHistory,
-      );
-
-      this.save(!noHistory);
-    },
-
-    updateTextBoxHeight(element: TextBoxElement, height: number) {
-      // The height could be updated by many text box elements at once
-      // (e.g. if PageSetup changes) so we debounce the save.
-      element.height = height;
-      this.textBoxCalculationCount++;
-      this.saveDebounced(false);
-    },
-
-    updateModeKey(element: ModeKeyElement, newValues: Partial<ModeKeyElement>) {
-      this.commandService.execute(
-        modeKeyCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    updateModeKeyTempo(element: ModeKeyElement, tempo: TempoSign | null) {
-      let bpm = element.bpm;
-
-      if (tempo != null) {
-        bpm =
-          this.editorPreferences.getDefaultTempo(tempo) ??
-          TempoElement.getDefaultBpm(tempo);
-      }
-
-      this.updateModeKey(element, { tempo, bpm });
-    },
-
-    updateModeKeyFromTemplate(
-      element: ModeKeyElement,
-      template: ModeKeyElement,
-    ) {
-      const {
-        templateId,
-        mode,
-        scale,
-        scaleNote,
-        fthora,
-        martyria,
-        fthoraAboveNote,
-        fthoraAboveNote2,
-        fthoraAboveQuantitativeNeumeRight,
-        note,
-        note2,
-        quantitativeNeumeAboveNote,
-        quantitativeNeumeAboveNote2,
-        quantitativeNeumeRight,
-      } = template;
-
-      const newValues = {
-        templateId,
-        mode,
-        scale,
-        scaleNote,
-        fthora,
-        martyria,
-        fthoraAboveNote,
-        fthoraAboveNote2,
-        fthoraAboveQuantitativeNeumeRight,
-        note,
-        note2,
-        quantitativeNeumeAboveNote,
-        quantitativeNeumeAboveNote2,
-        quantitativeNeumeRight,
-      };
-
-      this.updateModeKey(element, newValues);
-
-      this.save();
-    },
-
-    updateMartyria(
-      element: MartyriaElement,
-      newValues: Partial<MartyriaElement>,
-    ) {
-      this.commandService.execute(
-        martyriaCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    updateMartyriaFthora(element: MartyriaElement, fthora: Fthora | null) {
-      let chromaticFthoraNote: ScaleNote | null = null;
-
-      if (
-        fthora === Fthora.SoftChromaticThi_Top ||
-        fthora === Fthora.SoftChromaticThi_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Thi;
-      } else if (
-        fthora === Fthora.SoftChromaticPa_Top ||
-        fthora === Fthora.SoftChromaticPa_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Ga;
-      } else if (
-        fthora === Fthora.HardChromaticThi_Top ||
-        fthora === Fthora.HardChromaticThi_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Thi;
-      } else if (
-        fthora === Fthora.HardChromaticPa_Top ||
-        fthora === Fthora.HardChromaticPa_Bottom
-      ) {
-        chromaticFthoraNote = ScaleNote.Pa;
-      }
-
-      this.updateMartyria(element, { fthora, chromaticFthoraNote });
-    },
-
-    updateMartyriaTempoLeft(
-      element: MartyriaElement,
-      tempoLeft: TempoSign | null,
-    ) {
-      let bpm = element.bpm;
-
-      if (tempoLeft != null) {
-        bpm =
-          this.editorPreferences.getDefaultTempo(tempoLeft) ??
-          TempoElement.getDefaultBpm(tempoLeft);
-      }
-
-      this.updateMartyria(element, {
-        tempoLeft,
-        bpm,
-        tempo: null,
-        tempoRight: null,
-      });
-    },
-
-    updateMartyriaTempo(element: MartyriaElement, tempo: TempoSign | null) {
-      let bpm = element.bpm;
-
-      if (tempo != null) {
-        bpm =
-          this.editorPreferences.getDefaultTempo(tempo) ??
-          TempoElement.getDefaultBpm(tempo);
-      }
-
-      this.updateMartyria(element, {
-        tempo,
-        bpm,
-        tempoLeft: null,
-        tempoRight: null,
-      });
-    },
-
-    updateMartyriaTempoRight(
-      element: MartyriaElement,
-      tempoRight: TempoSign | null,
-    ) {
-      let bpm = element.bpm;
-
-      if (tempoRight != null) {
-        bpm =
-          this.editorPreferences.getDefaultTempo(tempoRight) ??
-          TempoElement.getDefaultBpm(tempoRight);
-      }
-
-      this.updateMartyria(element, {
-        tempoRight,
-        bpm,
-        tempoLeft: null,
-        tempo: null,
-      });
-    },
-
-    updateMartyriaBpm(element: MartyriaElement, bpm: number) {
-      this.updateMartyria(element, { bpm });
-      this.save();
-    },
-
-    updateMartyriaMeasureBar(
-      element: MartyriaElement,
-      {
-        measureBarLeft,
-        measureBarRight,
-      }: {
-        measureBarLeft: MeasureBar | null;
-        measureBarRight: MeasureBar | null;
-      },
-    ) {
-      this.updateMartyria(element, {
-        measureBarLeft,
-        measureBarRight,
-      });
-      this.save();
-    },
-
-    updateTempo(element: TempoElement, newValues: Partial<TempoElement>) {
-      this.commandService.execute(
-        tempoCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    updateDropCap(element: DropCapElement, newValues: Partial<DropCapElement>) {
-      this.commandService.execute(
-        dropCapCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    updateDropCapContent(element: DropCapElement, content: string) {
-      // Replace newlines. This should only happen if the user pastes
-      // text containing new lines.
-      const sanitizedContent = content.replace(/(?:\r\n|\r|\n)/g, ' ');
-      if (sanitizedContent !== content) {
-        content = sanitizedContent;
-
-        // Force the lyrics to re-render
-        element.keyHelper++;
-      }
-
-      if (content === '') {
-        const index = this.elements.indexOf(element);
-
-        if (index > -1) {
-          if (this.selectedElement === element) {
-            this.selectedElement = null;
-          }
-
-          this.removeScoreElement(element);
-        }
-      } else if (element.content !== content) {
-        this.commandService.execute(
-          dropCapCommandFactory.create('update-properties', {
-            target: element,
-            newValues: { content },
-          }),
-        );
-
-        this.refreshStaffLyrics();
-      }
-
-      this.save();
-    },
-
-    updateImageBox(
-      element: ImageBoxElement,
-      newValues: Partial<ImageBoxElement>,
-    ) {
-      this.commandService.execute(
-        imageBoxCommandFactory.create('update-properties', {
-          target: element,
-          newValues: newValues,
-        }),
-      );
-
-      this.save();
-    },
-
-    deleteSelectedElement() {
-      if (
-        this.selectedWorkspace.selectedAnnotationElement != null &&
-        this.selectedElement?.elementType === ElementType.Note
-      ) {
-        this.removeAnnotation(
-          this.selectedElement as NoteElement,
-          this.selectedWorkspace.selectedAnnotationElement,
-        );
-
-        return;
-      }
-
-      if (
-        this.selectedWorkspace.selectedAlternateLineElement != null &&
-        this.selectedElement?.elementType === ElementType.Note
-      ) {
-        this.removeAlternateLine(
-          this.selectedElement as NoteElement,
-          this.selectedWorkspace.selectedAlternateLineElement,
-        );
-
-        return;
-      }
-
-      if (
-        this.selectedElement != null &&
-        !this.isLastElement(this.selectedElement)
-      ) {
-        const index = this.selectedElementIndex;
-
-        this.removeScoreElement(this.selectedElement);
-
-        this.selectedElement = this.elements[index];
-
-        this.save();
-      } else if (this.selectionRange != null) {
-        const elementsToDelete = this.elements.filter(
-          (x) => x.elementType != ElementType.Empty && this.isSelected(x),
-        );
-
-        this.commandService.executeAsBatch(
-          elementsToDelete.map((element) =>
-            scoreElementCommandFactory.create('remove-from-collection', {
-              element,
-              collection: this.elements,
-            }),
-          ),
-        );
-
-        this.refreshStaffLyrics();
-
-        const start = Math.min(
-          this.selectionRange.start,
-          this.selectionRange.end,
-        );
-
-        this.selectedElement =
-          this.elements[Math.min(start, this.elements.length - 1)];
-
-        this.save();
-      }
-    },
-
-    deletePreviousElement() {
-      if (this.selectedWorkspace.selectedAlternateLineElement) {
-        const elements =
-          this.selectedWorkspace.selectedAlternateLineElement.elements;
-        this.removeScoreElement(elements[this.elements.length - 1], elements);
-
-        return;
-      }
-
-      if (
-        this.selectedElement &&
-        this.selectedElementIndex > 0 &&
-        navigableElements.includes(
-          this.elements[this.selectedElementIndex - 1].elementType,
-        )
-      ) {
-        this.removeScoreElement(this.elements[this.selectedElementIndex - 1]);
-
-        this.save();
-      }
-    },
-
-    updatePageSetup(pageSetup: PageSetup) {
-      const needToRecalcRichTextBoxes =
-        pageSetup.textBoxDefaultFontFamily !=
-          this.score.pageSetup.textBoxDefaultFontFamily ||
-        pageSetup.textBoxDefaultFontSize !=
-          this.score.pageSetup.textBoxDefaultFontSize;
-
-      const updateCommands: Command[] = [
-        pageSetupCommandFactory.create('update-properties', {
-          target: this.score.pageSetup,
-          newValues: pageSetup,
-        }),
-      ];
-
-      if (
-        pageSetup.richHeaderFooter &&
-        !this.score.pageSetup.richHeaderFooter
-      ) {
-        updateCommands.push(
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.default.elements,
-            element: this.createRichHeaderFooter('', 'Title', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.even.elements,
-            element: this.createRichHeaderFooter('$p', 'Title', ''),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.firstPage.elements,
-            element: this.createRichHeaderFooter('', 'Title', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.odd.elements,
-            element: this.createRichHeaderFooter('', 'Title', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.default.elements,
-            element: this.createRichHeaderFooter('', 'Footer', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.even.elements,
-            element: this.createRichHeaderFooter('$p', 'Footer', ''),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.firstPage.elements,
-            element: this.createRichHeaderFooter('', 'Footer', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.odd.elements,
-            element: this.createRichHeaderFooter('', 'Footer', '$p'),
-            replaceAtIndex: 0,
-          }),
-        );
-      } else if (
-        !pageSetup.richHeaderFooter &&
-        this.score.pageSetup.richHeaderFooter
-      ) {
-        updateCommands.push(
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.default.elements,
-            element: this.createRegularHeaderFooter('', 'Title', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.even.elements,
-            element: this.createRegularHeaderFooter('$p', 'Title', ''),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.firstPage.elements,
-            element: this.createRegularHeaderFooter('', 'Title', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.headers.odd.elements,
-            element: this.createRegularHeaderFooter('', 'Title', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.default.elements,
-            element: this.createRegularHeaderFooter('', 'Footer', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.even.elements,
-            element: this.createRegularHeaderFooter('$p', 'Footer', ''),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.firstPage.elements,
-            element: this.createRegularHeaderFooter('', 'Footer', '$p'),
-            replaceAtIndex: 0,
-          }),
-          scoreElementCommandFactory.create('replace-element-in-collection', {
-            collection: this.score.footers.odd.elements,
-            element: this.createRegularHeaderFooter('', 'Footer', '$p'),
-            replaceAtIndex: 0,
-          }),
-        );
-      }
-
-      this.commandService.executeAsBatch(updateCommands);
-
-      if (needToRecalcRichTextBoxes) {
-        this.recalculateRichTextBoxHeights();
-        this.recalculateTextBoxHeights();
-      }
-
-      this.save();
-    },
-
-    updatePageSetupUseOptionalDiatonicFthoras(
-      useOptionalDiatonicFthoras: boolean,
-    ) {
-      this.commandService.execute(
-        pageSetupCommandFactory.create('update-properties', {
-          target: this.score.pageSetup,
-          newValues: { useOptionalDiatonicFthoras },
-        }),
-      );
-
-      this.save();
-    },
-
-    createRegularHeaderFooter(left: string, center: string, right: string) {
-      const textbox = new TextBoxElement();
-      textbox.multipanel = true;
-      textbox.contentLeft = left;
-      textbox.contentCenter = center;
-      textbox.contentRight = right;
-      return textbox;
-    },
-
-    createRichHeaderFooter(left: string, center: string, right: string) {
-      const textbox = new RichTextBoxElement();
-      textbox.multipanel = true;
-      textbox.contentLeft = `${left}`;
-      textbox.contentCenter = `<p style="text-align:center;">${center}</p>`;
-      textbox.contentRight = `<p style="text-align:right;">${right}</p>`;
-      return textbox;
-    },
-
-    updateEntryMode(mode: EntryMode) {
-      this.entryMode = mode;
-    },
-
-    updateZoom(zoom: number) {
-      if (zoom < 0.5 || zoom > 5) {
-        if (this.ipcService.isShowMessageBoxSupported()) {
-          this.ipcService.showMessageBox({
-            type: 'error',
-            title: 'Range overflow',
-            message: this.$t(($) => $.toolbar.main.invalidZoom, {
-              ns: 'toolbar',
-            }),
-          });
-        } else {
-          alert(this.$t(($) => $.toolbar.main.invalidZoom, { ns: 'toolbar' }));
+            break;
+          case ElementType.Tempo:
+            if (
+              !shallowEquals(
+                (currentElement as TempoElement).getClipboardProperties(),
+                (clipboardElement as TempoElement).getClipboardProperties(),
+              )
+            ) {
+              commands.push(
+                tempoCommandFactory.create('update-properties', {
+                  target: currentElement as TempoElement,
+                  newValues: (
+                    clipboardElement as TempoElement
+                  ).getClipboardProperties(),
+                }),
+              );
+            }
+            break;
+          case ElementType.Martyria:
+            if (
+              !shallowEquals(
+                (currentElement as MartyriaElement).getClipboardProperties(),
+                (clipboardElement as MartyriaElement).getClipboardProperties(),
+              )
+            ) {
+              commands.push(
+                martyriaCommandFactory.create('update-properties', {
+                  target: currentElement as MartyriaElement,
+                  newValues: (
+                    clipboardElement as MartyriaElement
+                  ).getClipboardProperties(),
+                }),
+              );
+            }
+            break;
+          case ElementType.DropCap:
+            if (
+              !shallowEquals(
+                (currentElement as DropCapElement).getClipboardProperties(),
+                (clipboardElement as DropCapElement).getClipboardProperties(),
+              )
+            ) {
+              commands.push(
+                dropCapCommandFactory.create('update-properties', {
+                  target: currentElement as DropCapElement,
+                  newValues: (
+                    clipboardElement as DropCapElement
+                  ).getClipboardProperties(),
+                }),
+              );
+            }
+            break;
+          case ElementType.ModeKey:
+            if (
+              !shallowEquals(
+                (currentElement as ModeKeyElement).getClipboardProperties(),
+                (clipboardElement as ModeKeyElement).getClipboardProperties(),
+              )
+            ) {
+              commands.push(
+                modeKeyCommandFactory.create('update-properties', {
+                  target: currentElement as ModeKeyElement,
+                  newValues: (
+                    clipboardElement as ModeKeyElement
+                  ).getClipboardProperties(),
+                }),
+              );
+            }
+            break;
+          case ElementType.TextBox:
+            if (
+              !shallowEquals(
+                (currentElement as TextBoxElement).getClipboardProperties(),
+                (clipboardElement as TextBoxElement).getClipboardProperties(),
+              )
+            ) {
+              commands.push(
+                textBoxCommandFactory.create('update-properties', {
+                  target: currentElement as TextBoxElement,
+                  newValues: (
+                    clipboardElement as TextBoxElement
+                  ).getClipboardProperties(),
+                }),
+              );
+            }
+            break;
         }
       } else {
-        this.zoom = zoom;
-        this.zoomToFit = false;
-      }
-    },
-
-    updateZoomToFit(zoomToFit: boolean) {
-      this.zoomToFit = zoomToFit;
-
-      if (zoomToFit) {
-        this.performZoomToFit();
-      }
-    },
-
-    performZoomToFit() {
-      const pageBackgroundElement = this.$refs[
-        'page-background'
-      ] as HTMLElement;
-
-      const computedStyle = getComputedStyle(pageBackgroundElement);
-
-      const availableWidth =
-        pageBackgroundElement.clientWidth -
-        parseFloat(computedStyle.paddingLeft) -
-        parseFloat(computedStyle.paddingRight);
-
-      this.zoom = availableWidth / this.score.pageSetup.pageWidth;
-    },
-
-    playAudio() {
-      try {
-        if (this.audioService.state === AudioState.Stopped) {
-          this.playbackEvents = this.playbackService.computePlaybackSequence(
-            this.elements,
-            this.audioOptions,
-            this.score.pageSetup.chrysanthineAccidentals,
-          );
-
-          if (this.playbackEvents.length === 0) {
-            return;
-          }
-
-          const startAt = this.playbackEvents.find(
-            (x) => x.elementIndex >= this.selectedElementIndex,
-          );
-
-          this.audioService.play(
-            this.playbackEvents,
-            this.audioOptions,
-            startAt,
-          );
-
-          if (startAt) {
-            this.selectedWorkspace.playbackTime = startAt.absoluteTime;
-          }
-
-          this.startPlaybackClock();
-        } else {
-          this.pauseAudio();
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    },
-
-    stopAudio() {
-      try {
-        this.audioService.stop();
-
-        this.playbackEvents = [];
-
-        this.stopPlaybackClock();
-      } catch (error) {
-        console.error(error);
-      }
-    },
-
-    pauseAudio() {
-      try {
-        this.audioService.togglePause();
-
-        if (this.audioService.state === AudioState.Paused) {
-          this.audioElement = null;
-          this.stopPlaybackClock();
-        } else {
-          this.startPlaybackClock();
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    },
-
-    startPlaybackClock() {
-      this.stopPlaybackClock();
-
-      this.playbackTimeInterval = setInterval(() => {
-        this.selectedWorkspace.playbackTime += 0.1;
-      }, 100);
-    },
-
-    stopPlaybackClock() {
-      if (this.playbackTimeInterval != null) {
-        clearInterval(this.playbackTimeInterval);
-      }
-    },
-
-    playTestTone() {
-      try {
-        this.audioService.playTestTone(this.audioOptions.frequencyDi);
-      } catch (error) {
-        console.error(error);
-      }
-    },
-
-    updateAudioOptionsSpeed(speed: number) {
-      if (this.audioService.state === AudioState.Paused) {
-        this.stopAudio();
-      }
-
-      speed = Math.max(0.1, speed);
-      speed = Math.min(3, speed);
-      speed = +speed.toFixed(2);
-
-      this.selectedWorkspace.playbackBpm /= this.audioOptions.speed;
-      this.selectedWorkspace.playbackBpm *= speed;
-
-      this.audioOptions.speed = speed;
-
-      this.saveAudioOptions();
-    },
-
-    saveAudioOptions() {
-      localStorage.setItem(
-        'audioOptionsDefault',
-        JSON.stringify(this.audioOptions),
-      );
-    },
-
-    onAudioServiceEventPlay(event: PlaybackSequenceEvent) {
-      if (this.audioService.state === AudioState.Playing) {
-        this.selectedWorkspace.playbackTime = event.absoluteTime;
-        this.selectedWorkspace.playbackBpm = event.bpm;
-
-        this.audioElement = this.elements[event.elementIndex];
-
-        // Scroll the currently playing element into view
-        const lyrics = (
-          this.$refs[`lyrics-${event.elementIndex}`] as InstanceType<
-            typeof ContentEditable
-          >[]
-        )[0];
-
-        const neumeBox = (
-          this.$refs[`element-${event.elementIndex}`] as any[]
-        )[0];
-
-        if ((lyrics?.htmlElement as any)?.scrollIntoViewIfNeeded) {
-          (lyrics?.htmlElement as any).scrollIntoViewIfNeeded(false);
-        }
-
-        if (neumeBox?.scrollIntoViewIfNeeded) {
-          neumeBox.scrollIntoViewIfNeeded(false);
-        }
-      }
-    },
-
-    onAudioServiceStop() {
-      this.audioElement = null;
-
-      this.stopPlaybackClock();
-    },
-
-    recalculateRichTextBoxHeights() {
-      if (this.richTextBoxCalculation) {
-        this.richTextBoxCalculation = false;
-      }
-
-      nextTick(async () => {
-        const expectedCount = this.resizableRichTextBoxElements.length;
-        this.richTextBoxCalculationCount = 0;
-        this.richTextBoxCalculation = true;
-
-        const maxTries = 4 * 30; // 30 seconds
-        let tries = 1;
-        let lastCount = 0;
-
-        // Wait until all rich text boxes have updated
-        const poll = (resolve: (value: unknown) => void) => {
-          if (
-            this.richTextBoxCalculationCount === expectedCount ||
-            tries >= maxTries ||
-            this.richTextBoxCalculationCount < lastCount
-          ) {
-            resolve(true);
-          } else {
-            tries++;
-            lastCount = this.richTextBoxCalculationCount;
-            setTimeout(() => poll(resolve), 250);
-          }
-        };
-
-        await new Promise(poll);
-
-        this.richTextBoxCalculation = false;
-        this.saveDebounced(false);
-      });
-    },
-
-    recalculateTextBoxHeights() {
-      if (this.textBoxCalculation) {
-        this.textBoxCalculation = false;
-      }
-
-      nextTick(async () => {
-        const expectedCount = this.resizableTextBoxElements.length;
-        this.textBoxCalculationCount = 0;
-        this.textBoxCalculation = true;
-
-        const maxTries = 4 * 30; // 30 seconds
-        let tries = 1;
-        let lastCount = 0;
-
-        // Wait until all text boxes have updated
-        const poll = (resolve: (value: unknown) => void) => {
-          if (
-            this.textBoxCalculationCount === expectedCount ||
-            tries >= maxTries ||
-            this.textBoxCalculationCount < lastCount
-          ) {
-            resolve(true);
-          } else {
-            tries++;
-            lastCount = this.textBoxCalculationCount;
-            setTimeout(() => poll(resolve), 250);
-          }
-        };
-
-        await new Promise(poll);
-
-        this.textBoxCalculation = false;
-        this.saveDebounced(false);
-      });
-    },
-
-    onFileMenuNewScore() {
-      const workspace = new Workspace();
-      workspace.tempFileName = this.getTempFilename();
-      workspace.score = this.createDefaultScore();
-
-      this.addWorkspace(workspace);
-
-      this.selectedWorkspace = workspace;
-
-      this.selectedElement =
-        this.score.staff.elements[this.score.staff.elements.length - 1];
-      this.save(false);
-    },
-
-    async onFileMenuOpenScore(args: FileMenuOpenScoreArgs) {
-      if (!this.dialogOpen && args.success) {
-        this.openScore(args);
-      }
-    },
-
-    onFileMenuImportOcr(args: FileMenuImportOcrArgs) {
-      if (!this.dialogOpen && args.success) {
-        try {
-          const elements = this.ocrImporter.import(args.data);
-
-          const workspace = new Workspace();
-          workspace.tempFileName = this.getTempFilename();
-          workspace.score = new Score();
-
-          this.addWorkspace(workspace);
-
-          this.selectedWorkspace = workspace;
-
-          this.currentFilePath = null;
-          this.score.staff.elements.unshift(...elements);
-
-          this.save();
-        } catch (error) {
-          console.error(error);
-
-          if (error instanceof Error) {
-            if (this.ipcService.isShowMessageBoxSupported()) {
-              this.ipcService.showMessageBox({
-                type: 'error',
-                title: 'OCR import failed',
-                message: error.message,
-              });
-            } else {
-              alert(error.message);
-            }
-          }
-        }
-      }
-    },
-
-    onFileMenuPageSetup() {
-      this.pageSetupDialogIsOpen = true;
-    },
-
-    async onFileMenuPrint() {
-      this.printMode = true;
-
-      // Blur the active element so that focus outlines and
-      // blinking cursors don't show up in the printed page
-      const activeElement = this.blurActiveElement();
-
-      const previousTitle = window.document.title;
-      window.document.title = this.getFileName(this.selectedWorkspace, false);
-
-      nextTick(async () => {
-        await this.ipcService.printWorkspace(this.selectedWorkspace);
-        this.printMode = false;
-        window.document.title = previousTitle;
-
-        // Re-focus the active element
-        this.focusElement(activeElement);
-      });
-    },
-
-    async onFileMenuExportAsPdf() {
-      this.printMode = true;
-
-      // Blur the active element so that focus outlines and
-      // blinking cursors don't show up in the printed page
-      const activeElement = this.blurActiveElement();
-
-      const previousTitle = window.document.title;
-      window.document.title = this.getFileName(this.selectedWorkspace, false);
-
-      await nextTick();
-      await this.ipcService.exportWorkspaceAsPdf(this.selectedWorkspace);
-      this.printMode = false;
-      window.document.title = previousTitle;
-
-      // Re-focus the active element
-      this.focusElement(activeElement);
-    },
-
-    async onFileMenuExportAsImage() {
-      this.exportFormat = ExportFormat.PNG;
-      this.exportDialogIsOpen = true;
-    },
-
-    async exportAsPng(args: ExportAsPngSettings) {
-      let reply: ExportWorkspaceAsImageReplyArgs;
-
-      try {
-        reply = await this.ipcService.exportWorkspaceAsImage(
-          this.selectedWorkspace,
-          'png',
+        commands.push(
+          scoreElementCommandFactory.create('replace-element-in-collection', {
+            element: clipboardElement.clone(),
+            collection: elements.value,
+            replaceAtIndex: currentIndex,
+          }),
         );
-
-        if (!reply.success) {
-          return;
-        }
-      } catch (error) {
-        console.error(error);
-        return;
       }
+    }
 
-      this.printMode = true;
-      this.exportInProgress = true;
+    currentIndex++;
+  }
 
-      // Blur the active element so that focus outlines and
-      // blinking cursors don't show up in the printed page
-      const activeElement = this.blurActiveElement();
+  if (commands.length > 1) {
+    commandService.value.executeAsBatch(commands);
+    refreshStaffLyrics();
+  } else if (commands.length === 1) {
+    commandService.value.execute(commands[0]);
+    refreshStaffLyrics();
+  }
 
-      nextTick(async () => {
+  save();
+}
+
+function onPasteScoreElementsAuto(includeLyrics: boolean) {
+  moveRight();
+  const currentIndex = selectedElementIndex.value;
+
+  onPasteScoreElementsEdit(includeLyrics);
+
+  // Set the selected element to the last element that was pasted
+  selectedElement.value =
+    elements.value[currentIndex + clipboard.value.length - 1];
+}
+
+function getLyricLength(element: NoteElement) {
+  return getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+    `lyrics-${elements.value.indexOf(element)}`,
+  )[0].getInnerText().length;
+}
+
+function moveLeft() {
+  let index = -1;
+
+  if (selectedElement.value) {
+    index = elements.value.indexOf(selectedElement.value);
+  } else if (selectionRange.value) {
+    index = selectionRange.value.end;
+  }
+
+  if (
+    index - 1 >= 0 &&
+    navigableElements.includes(elements.value[index - 1].elementType)
+  ) {
+    // If the currently selected element is a drop cap or text box, blur it first
+    if (selectedElement.value?.elementType === ElementType.DropCap) {
+      getTemplateRef<InstanceType<typeof DropCap>[]>(
+        `element-${index}`,
+      )[0].blur();
+    } else if (selectedElement.value?.elementType === ElementType.TextBox) {
+      getTemplateRef<InstanceType<typeof TextBox>[]>(
+        `element-${index}`,
+      )[0].blur();
+    }
+
+    selectedElement.value = elements.value[index - 1];
+
+    // If the newly selected element is a drop cap or text box, focus it
+    if (selectedElement.value.elementType === ElementType.DropCap) {
+      getTemplateRef<InstanceType<typeof DropCap>[]>(
+        `element-${index - 1}`,
+      )[0].focus();
+    } else if (selectedElement.value.elementType === ElementType.TextBox) {
+      getTemplateRef<InstanceType<typeof TextBox>[]>(
+        `element-${index - 1}`,
+      )[0].focus();
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+function moveRight() {
+  let index = -1;
+
+  if (selectedElement.value) {
+    index = elements.value.indexOf(selectedElement.value);
+  } else if (selectionRange.value) {
+    index = selectionRange.value.end;
+  }
+
+  if (
+    index >= 0 &&
+    index + 1 < elements.value.length &&
+    navigableElements.includes(elements.value[index + 1].elementType)
+  ) {
+    // If the currently selected element is a drop cap, blur it first
+    if (selectedElement.value?.elementType === ElementType.DropCap) {
+      getTemplateRef<InstanceType<typeof DropCap>[]>(
+        `element-${index}`,
+      )[0].blur();
+    } else if (selectedElement.value?.elementType === ElementType.TextBox) {
+      getTemplateRef<InstanceType<typeof TextBox>[]>(
+        `element-${index}`,
+      )[0].blur();
+    }
+
+    selectedElement.value = elements.value[index + 1];
+
+    // If the newly selected element is a drop cap, focus it
+    if (selectedElement.value.elementType === ElementType.DropCap) {
+      getTemplateRef<InstanceType<typeof DropCap>[]>(
+        `element-${index + 1}`,
+      )[0].focus();
+    } else if (selectedElement.value.elementType === ElementType.TextBox) {
+      getTemplateRef<InstanceType<typeof TextBox>[]>(
+        `element-${index + 1}`,
+      )[0].focus();
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+function moveSelectionLeft() {
+  if (selectionRange.value != null) {
+    if (
+      selectionRange.value.end > 0 &&
+      navigableElements.includes(
+        elements.value[selectionRange.value.end - 1].elementType,
+      )
+    ) {
+      setSelectionRange(elements.value[selectionRange.value.end - 1]);
+    }
+  } else if (
+    selectedElement.value != null &&
+    selectedElementIndex.value > 0 &&
+    navigableElements.includes(
+      elements.value[selectedElementIndex.value - 1].elementType,
+    )
+  ) {
+    setSelectionRange(elements.value[selectedElementIndex.value - 1]);
+  }
+}
+
+function moveSelectionRight() {
+  if (selectionRange.value != null) {
+    if (
+      selectionRange.value.end + 1 < elements.value.length - 1 &&
+      navigableElements.includes(
+        elements.value[selectionRange.value.end + 1].elementType,
+      )
+    ) {
+      setSelectionRange(elements.value[selectionRange.value.end + 1]);
+    }
+  } else if (
+    selectedElement.value != null &&
+    selectedElementIndex.value + 1 < elements.value.length - 1 &&
+    navigableElements.includes(
+      elements.value[selectedElementIndex.value + 1].elementType,
+    )
+  ) {
+    setSelectionRange(elements.value[selectedElementIndex.value + 1]);
+  }
+}
+
+function getNextLyricBoxIndex() {
+  if (selectedLyrics.value) {
+    const currentIndex = elements.value.indexOf(selectedLyrics.value);
+
+    // Find the index of the next note
+    for (let i = currentIndex + 1; i < elements.value.length; i++) {
+      if (elements.value[i].elementType === ElementType.Note) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function moveToNextLyricBox(clearMelisma: boolean = false) {
+  const nextIndex = getNextLyricBoxIndex();
+
+  if (nextIndex >= 0) {
+    // If the lyrics for the last neume on the line have been updated to be so long
+    // that the neume is moved to the next line by processPages(), then focusLyrics()
+    // will fail if called on its own. This is because the order of events would
+    // be the following:
+    // focus next element => blur previous element => updateLyrics => processPages
+    // and finally the newly selected element would lose focus because processPages
+    // moves the element to the next line.
+
+    // To prevent this we, preemptively call updateLyrics and then use nextTick
+    // to only focus the next lyrics after the UI has been redrawn.
+
+    const noteElement = selectedLyrics.value!;
+
+    const text = getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+      `lyrics-${elements.value.indexOf(noteElement)}`,
+    )[0].getInnerText();
+
+    updateLyrics(noteElement, text, clearMelisma);
+
+    nextTick(() => {
+      focusLyrics(nextIndex, true);
+    });
+
+    return true;
+  }
+
+  return false;
+}
+
+function moveToPreviousLyricBox() {
+  if (selectedLyrics.value) {
+    const currentIndex = elements.value.indexOf(selectedLyrics.value);
+    let nextIndex = -1;
+
+    // Find the index of the previous note
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      if (elements.value[i].elementType === ElementType.Note) {
+        nextIndex = i;
+        break;
+      }
+    }
+
+    if (nextIndex >= 0) {
+      focusLyrics(nextIndex, true);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function calculatePageNumber() {
+  let maxPercentage = 0;
+  let maxPercentageIndex = -1;
+
+  const viewportHeight =
+    window.innerHeight || document.documentElement.clientHeight;
+
+  for (let pageIndex = 0; pageIndex < pageCount.value; pageIndex++) {
+    const rect = (pagesRef.value as Element[])[
+      pageIndex
+    ].getBoundingClientRect();
+
+    const percentage =
+      Math.max(
+        0,
+        rect.top > 0
+          ? Math.min(rect.height, viewportHeight - rect.top)
+          : rect.bottom < viewportHeight
+            ? rect.bottom
+            : viewportHeight,
+      ) / rect.height;
+
+    if (percentage > maxPercentage) {
+      maxPercentage = percentage;
+      maxPercentageIndex = pageIndex;
+    }
+  }
+
+  if (maxPercentageIndex >= 0) {
+    currentPageNumber.value = maxPercentageIndex + 1;
+  }
+}
+
+function save(markUnsavedChanges: boolean = true) {
+  if (markUnsavedChanges) {
+    hasUnsavedChanges.value = true;
+  }
+
+  // Save the indexes of the visible pages
+  const visiblePages = pages.value
+    .map((_, i) => i)
+    .filter((i) => pages.value[i].isVisible);
+
+  const processedPages = LayoutService.processPages(
+    toRaw(selectedWorkspace.value),
+  );
+
+  // Set page visibility for the newly processed pages
+  processedPages.forEach(
+    (x, index) => (x.isVisible = visiblePages.includes(index)),
+  );
+
+  // Only re-render elements that are visible and that have been updated by processPages
+  processedPages
+    .filter((x) => x.isVisible)
+    .forEach((page) => {
+      page.lines.forEach((line) =>
+        line.elements
+          .filter((x) => x.updated)
+          .forEach((element) => {
+            element.keyHelper++;
+          }),
+      );
+    });
+
+  // Re-render headers and footers if they changed
+  score.value.headersAndFooters
+    .filter((x) => x.updated)
+    .forEach((element) => {
+      element.keyHelper++;
+    });
+
+  pages.value = processedPages;
+
+  // If using the browser, save the workspace to local storage
+  if (isBrowser.value) {
+    const workspaceLocalStorage = {
+      id: selectedWorkspace.value.id,
+      score: JSON.stringify(SaveService.SaveScoreToJson(score.value)),
+      filePath: currentFilePath.value,
+      tempFileName: selectedWorkspace.value.tempFileName,
+      hasUnsavedChanges: hasUnsavedChanges.value,
+    } as WorkspaceLocalStorage;
+
+    localStorage.setItem(
+      `workspace-${selectedWorkspace.value.id}`,
+      JSON.stringify(workspaceLocalStorage),
+    );
+  } else if (isDevelopment.value) {
+    localStorage.setItem(
+      'score',
+      JSON.stringify(SaveService.SaveScoreToJson(score.value)),
+    );
+
+    if (currentFilePath.value != null) {
+      localStorage.setItem('filePath', currentFilePath.value);
+    } else {
+      localStorage.removeItem('filePath');
+    }
+
+    localStorage.setItem(
+      'hasUnsavedChanges',
+      hasUnsavedChanges.value.toString(),
+    );
+  }
+}
+
+async function load() {
+  if (isBrowser.value) {
+    Object.keys(localStorage).forEach((key) => {
+      if (key.startsWith('workspace-')) {
         try {
-          const pages = this.$refs.pages as HTMLElement[];
+          const localStorageWorkspace: WorkspaceLocalStorage = JSON.parse(
+            localStorage.getItem(key)!,
+          );
+          const workspace = new Workspace();
+          workspace.id = localStorageWorkspace.id;
+          workspace.hasUnsavedChanges = localStorageWorkspace.hasUnsavedChanges;
+          workspace.filePath = localStorageWorkspace.filePath;
+          workspace.tempFileName = localStorageWorkspace.tempFileName;
+          workspace.score = SaveService.LoadScoreFromJson(
+            JSON.parse(localStorageWorkspace.score),
+          );
 
-          if (pages.length > 0) {
-            const fontEmbedCSS = await getFontEmbedCSS(pages[0]);
-
-            let pageNumber = 1;
-
-            for (const page of pages) {
-              const options = {
-                fontEmbedCSS,
-                pixelRatio: args.dpi / 96,
-                style: { margin: '0' },
-              } as any;
-
-              if (args.transparentBackground) {
-                options.style.backgroundColor = 'transparent';
-              }
-
-              let data = await toPng(page, options);
-
-              if (data != null) {
-                const fileName = reply.filePath.replace(
-                  /\.png$/,
-                  `-${pageNumber++}.png`,
-                );
-
-                data = data.replace(/^data:image\/png;base64,/, '');
-
-                if (
-                  !(await this.ipcService.exportPageAsImage(fileName, data))
-                ) {
-                  break;
-                }
-              }
-            }
-          }
-
-          if (args.openFolder) {
-            await this.ipcService.showItemInFolder(
-              reply.filePath.replace(/\.png$/, '-1.png'),
-            );
-          }
+          addWorkspace(workspace);
         } catch (error) {
+          // We couldn't load this workspace for some reason. Remove it from storage.
+          localStorage.removeItem(key);
           console.error(error);
-        } finally {
-          this.printMode = false;
-          this.exportInProgress = false;
-          this.closeExportDialog();
-          // Re-focus the active element
-          this.focusElement(activeElement);
         }
-      });
-    },
+      }
+    });
 
-    // async exportAsSvg(openFolder: boolean) {
-    //   let reply: ExportWorkspaceAsImageReplyArgs;
+    if (workspaces.value.length > 0) {
+      selectedWorkspace.value = workspaces.value[0] as Workspace;
+      return;
+    }
+  }
 
-    //   try {
-    //     reply = await this.ipcService.exportWorkspaceAsImage(
-    //       this.selectedWorkspace,
-    //       'svg',
-    //     );
+  // First, try to load files passed in on the command line.
+  // If there are none, then create a default workspace.
+  const openWorkspaceResults = await ipcService.openWorkspaceFromArgv();
 
-    //     if (!reply.success) {
-    //       return;
-    //     }
-    //   } catch (error) {
-    //     console.error(error);
-    //     return;
-    //   }
+  if (openWorkspaceResults.silentPdf) {
+    for (const file of openWorkspaceResults.files.filter((x) => x.success)) {
+      openScore(file);
+      await onFileMenuExportAsPdf();
+      removeWorkspace(selectedWorkspace.value);
+    }
+  }
 
-    //   this.printMode = true;
-    //   this.exportInProgress = true;
+  if (openWorkspaceResults.silentHtml) {
+    for (const file of openWorkspaceResults.files.filter((x) => x.success)) {
+      openScore(file);
+      await onFileMenuExportAsHtml();
+      removeWorkspace(selectedWorkspace.value);
+    }
+  }
 
-    //   // Blur the active element so that focus outlines and
-    //   // blinking cursors don't show up in the printed page
-    //   const activeElement = this.blurActiveElement();
-
-    //   nextTick(async () => {
-    //     try {
-    //       const pages = this.$refs.pages as HTMLElement[];
-
-    //       if (pages.length > 0) {
-    //         const fontEmbedCSS = await getFontEmbedCSS(pages[0]);
-
-    //         let pageNumber = 1;
-
-    //         for (let page of pages) {
-    //           const data = await toSvg(page, {
-    //             fontEmbedCSS,
-    //           });
-
-    //           if (data != null) {
-    //             const fileName = reply.filePath.replace(
-    //               /.svg$/,
-    //               `-${pageNumber++}.svg`,
-    //             );
-
-    //             if (!(await this.ipcService.exportPageAsImage(fileName, data))) {
-    //               break;
-    //             }
-    //           }
-    //         }
-    //       }
-
-    //       if (openFolder) {
-    //         await this.ipcService.showItemInFolder(
-    //           reply.filePath.replace(/\.svg$/, '-1.svg'),
-    //         );
-    //       }
-    //     } catch (error) {
-    //       console.error(error);
-    //     } finally {
-    //       this.printMode = false;
-    //       this.exportInProgress = false;
-    //       this.closeExportDialog();
-    //       // Re-focus the active element
-    //       this.focusElement(activeElement);
-    //     }
-    //   });
-    // }
-
-    async onFileMenuExportAsHtml() {
-      await this.ipcService.exportWorkspaceAsHtml(
-        this.selectedWorkspace,
-        this.byzHtmlExporter.exportScore(this.score),
-      );
-    },
-
-    onFileMenuExportAsMusicXml() {
-      this.exportFormat = ExportFormat.MusicXml;
-      this.exportDialogIsOpen = true;
-    },
-
-    onFileMenuExportAsLatex() {
-      this.exportFormat = ExportFormat.Latex;
-      this.exportDialogIsOpen = true;
-    },
-
-    async exportAsMusicXml(args: ExportAsMusicXmlSettings) {
-      await this.ipcService.exportWorkspaceAsMusicXml(
-        this.selectedWorkspace,
-        this.musicXmlExporter.export(this.score, args.options),
-        args.compressed,
-        args.openFolder,
-      );
-
-      this.closeExportDialog();
-    },
-
-    async exportAsLatex(args: ExportAsLatexSettings) {
-      await this.ipcService.exportWorkspaceAsLatex(
-        this.selectedWorkspace,
+  if (openWorkspaceResults.silentLatex) {
+    for (const file of openWorkspaceResults.files.filter((x) => x.success)) {
+      const options = new LatexExporterOptions();
+      options.includeModeKeys =
+        openWorkspaceResults.silentLatexIncludeModeKeys ?? false;
+      options.includeTextBoxes =
+        openWorkspaceResults.silentLatexIncludeTextBoxes ?? false;
+      openScore(file);
+      await ipcService.exportWorkspaceAsLatex(
+        selectedWorkspace.value,
         JSON.stringify(
-          this.latexExporter.export(
-            this.pages,
-            this.score.pageSetup,
-            args.options,
-          ),
+          latexExporter.export(pages.value, score.value.pageSetup, options),
           null,
           2,
         ),
       );
+      removeWorkspace(selectedWorkspace.value);
+    }
+  }
 
-      this.closeExportDialog();
-    },
+  if (
+    openWorkspaceResults.silentPdf ||
+    openWorkspaceResults.silentLatex ||
+    openWorkspaceResults.silentHtml
+  ) {
+    await ipcService.exitApplication();
+  }
 
-    blurActiveElement() {
-      const activeElement = document.activeElement;
+  openWorkspaceResults.files
+    .filter((x) => x.success)
+    .forEach((x) => openScore(x));
 
-      if (activeElement instanceof HTMLElement) {
-        activeElement.blur();
-      }
+  if (openWorkspaceResults.files.some((x) => x.success)) {
+    return;
+  }
 
-      return activeElement;
-    },
+  const workspace = new Workspace();
+  workspace.tempFileName = getTempFilename();
+  workspace.score = createDefaultScore();
 
-    focusElement(element: Element | null) {
-      if (element instanceof HTMLElement) {
-        element.focus();
-      }
-    },
+  addWorkspace(workspace);
 
-    onFileMenuInsertAnnotation() {
-      if (this.selectedElement?.elementType === ElementType.Note) {
-        const el = new AnnotationElement();
-        const fontHeight = TextMeasurementService.getFontHeight(
-          this.score.pageSetup.lyricsFont,
-        );
-        el.x = 0;
-        el.y = -fontHeight;
-        (this.selectedElement as NoteElement).annotations.push(el);
-        this.selectedWorkspace.selectedAnnotationElement = el;
-        this.save();
-      }
-    },
+  if (isDevelopment.value) {
+    const scoreString = localStorage.getItem('score');
 
-    onFileMenuInsertAlternateLine() {
-      if (this.selectedElement?.elementType === ElementType.Note) {
-        const el = new AlternateLineElement();
-        const fontHeight = TextMeasurementService.getFontHeight(
-          this.score.pageSetup.lyricsFont,
-        );
-        el.x = 0;
-        el.y = -fontHeight;
-        (this.selectedElement as NoteElement).alternateLines.push(el);
-        this.selectedWorkspace.selectedAlternateLineElement = el;
-        this.save();
-      }
-    },
+    if (scoreString) {
+      const score: Score = SaveService.LoadScoreFromJson(
+        JSON.parse(scoreString),
+      );
+      currentFilePath.value = localStorage.getItem('filePath');
+      hasUnsavedChanges.value =
+        localStorage.getItem('hasUnsavedChanges') === 'true';
 
-    onFileMenuInsertTextBox(args?: FileMenuInsertTextboxArgs) {
-      const element = new TextBoxElement();
-      element.inline = args?.inline ?? false;
+      workspace.score = score;
+    }
+  }
 
-      if (element.inline) {
-        element.color = this.score.pageSetup.lyricsDefaultColor;
-        element.fontFamily = this.score.pageSetup.lyricsDefaultFontFamily;
-        element.fontSize = this.score.pageSetup.lyricsDefaultFontSize;
-        element.strokeWidth = this.score.pageSetup.lyricsDefaultStrokeWidth;
-        element.bold = this.score.pageSetup.lyricsDefaultFontWeight === '700';
-        element.italic =
-          this.score.pageSetup.lyricsDefaultFontStyle === 'italic';
-      } else {
-        element.color = this.score.pageSetup.textBoxDefaultColor;
-        element.fontFamily = this.score.pageSetup.textBoxDefaultFontFamily;
-        element.fontSize = this.score.pageSetup.textBoxDefaultFontSize;
-        element.strokeWidth = this.score.pageSetup.textBoxDefaultStrokeWidth;
-        element.lineHeight = this.score.pageSetup.textBoxDefaultLineHeight;
-        element.bold = this.score.pageSetup.textBoxDefaultFontWeight === '700';
-        element.italic =
-          this.score.pageSetup.textBoxDefaultFontStyle === 'italic';
-      }
+  selectedWorkspace.value = workspace;
 
-      this.addScoreElement(element, this.selectedElementIndex);
+  selectedElement.value =
+    score.value.staff.elements[score.value.staff.elements.length - 1];
 
-      this.selectedElement = element;
+  pages.value = LayoutService.processPages(selectedWorkspace.value);
+}
 
-      this.save();
+async function saveWorkspace(workspace: Workspace) {
+  if (!lyricsLocked.value) {
+    lyrics.value = lyricService.extractLyrics(
+      elements.value,
+      score.value.pageSetup.disableGreekMelismata,
+    );
+  }
 
-      nextTick(() => {
-        const index = this.elements.indexOf(element);
+  return await ipcService.saveWorkspace(workspace);
+}
 
-        (this.$refs[`element-${index}`] as any)[0].focus();
+async function saveWorkspaceAs(workspace: Workspace) {
+  if (!lyricsLocked.value) {
+    lyrics.value = lyricService.extractLyrics(
+      elements.value,
+      score.value.pageSetup.disableGreekMelismata,
+    );
+  }
+
+  return await ipcService.saveWorkspaceAs(workspace);
+}
+
+async function closeWorkspace(workspace: Workspace) {
+  let shouldClose = true;
+
+  if (workspace.hasUnsavedChanges) {
+    const fileName =
+      workspace.filePath != null
+        ? getFileNameFromPath(workspace.filePath)
+        : workspace.tempFileName;
+
+    let dialogResult: ShowMessageBoxReplyArgs;
+
+    if (ipcService.isShowMessageBoxSupported()) {
+      dialogResult = await ipcService.showMessageBox({
+        title: import.meta.env.VITE_TITLE,
+        message: `Do you want to save the changes you made to ${fileName}?`,
+        detail: "Your changes will be lost if you don't save them.",
+        type: 'warning',
+        buttons: ['Save', "Don't Save", 'Cancel'],
       });
+    } else {
+      dialogResult = {
+        response: confirm(
+          `${fileName} has unsaved changes. Are you sure you want to close it?`,
+        )
+          ? 1
+          : 2,
+        checkboxChecked: false,
+      };
+    }
+
+    if (dialogResult.response === 0) {
+      // User chose "Save"
+      const saveResult =
+        workspace.filePath != null
+          ? await saveWorkspace(workspace)
+          : await saveWorkspaceAs(workspace);
+
+      // If they successfully saved, then we can close the workspacce
+      shouldClose = saveResult.success;
+    } else if (dialogResult.response === 2) {
+      // User chose "Cancel", so don't close the workspace.
+      shouldClose = false;
+    }
+  }
+
+  if (shouldClose) {
+    // If using the browser, remove the item from local storage
+    if (isBrowser.value) {
+      localStorage.removeItem(`workspace-${workspace.id}`);
+    }
+
+    // If the last tab has closed, then exit
+    if (workspaces.value.length == 1) {
+      await ipcService.exitApplication();
+    }
+
+    removeWorkspace(workspace);
+  }
+
+  return shouldClose;
+}
+
+async function onCloseWorkspaces(args: CloseWorkspacesArgs) {
+  const workspacesToClose: Workspace[] = workspaces.value.filter(
+    (workspace) => {
+      const index: number = tabs.value.findIndex((x) => x.key === workspace.id);
+
+      const pivot: number = args.workspaceId
+        ? tabs.value.findIndex((x) => x.key === args.workspaceId)
+        : tabs.value.findIndex((x) => x.key === selectedWorkspace.value.id);
+
+      switch (args.disposition) {
+        case CloseWorkspacesDisposition.SELF:
+          return index === pivot;
+        case CloseWorkspacesDisposition.OTHERS:
+          return index !== pivot;
+        case CloseWorkspacesDisposition.LEFT:
+          return index < pivot;
+        case CloseWorkspacesDisposition.RIGHT:
+          return index > pivot;
+        default:
+          throw new Error(`Error: Unknown disposition ${args.disposition}.`);
+      }
     },
+  ) as Workspace[];
 
-    onFileMenuInsertRichTextBox() {
-      const element = new RichTextBoxElement();
-      element.rtl = this.score.pageSetup.melkiteRtl;
+  for (const workspaceToClose of workspacesToClose) {
+    if (!(await closeWorkspace(workspaceToClose))) {
+      // The user vetoed the operation.
+      break;
+    }
+  }
+}
 
-      this.addScoreElement(element, this.selectedElementIndex);
+async function onCloseApplication() {
+  // Give the user a chance to save their changes before exiting
+  const unsavedWorkspaces = workspaces.value.filter(
+    (x) => x.hasUnsavedChanges,
+  ) as Workspace[];
 
-      this.selectedElement = element;
+  for (const workspace of unsavedWorkspaces) {
+    if (!(await closeWorkspace(workspace))) {
+      await ipcService.cancelExit();
+      return false;
+    }
+  }
 
-      this.save();
+  await ipcService.exitApplication();
+}
 
-      nextTick(() => {
-        const index = this.elements.indexOf(element);
-
-        (this.$refs[`element-${index}`] as any)[0].focus();
+function setKlasma(element: NoteElement) {
+  if (onlyTakesBottomKlasma(element.quantitativeNeume)) {
+    if (element.timeNeume === TimeNeume.Klasma_Bottom) {
+      updateNoteAndSave(element, { timeNeume: null });
+    } else {
+      updateNoteAndSave(element, {
+        timeNeume: TimeNeume.Klasma_Bottom,
       });
-    },
+    }
+    return;
+  } else if (onlyTakesTopKlasma(element.quantitativeNeume)) {
+    if (element.timeNeume === TimeNeume.Klasma_Top) {
+      updateNoteAndSave(element, { timeNeume: null });
+    } else {
+      updateNoteAndSave(element, {
+        timeNeume: TimeNeume.Klasma_Top,
+      });
+    }
+    return;
+  } else if (element.timeNeume == null) {
+    updateNoteAndSave(element, {
+      timeNeume: TimeNeume.Klasma_Top,
+    });
+  } else if (element.timeNeume === TimeNeume.Klasma_Top) {
+    updateNoteAndSave(element, {
+      timeNeume: TimeNeume.Klasma_Bottom,
+    });
+  } else if (element.timeNeume === TimeNeume.Klasma_Bottom) {
+    updateNoteAndSave(element, { timeNeume: null });
+  }
+}
 
-    onFileMenuInsertModeKey() {
-      const element = this.createDefaultModeKey(this.score.pageSetup);
+function setGorgon(element: NoteElement, neumes: GorgonNeume | GorgonNeume[]) {
+  let equivalent = false;
 
-      this.addScoreElement(element, this.selectedElementIndex);
+  // Force neumes to be an array if it's not
+  neumes = Array.isArray(neumes) ? neumes : [neumes];
 
-      this.selectedElement = element;
+  for (const neume of neumes) {
+    if (
+      neume === GorgonNeume.Gorgon_Bottom &&
+      onlyTakesTopGorgon(element.quantitativeNeume)
+    ) {
+      continue;
+    }
 
-      this.openModeKeyDialog();
+    // If previous neume was matched, set to the next neume in the cycle
+    if (equivalent) {
+      updateNoteAndSave(element, { gorgonNeume: neume });
+      return;
+    }
 
-      this.save();
-    },
+    equivalent = element.gorgonNeume === neume;
+  }
 
-    onFileMenuInsertDropCapBefore() {
-      this.addDropCap(false);
-    },
+  // We've cycled through all the neumes.
+  // If we got to the end of the cycle, remove all
+  // gorgon neumes. Otherwise set gorgon to the first neume
+  // in the cycle.
+  if (equivalent) {
+    updateNoteAndSave(element, { gorgonNeume: null });
+  } else {
+    updateNoteAndSave(element, { gorgonNeume: neumes[0] });
+  }
+}
 
-    onFileMenuInsertDropCapAfter() {
-      this.addDropCap(true);
-    },
+function setSecondaryGorgon(element: NoteElement, neume: GorgonNeume) {
+  if (element.secondaryGorgonNeume === neume) {
+    updateNoteAndSave(element, { secondaryGorgonNeume: null });
+  } else {
+    updateNoteAndSave(element, { secondaryGorgonNeume: neume });
+  }
+}
 
-    onFileMenuInsertImage(args: FileMenuOpenImageArgs) {
-      const element = new ImageBoxElement();
+function setFthoraNote(element: NoteElement, neumes: Fthora[]) {
+  let equivalent = false;
 
-      element.data = args.data;
-      element.imageWidth = args.imageWidth;
-      element.imageHeight = args.imageHeight;
+  for (const neume of neumes) {
+    // If previous neume was matched, set to the next neume in the cycle
+    if (equivalent) {
+      updateNoteFthora(element, neume);
+      return;
+    }
 
-      this.addScoreElement(element, this.selectedElementIndex);
+    equivalent = element.fthora === neume;
+  }
 
-      this.selectedElement = element;
+  // We've cycled through all the neumes.
+  // If we got to the end of the cycle, remove all
+  // fthora neumes. Otherwise set fthora to the first neume
+  // in the cycle.
+  if (equivalent) {
+    updateNoteFthora(element, null);
+  } else {
+    updateNoteFthora(element, neumes[0]);
+  }
+}
 
-      this.save();
-    },
+function setSecondaryFthora(element: NoteElement, neume: Fthora) {
+  if (element.secondaryFthora === neume) {
+    updateNoteFthoraSecondary(element, null);
+  } else {
+    updateNoteFthoraSecondary(element, neume);
+  }
+}
 
-    onFileMenuInsertHeader() {
-      if (this.score.pageSetup.showHeader) {
-        return;
-      }
+function setTertiaryFthora(element: NoteElement, neume: Fthora) {
+  if (element.tertiaryFthora === neume) {
+    updateNoteFthoraTertiary(element, null);
+  } else {
+    updateNoteFthoraTertiary(element, neume);
+  }
+}
 
-      this.score.pageSetup.showHeader = true;
+function setFthoraMartyria(element: MartyriaElement, neume: Fthora) {
+  if (element.fthora === neume) {
+    updateMartyriaFthora(element, null);
+  } else {
+    updateMartyriaFthora(element, neume);
+  }
+}
 
-      this.updatePageSetup(this.score.pageSetup);
-    },
+function setMartyriaTempoLeft(element: MartyriaElement, neume: TempoSign) {
+  if (element.tempoLeft === neume) {
+    updateMartyriaTempoLeft(element, null);
+  } else {
+    updateMartyriaTempoLeft(element, neume);
+  }
+}
 
-    onFileMenuInsertFooter() {
-      if (this.score.pageSetup.showFooter) {
-        return;
-      }
+function setMartyriaTempo(element: MartyriaElement, neume: TempoSign) {
+  if (element.tempo === neume) {
+    updateMartyriaTempo(element, null);
+  } else {
+    updateMartyriaTempo(element, neume);
+  }
+}
 
-      this.score.pageSetup.showFooter = true;
+function setMartyriaTempoRight(element: MartyriaElement, neume: TempoSign) {
+  if (element.tempoRight === neume) {
+    updateMartyriaTempoRight(element, null);
+  } else {
+    updateMartyriaTempoRight(element, neume);
+  }
+}
 
-      this.updatePageSetup(this.score.pageSetup);
-    },
+function setMartyriaQuantitativeNeume(
+  element: MartyriaElement,
+  neume: QuantitativeNeume,
+) {
+  if (element.quantitativeNeume === neume) {
+    updateMartyria(element, { quantitativeNeume: null });
+  } else {
+    updateMartyria(element, { quantitativeNeume: neume });
+  }
+}
 
-    onFileMenuToolsCopyElementLink() {
-      if (this.selectedElement?.id != null) {
-        navigator.clipboard.writeText(
-          '#element-' + this.selectedElement.id.toString(),
-        );
-      }
-    },
+function setModeKeyTempo(element: ModeKeyElement, neume: TempoSign) {
+  if (element.tempo === neume) {
+    updateModeKeyTempo(element, null);
+  } else {
+    updateModeKeyTempo(element, neume);
+  }
+}
 
-    async onFileMenuSave() {
-      const workspace = this.selectedWorkspace;
+function setAccidental(element: NoteElement, neume: Accidental) {
+  if (element.accidental != null && element.accidental === neume) {
+    updateNoteAndSave(element, { accidental: null });
+  } else {
+    updateNoteAndSave(element, { accidental: neume });
+  }
+}
 
-      if (workspace.filePath != null) {
-        const result = await this.saveWorkspace(workspace);
-        if (result.success) {
-          workspace.hasUnsavedChanges = false;
+function setSecondaryAccidental(element: NoteElement, neume: Accidental) {
+  if (
+    element.secondaryAccidental != null &&
+    element.secondaryAccidental === neume
+  ) {
+    updateNoteAndSave(element, { secondaryAccidental: null });
+  } else {
+    updateNoteAndSave(element, { secondaryAccidental: neume });
+  }
+}
+
+function setTertiaryAccidental(element: NoteElement, neume: Accidental) {
+  if (
+    element.tertiaryAccidental != null &&
+    element.tertiaryAccidental === neume
+  ) {
+    updateNoteAndSave(element, { tertiaryAccidental: null });
+  } else {
+    updateNoteAndSave(element, { tertiaryAccidental: neume });
+  }
+}
+
+function setTimeNeume(element: NoteElement, neume: TimeNeume) {
+  if (element.timeNeume === neume) {
+    updateNoteAndSave(element, { timeNeume: null });
+  } else {
+    updateNoteAndSave(element, { timeNeume: neume });
+  }
+}
+
+function setMeasureNumber(element: NoteElement, neume: MeasureNumber) {
+  if (neume === element.measureNumber) {
+    updateNoteAndSave(element, { measureNumber: null });
+  } else {
+    updateNoteAndSave(element, { measureNumber: neume });
+  }
+}
+
+function setMeasureBarNote(element: NoteElement, neume: MeasureBar) {
+  // Cycle through
+  // Left
+  // Right
+  // Both Sides
+  // None
+  const normalizedMeasureBar = element.measureBarLeft?.endsWith('Above')
+    ? measureBarAboveToLeft.get(element.measureBarLeft)
+    : element.measureBarLeft;
+  if (neume === normalizedMeasureBar && neume === element.measureBarRight) {
+    updateNoteAndSave(element, {
+      measureBarLeft: null,
+      measureBarRight: null,
+    });
+  } else if (neume === normalizedMeasureBar) {
+    updateNoteAndSave(element, {
+      measureBarLeft: null,
+      measureBarRight: neume,
+    });
+  } else if (neume === element.measureBarRight) {
+    updateNoteAndSave(element, {
+      measureBarLeft: neume,
+      measureBarRight: neume,
+    });
+  } else {
+    updateNoteAndSave(element, {
+      measureBarLeft: neume,
+      measureBarRight: null,
+    });
+  }
+}
+
+function setMeasureBarMartyria(element: MartyriaElement, neume: MeasureBar) {
+  // Cycle through
+  // Left
+  // Right
+  // Both Sides
+  // None
+  const normalizedMeasureBar = element.measureBarLeft?.endsWith('Above')
+    ? measureBarAboveToLeft.get(element.measureBarLeft)
+    : element.measureBarLeft;
+  if (neume === normalizedMeasureBar && neume === element.measureBarRight) {
+    updateMartyria(element, {
+      measureBarLeft: null,
+      measureBarRight: null,
+    });
+  } else if (neume === normalizedMeasureBar) {
+    updateMartyria(element, {
+      measureBarLeft: null,
+      measureBarRight: neume,
+    });
+  } else if (neume === element.measureBarRight) {
+    updateMartyria(element, {
+      measureBarLeft: neume,
+      measureBarRight: neume,
+    });
+  } else {
+    updateMartyria(element, {
+      measureBarLeft: neume,
+      measureBarRight: null,
+    });
+  }
+}
+
+function setIson(element: NoteElement, neume: Ison) {
+  if (neume === element.ison) {
+    updateNoteAndSave(element, { ison: null });
+  } else {
+    updateNoteAndSave(element, { ison: neume });
+  }
+}
+
+function setVocalExpression(element: NoteElement, neume: VocalExpressionNeume) {
+  if (
+    element.vocalExpressionNeume != null &&
+    areVocalExpressionsEquivalent(neume, element.vocalExpressionNeume)
+  ) {
+    updateNoteExpression(element, null);
+  } else {
+    updateNoteExpression(element, neume);
+  }
+}
+
+function setTie(element: NoteElement, neumes: Tie[]) {
+  let equivalent = false;
+
+  for (const neume of neumes) {
+    // If previous neume was matched, set to the next neume in the cycle
+    if (equivalent) {
+      updateNoteAndSave(element, { tie: neume });
+      return;
+    }
+
+    equivalent = element.tie === neume;
+  }
+
+  // We've cycled through all the neumes.
+  // If we got to the end of the cycle, remove all
+  // fthora neumes. Otherwise set fthora to the first neume
+  // in the cycle.
+  if (equivalent) {
+    updateNoteAndSave(element, { tie: null });
+  } else {
+    updateNoteAndSave(element, { tie: neumes[0] });
+  }
+}
+
+function addScoreElement(
+  element: ScoreElement,
+  insertAtIndex?: number,
+  collection?: ScoreElement[],
+) {
+  commandService.value.execute(
+    scoreElementCommandFactory.create('add-to-collection', {
+      elements: [element],
+      collection: collection ?? elements.value,
+      insertAtIndex,
+    }),
+  );
+
+  refreshStaffLyrics();
+}
+
+function addScoreElements(newElements: ScoreElement[], insertAtIndex?: number) {
+  commandService.value.execute(
+    scoreElementCommandFactory.create('add-to-collection', {
+      elements: newElements,
+      collection: elements.value,
+      insertAtIndex,
+    }),
+  );
+
+  refreshStaffLyrics();
+}
+
+function replaceScoreElement(element: ScoreElement, replaceAtIndex: number) {
+  commandService.value.execute(
+    scoreElementCommandFactory.create('replace-element-in-collection', {
+      element,
+      collection: elements.value,
+      replaceAtIndex,
+    }),
+  );
+
+  refreshStaffLyrics();
+}
+
+function removeScoreElement(
+  element: ScoreElement,
+  collection?: ScoreElement[],
+) {
+  commandService.value.execute(
+    scoreElementCommandFactory.create('remove-from-collection', {
+      element,
+      collection: collection ?? elements.value,
+    }),
+  );
+
+  refreshStaffLyrics();
+}
+
+function updatePageVisibility(page: Page, isVisible: boolean) {
+  page.isVisible = isVisible;
+}
+
+function updateNoteAndSave(
+  element: NoteElement,
+  newValues: Partial<NoteElement>,
+) {
+  updateNote(element, newValues);
+  save();
+}
+
+function updateNote(element: NoteElement, newValues: Partial<NoteElement>) {
+  commandService.value.execute(
+    noteElementCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
+
+  // Force the element to update so that the neume toolbar updates
+  element.keyHelper++;
+
+  // If we change certain fields, we need to refresh the staff lyrics
+  if (
+    newValues.quantitativeNeume !== undefined ||
+    newValues.tie !== undefined ||
+    newValues.acceptsLyrics !== undefined
+  ) {
+    refreshStaffLyrics();
+  }
+}
+
+function updateNoteFthora(element: NoteElement, fthora: Fthora | null) {
+  let chromaticFthoraNote: ScaleNote | null = null;
+
+  if (
+    fthora === Fthora.SoftChromaticThi_Top ||
+    fthora === Fthora.SoftChromaticThi_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Thi;
+  } else if (
+    fthora === Fthora.SoftChromaticPa_Top ||
+    fthora === Fthora.SoftChromaticPa_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Ga;
+  } else if (
+    fthora === Fthora.HardChromaticThi_Top ||
+    fthora === Fthora.HardChromaticThi_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Thi;
+  } else if (
+    fthora === Fthora.HardChromaticPa_Top ||
+    fthora === Fthora.HardChromaticPa_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Pa;
+  }
+
+  updateNote(element, { fthora, chromaticFthoraNote });
+  save();
+}
+
+function updateNoteFthoraSecondary(
+  element: NoteElement,
+  secondaryFthora: Fthora | null,
+) {
+  let secondaryChromaticFthoraNote: ScaleNote | null = null;
+
+  if (secondaryFthora === Fthora.SoftChromaticThi_TopSecondary) {
+    secondaryChromaticFthoraNote = ScaleNote.Thi;
+  } else if (secondaryFthora === Fthora.SoftChromaticPa_TopSecondary) {
+    secondaryChromaticFthoraNote = ScaleNote.Ga;
+  } else if (secondaryFthora === Fthora.HardChromaticThi_TopSecondary) {
+    secondaryChromaticFthoraNote = ScaleNote.Thi;
+  } else if (secondaryFthora === Fthora.HardChromaticPa_TopSecondary) {
+    secondaryChromaticFthoraNote = ScaleNote.Pa;
+  }
+
+  updateNote(element, {
+    secondaryFthora,
+    secondaryChromaticFthoraNote,
+  });
+  save();
+}
+
+function updateNoteFthoraTertiary(
+  element: NoteElement,
+  tertiaryFthora: Fthora | null,
+) {
+  let tertiaryChromaticFthoraNote: ScaleNote | null = null;
+
+  if (tertiaryFthora === Fthora.SoftChromaticThi_TopTertiary) {
+    tertiaryChromaticFthoraNote = ScaleNote.Thi;
+  } else if (tertiaryFthora === Fthora.SoftChromaticPa_TopTertiary) {
+    tertiaryChromaticFthoraNote = ScaleNote.Ga;
+  } else if (tertiaryFthora === Fthora.HardChromaticThi_TopTertiary) {
+    tertiaryChromaticFthoraNote = ScaleNote.Thi;
+  } else if (tertiaryFthora === Fthora.HardChromaticPa_TopTertiary) {
+    tertiaryChromaticFthoraNote = ScaleNote.Pa;
+  }
+
+  updateNote(element, { tertiaryFthora, tertiaryChromaticFthoraNote });
+  save();
+}
+
+function updateNoteExpression(
+  element: NoteElement,
+  vocalExpressionNeume: VocalExpressionNeume | null,
+) {
+  // Replace the psifiston with a slanted psifiston if the previous neume
+  // contains a long heteron
+  if (vocalExpressionNeume === VocalExpressionNeume.Psifiston) {
+    const index = getElementIndex(element);
+
+    if (index > 0) {
+      const previousElement = elements.value[index - 1];
+
+      if (previousElement.elementType === ElementType.Note) {
+        const previousNote = previousElement as NoteElement;
+
+        if (
+          previousNote.vocalExpressionNeume ===
+          VocalExpressionNeume.HeteronConnectingLong
+        ) {
+          vocalExpressionNeume = VocalExpressionNeume.PsifistonSlanted;
         }
-      } else {
-        const result = await this.saveWorkspaceAs(workspace);
-        if (result.success) {
-          workspace.filePath = result.filePath;
-          workspace.hasUnsavedChanges = false;
-        }
       }
+    }
+  }
+
+  updateNote(element, { vocalExpressionNeume });
+  save();
+}
+
+function updateLyricsLocked(locked: boolean) {
+  lyricsLocked.value = locked;
+  hasUnsavedChanges.value = true;
+}
+
+function updateStaffLyrics(staffLyrics: string) {
+  lyrics.value = staffLyrics;
+  throttled.assignLyrics();
+  hasUnsavedChanges.value = true;
+}
+
+function assignLyrics() {
+  const updateCommands: Command[] = [];
+
+  lyricService.assignLyrics(
+    lyrics.value,
+    elements.value,
+    rtl.value,
+    score.value.pageSetup.disableGreekMelismata,
+    (note, lyrics) => setLyrics(getElementIndex(note), lyrics),
+    (note, newValues) => {
+      note.updated = true;
+      updateCommands.push(
+        noteElementCommandFactory.create('update-properties', {
+          target: note,
+          newValues,
+        }),
+      );
     },
-
-    async onFileMenuSaveAs() {
-      const workspace = this.selectedWorkspace;
-
-      const result = await this.saveWorkspaceAs(workspace);
-      if (result.success) {
-        workspace.filePath = result.filePath;
-        workspace.hasUnsavedChanges = false;
-      }
+    (dropCap, token) => {
+      updateCommands.push(
+        dropCapCommandFactory.create('update-properties', {
+          target: dropCap,
+          newValues: { content: token },
+        }),
+      );
     },
+  );
 
-    onFileMenuUndo() {
-      const currentIndex = this.selectedElementIndex;
+  if (updateCommands.length > 0) {
+    commandService.value.executeAsBatch(updateCommands, lyricsLocked.value);
+    save();
+  }
+}
 
-      const textBoxDefaultFontFamilyPrevious =
-        this.score.pageSetup.textBoxDefaultFontFamily;
-      const textBoxDefaultFontSizePrevious =
-        this.score.pageSetup.textBoxDefaultFontSize;
+function assignAcceptsLyricsFromCurrentLyrics() {
+  const commands: Command[] = [];
 
-      this.commandService.undo();
-
-      // TODO this may be overkill, but the alternative is putting in place
-      // an event system to only refresh on certain undo actions
-      this.refreshStaffLyrics();
-
-      if (currentIndex > -1) {
-        // If the selected element was removed during the undo process, choose a new one
-        const clampedIndex = Math.min(currentIndex, this.elements.length - 1);
-
-        if (this.selectedElement !== this.elements[clampedIndex]) {
-          this.selectedElement = this.elements[clampedIndex];
-        }
-
-        // Undo/redo could affect the note display in the neume toolbar (among other things),
-        // so we force a refresh here
-        this.selectedElement.keyHelper++;
-      }
-
-      if (
-        textBoxDefaultFontFamilyPrevious !=
-          this.score.pageSetup.textBoxDefaultFontFamily ||
-        textBoxDefaultFontSizePrevious !=
-          this.score.pageSetup.textBoxDefaultFontSize
-      ) {
-        this.recalculateRichTextBoxHeights();
-        this.recalculateTextBoxHeights();
-      }
-
-      this.save();
+  lyricService.assignAcceptsLyricsFromCurrentLyrics(
+    elements.value,
+    score.value.pageSetup.disableGreekMelismata,
+    (note, acceptsLyrics) => {
+      commands.push(
+        noteElementCommandFactory.create('update-properties', {
+          target: note,
+          newValues: {
+            acceptsLyrics,
+          },
+        }),
+      );
     },
+  );
 
-    onFileMenuRedo() {
-      const currentIndex = this.selectedElementIndex;
+  if (commands.length > 0) {
+    commandService.value.executeAsBatch(commands);
+    refreshStaffLyrics();
+    save();
+  }
+}
 
-      const textBoxDefaultFontFamilyPrevious =
-        this.score.pageSetup.textBoxDefaultFontFamily;
-      const textBoxDefaultFontSizePrevious =
-        this.score.pageSetup.textBoxDefaultFontSize;
+function updateLyrics(
+  element: NoteElement,
+  lyrics: string,
+  clearMelisma: boolean = false,
+) {
+  const newValues = lyricService.getLyricUpdateValues(
+    element,
+    lyrics,
+    elements.value,
+    rtl.value,
+    (note, lyrics) => setLyrics(getElementIndex(note), lyrics),
+    clearMelisma,
+  );
 
-      this.commandService.redo();
+  if (newValues != null) {
+    commandService.value.execute(
+      noteElementCommandFactory.create('update-properties', {
+        target: element,
+        newValues,
+      }),
+    );
+    refreshStaffLyrics();
+    save();
+  }
+}
 
-      // TODO this may be overkill, but the alternative is putting in place
-      // an event system to only refresh on certain undo actions
-      this.refreshStaffLyrics();
+function refreshStaffLyrics() {
+  if (lyricsLocked.value) {
+    assignLyrics();
+  } else if (lyricManagerIsOpen.value) {
+    lyrics.value = lyricService.extractLyrics(
+      elements.value,
+      score.value.pageSetup.disableGreekMelismata,
+    );
+  }
+}
 
-      if (currentIndex > -1) {
-        // If the selected element was removed during the redo process, choose a new one
-        const clampedIndex = Math.min(currentIndex, this.elements.length - 1);
+function updateAnnotation(
+  element: AnnotationElement,
+  newValues: Partial<AnnotationElement>,
+) {
+  commandService.value.execute(
+    annotationCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
 
-        if (this.selectedElement !== this.elements[clampedIndex]) {
-          this.selectedElement = this.elements[clampedIndex];
-        }
+  save();
+}
 
-        // Undo/redo could affect the note display in the neume toolbar (among other things),
-        // so we force a refresh here
-        this.selectedElement.keyHelper++;
+function removeAnnotation(
+  note: NoteElement,
+  annotation: AnnotationElement,
+  noHistory: boolean = false,
+) {
+  commandService.value.execute(
+    annotationCommandFactory.create('remove-from-collection', {
+      element: annotation,
+      collection: note.annotations,
+    }),
+    noHistory,
+  );
+
+  selectedWorkspace.value.selectedAnnotationElement = null;
+
+  save();
+}
+
+function updateAlternateLine(
+  element: AlternateLineElement,
+  newValues: Partial<AlternateLineElement>,
+) {
+  commandService.value.execute(
+    alternateLineCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
+
+  save();
+}
+
+function removeAlternateLine(
+  note: NoteElement,
+  annotation: AlternateLineElement,
+  noHistory: boolean = false,
+) {
+  commandService.value.execute(
+    alternateLineCommandFactory.create('remove-from-collection', {
+      element: annotation,
+      collection: note.alternateLines,
+    }),
+    noHistory,
+  );
+
+  selectedWorkspace.value.selectedAlternateLineElement = null;
+
+  save();
+}
+
+function updateRichTextBox(
+  element: RichTextBoxElement,
+  newValues: Partial<RichTextBoxElement>,
+) {
+  if (newValues.rtl != null) {
+    element.keyHelper++;
+  }
+
+  const heightProp: keyof RichTextBoxElement = 'height';
+
+  const noHistory =
+    Object.keys(newValues).length === 1 && heightProp in newValues;
+
+  commandService.value.execute(
+    richTextBoxCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+    noHistory,
+  );
+
+  const modeChangeProp: keyof RichTextBoxElement = 'modeChange';
+
+  if (modeChangeProp in newValues) {
+    refreshStaffLyrics();
+  }
+
+  save(!noHistory);
+}
+
+function updateRichTextBoxHeight(element: RichTextBoxElement, height: number) {
+  // The height could be updated by many rich text box elements at once
+  // (e.g. if PageSetup changes) so we debounce the save.
+  element.height = height;
+  richTextBoxCalculationCount.value++;
+  saveDebounced(false);
+}
+
+function updateTextBox(
+  element: TextBoxElement,
+  newValues: Partial<TextBoxElement>,
+) {
+  const noHistory =
+    Object.keys(newValues).length === 1 && 'height' in newValues;
+
+  commandService.value.execute(
+    textBoxCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+    noHistory,
+  );
+
+  save(!noHistory);
+}
+
+function updateTextBoxHeight(element: TextBoxElement, height: number) {
+  // The height could be updated by many text box elements at once
+  // (e.g. if PageSetup changes) so we debounce the save.
+  element.height = height;
+  textBoxCalculationCount.value++;
+  saveDebounced(false);
+}
+
+function updateModeKey(
+  element: ModeKeyElement,
+  newValues: Partial<ModeKeyElement>,
+) {
+  commandService.value.execute(
+    modeKeyCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
+
+  save();
+}
+
+function updateModeKeyTempo(element: ModeKeyElement, tempo: TempoSign | null) {
+  let bpm = element.bpm;
+
+  if (tempo != null) {
+    bpm =
+      editorPreferences.value.getDefaultTempo(tempo) ??
+      TempoElement.getDefaultBpm(tempo);
+  }
+
+  updateModeKey(element, { tempo, bpm });
+}
+
+function updateModeKeyFromTemplate(
+  element: ModeKeyElement,
+  template: ModeKeyElement,
+) {
+  const {
+    templateId,
+    mode,
+    scale,
+    scaleNote,
+    fthora,
+    martyria,
+    fthoraAboveNote,
+    fthoraAboveNote2,
+    fthoraAboveQuantitativeNeumeRight,
+    note,
+    note2,
+    quantitativeNeumeAboveNote,
+    quantitativeNeumeAboveNote2,
+    quantitativeNeumeRight,
+  } = template;
+
+  const newValues = {
+    templateId,
+    mode,
+    scale,
+    scaleNote,
+    fthora,
+    martyria,
+    fthoraAboveNote,
+    fthoraAboveNote2,
+    fthoraAboveQuantitativeNeumeRight,
+    note,
+    note2,
+    quantitativeNeumeAboveNote,
+    quantitativeNeumeAboveNote2,
+    quantitativeNeumeRight,
+  };
+
+  updateModeKey(element, newValues);
+
+  save();
+}
+
+function updateMartyria(
+  element: MartyriaElement,
+  newValues: Partial<MartyriaElement>,
+) {
+  commandService.value.execute(
+    martyriaCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
+
+  save();
+}
+
+function updateMartyriaFthora(element: MartyriaElement, fthora: Fthora | null) {
+  let chromaticFthoraNote: ScaleNote | null = null;
+
+  if (
+    fthora === Fthora.SoftChromaticThi_Top ||
+    fthora === Fthora.SoftChromaticThi_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Thi;
+  } else if (
+    fthora === Fthora.SoftChromaticPa_Top ||
+    fthora === Fthora.SoftChromaticPa_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Ga;
+  } else if (
+    fthora === Fthora.HardChromaticThi_Top ||
+    fthora === Fthora.HardChromaticThi_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Thi;
+  } else if (
+    fthora === Fthora.HardChromaticPa_Top ||
+    fthora === Fthora.HardChromaticPa_Bottom
+  ) {
+    chromaticFthoraNote = ScaleNote.Pa;
+  }
+
+  updateMartyria(element, { fthora, chromaticFthoraNote });
+}
+
+function updateMartyriaTempoLeft(
+  element: MartyriaElement,
+  tempoLeft: TempoSign | null,
+) {
+  let bpm = element.bpm;
+
+  if (tempoLeft != null) {
+    bpm =
+      editorPreferences.value.getDefaultTempo(tempoLeft) ??
+      TempoElement.getDefaultBpm(tempoLeft);
+  }
+
+  updateMartyria(element, {
+    tempoLeft,
+    bpm,
+    tempo: null,
+    tempoRight: null,
+  });
+}
+
+function updateMartyriaTempo(
+  element: MartyriaElement,
+  tempo: TempoSign | null,
+) {
+  let bpm = element.bpm;
+
+  if (tempo != null) {
+    bpm =
+      editorPreferences.value.getDefaultTempo(tempo) ??
+      TempoElement.getDefaultBpm(tempo);
+  }
+
+  updateMartyria(element, {
+    tempo,
+    bpm,
+    tempoLeft: null,
+    tempoRight: null,
+  });
+}
+
+function updateMartyriaTempoRight(
+  element: MartyriaElement,
+  tempoRight: TempoSign | null,
+) {
+  let bpm = element.bpm;
+
+  if (tempoRight != null) {
+    bpm =
+      editorPreferences.value.getDefaultTempo(tempoRight) ??
+      TempoElement.getDefaultBpm(tempoRight);
+  }
+
+  updateMartyria(element, {
+    tempoRight,
+    bpm,
+    tempoLeft: null,
+    tempo: null,
+  });
+}
+
+// Retained from the Options API method surface.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function updateMartyriaBpm(element: MartyriaElement, bpm: number) {
+  updateMartyria(element, { bpm });
+  save();
+}
+
+// Retained from the Options API method surface.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function updateMartyriaMeasureBar(
+  element: MartyriaElement,
+  {
+    measureBarLeft,
+    measureBarRight,
+  }: {
+    measureBarLeft: MeasureBar | null;
+    measureBarRight: MeasureBar | null;
+  },
+) {
+  updateMartyria(element, {
+    measureBarLeft,
+    measureBarRight,
+  });
+  save();
+}
+
+function updateTempo(element: TempoElement, newValues: Partial<TempoElement>) {
+  commandService.value.execute(
+    tempoCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
+
+  save();
+}
+
+function updateDropCap(
+  element: DropCapElement,
+  newValues: Partial<DropCapElement>,
+) {
+  commandService.value.execute(
+    dropCapCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
+
+  save();
+}
+
+function updateDropCapContent(element: DropCapElement, content: string) {
+  // Replace newlines. This should only happen if the user pastes
+  // text containing new lines.
+  const sanitizedContent = content.replace(/(?:\r\n|\r|\n)/g, ' ');
+  if (sanitizedContent !== content) {
+    content = sanitizedContent;
+
+    // Force the lyrics to re-render
+    element.keyHelper++;
+  }
+
+  if (content === '') {
+    const index = elements.value.indexOf(element);
+
+    if (index > -1) {
+      if (selectedElement.value === element) {
+        selectedElement.value = null;
       }
 
-      if (
-        textBoxDefaultFontFamilyPrevious !=
-          this.score.pageSetup.textBoxDefaultFontFamily ||
-        textBoxDefaultFontSizePrevious !=
-          this.score.pageSetup.textBoxDefaultFontSize
-      ) {
-        this.recalculateRichTextBoxHeights();
-        this.recalculateTextBoxHeights();
-      }
+      removeScoreElement(element);
+    }
+  } else if (element.content !== content) {
+    commandService.value.execute(
+      dropCapCommandFactory.create('update-properties', {
+        target: element,
+        newValues: { content },
+      }),
+    );
 
-      this.save();
-    },
+    refreshStaffLyrics();
+  }
 
-    onFileMenuCut() {
-      if (!this.isTextInputFocused() && !this.dialogOpen) {
-        this.onCutScoreElements();
-      } else {
-        document.execCommand('cut');
-      }
-    },
+  save();
+}
 
-    onFileMenuCopy() {
-      if (!this.isTextInputFocused() && !this.dialogOpen) {
-        this.onCopyScoreElements();
-      } else {
-        document.execCommand('copy');
-      }
-    },
+function updateImageBox(
+  element: ImageBoxElement,
+  newValues: Partial<ImageBoxElement>,
+) {
+  commandService.value.execute(
+    imageBoxCommandFactory.create('update-properties', {
+      target: element,
+      newValues: newValues,
+    }),
+  );
 
-    onFileMenuCopyFormat() {
-      if (this.selectedElement == null) {
-        return;
-      }
+  save();
+}
 
-      if (this.selectedElement.elementType === ElementType.TextBox) {
-        this.formatType = ElementType.TextBox;
-        this.textBoxFormat = (
-          this.selectedElement as TextBoxElement
-        ).cloneFormat();
-      } else if (this.selectedElement.elementType === ElementType.Note) {
-        this.formatType = ElementType.Note;
-        this.noteFormat = (this.selectedElement as NoteElement).cloneFormat();
-      }
-    },
+function deleteSelectedElement() {
+  if (
+    selectedWorkspace.value.selectedAnnotationElement != null &&
+    selectedElement.value?.elementType === ElementType.Note
+  ) {
+    removeAnnotation(
+      selectedElement.value as NoteElement,
+      selectedWorkspace.value.selectedAnnotationElement,
+    );
 
-    onFileMenuCopyAsHtml() {
-      let elements: ScoreElement[] = [];
+    return;
+  }
 
-      if (this.selectionRange != null) {
-        elements = this.elements.filter(
-          (x) => x.elementType != ElementType.Empty && this.isSelected(x),
-        );
-      } else if (this.selectedElement != null) {
-        elements = [this.selectedElement];
-      } else if (this.selectedLyrics != null) {
-        elements = [this.selectedLyrics];
-      }
+  if (
+    selectedWorkspace.value.selectedAlternateLineElement != null &&
+    selectedElement.value?.elementType === ElementType.Note
+  ) {
+    removeAlternateLine(
+      selectedElement.value as NoteElement,
+      selectedWorkspace.value.selectedAlternateLineElement,
+    );
 
-      const html = this.byzHtmlExporter.exportElements(
-        elements,
-        this.score.pageSetup,
-        0,
-        true,
+    return;
+  }
+
+  if (selectedElement.value != null && !isLastElement(selectedElement.value)) {
+    const index = selectedElementIndex.value;
+
+    removeScoreElement(selectedElement.value);
+
+    selectedElement.value = elements.value[index];
+
+    save();
+  } else if (selectionRange.value != null) {
+    const elementsToDelete = elements.value.filter(
+      (x) => x.elementType != ElementType.Empty && isSelected(x),
+    );
+
+    commandService.value.executeAsBatch(
+      elementsToDelete.map((element) =>
+        scoreElementCommandFactory.create('remove-from-collection', {
+          element,
+          collection: elements.value,
+        }),
+      ),
+    );
+
+    refreshStaffLyrics();
+
+    const start = Math.min(
+      selectionRange.value.start,
+      selectionRange.value.end,
+    );
+
+    selectedElement.value =
+      elements.value[Math.min(start, elements.value.length - 1)];
+
+    save();
+  }
+}
+
+function deletePreviousElement() {
+  if (selectedWorkspace.value.selectedAlternateLineElement) {
+    const alternateLineElements =
+      selectedWorkspace.value.selectedAlternateLineElement.elements;
+    removeScoreElement(
+      alternateLineElements[alternateLineElements.length - 1],
+      alternateLineElements,
+    );
+
+    return;
+  }
+
+  if (
+    selectedElement.value &&
+    selectedElementIndex.value > 0 &&
+    navigableElements.includes(
+      elements.value[selectedElementIndex.value - 1].elementType,
+    )
+  ) {
+    removeScoreElement(elements.value[selectedElementIndex.value - 1]);
+
+    save();
+  }
+}
+
+function updatePageSetup(pageSetup: PageSetup) {
+  const needToRecalcRichTextBoxes =
+    pageSetup.textBoxDefaultFontFamily !=
+      score.value.pageSetup.textBoxDefaultFontFamily ||
+    pageSetup.textBoxDefaultFontSize !=
+      score.value.pageSetup.textBoxDefaultFontSize;
+
+  const updateCommands: Command[] = [
+    pageSetupCommandFactory.create('update-properties', {
+      target: score.value.pageSetup,
+      newValues: pageSetup,
+    }),
+  ];
+
+  if (pageSetup.richHeaderFooter && !score.value.pageSetup.richHeaderFooter) {
+    updateCommands.push(
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.default.elements,
+        element: createRichHeaderFooter('', 'Title', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.even.elements,
+        element: createRichHeaderFooter('$p', 'Title', ''),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.firstPage.elements,
+        element: createRichHeaderFooter('', 'Title', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.odd.elements,
+        element: createRichHeaderFooter('', 'Title', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.default.elements,
+        element: createRichHeaderFooter('', 'Footer', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.even.elements,
+        element: createRichHeaderFooter('$p', 'Footer', ''),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.firstPage.elements,
+        element: createRichHeaderFooter('', 'Footer', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.odd.elements,
+        element: createRichHeaderFooter('', 'Footer', '$p'),
+        replaceAtIndex: 0,
+      }),
+    );
+  } else if (
+    !pageSetup.richHeaderFooter &&
+    score.value.pageSetup.richHeaderFooter
+  ) {
+    updateCommands.push(
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.default.elements,
+        element: createRegularHeaderFooter('', 'Title', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.even.elements,
+        element: createRegularHeaderFooter('$p', 'Title', ''),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.firstPage.elements,
+        element: createRegularHeaderFooter('', 'Title', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.headers.odd.elements,
+        element: createRegularHeaderFooter('', 'Title', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.default.elements,
+        element: createRegularHeaderFooter('', 'Footer', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.even.elements,
+        element: createRegularHeaderFooter('$p', 'Footer', ''),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.firstPage.elements,
+        element: createRegularHeaderFooter('', 'Footer', '$p'),
+        replaceAtIndex: 0,
+      }),
+      scoreElementCommandFactory.create('replace-element-in-collection', {
+        collection: score.value.footers.odd.elements,
+        element: createRegularHeaderFooter('', 'Footer', '$p'),
+        replaceAtIndex: 0,
+      }),
+    );
+  }
+
+  commandService.value.executeAsBatch(updateCommands);
+
+  if (needToRecalcRichTextBoxes) {
+    recalculateRichTextBoxHeights();
+    recalculateTextBoxHeights();
+  }
+
+  save();
+}
+
+function updatePageSetupUseOptionalDiatonicFthoras(
+  useOptionalDiatonicFthoras: boolean,
+) {
+  commandService.value.execute(
+    pageSetupCommandFactory.create('update-properties', {
+      target: score.value.pageSetup,
+      newValues: { useOptionalDiatonicFthoras },
+    }),
+  );
+
+  save();
+}
+
+function createRegularHeaderFooter(
+  left: string,
+  center: string,
+  right: string,
+) {
+  const textbox = new TextBoxElement();
+  textbox.multipanel = true;
+  textbox.contentLeft = left;
+  textbox.contentCenter = center;
+  textbox.contentRight = right;
+  return textbox;
+}
+
+function createRichHeaderFooter(left: string, center: string, right: string) {
+  const textbox = new RichTextBoxElement();
+  textbox.multipanel = true;
+  textbox.contentLeft = `${left}`;
+  textbox.contentCenter = `<p style="text-align:center;">${center}</p>`;
+  textbox.contentRight = `<p style="text-align:right;">${right}</p>`;
+  return textbox;
+}
+
+function updateEntryMode(mode: EntryMode) {
+  entryMode.value = mode;
+}
+
+function updateZoom(newZoom: number) {
+  if (newZoom < 0.5 || newZoom > 5) {
+    if (ipcService.isShowMessageBoxSupported()) {
+      ipcService.showMessageBox({
+        type: 'error',
+        title: 'Range overflow',
+        message: t(($) => $.toolbar.main.invalidZoom, {
+          ns: 'toolbar',
+        }),
+      });
+    } else {
+      alert(t(($) => $.toolbar.main.invalidZoom, { ns: 'toolbar' }));
+    }
+  } else {
+    zoom.value = newZoom;
+    zoomToFit.value = false;
+  }
+}
+
+function updateZoomToFit(value: boolean) {
+  zoomToFit.value = value;
+
+  if (value) {
+    performZoomToFit();
+  }
+}
+
+function performZoomToFit() {
+  const pageBackgroundElement = pageBackgroundRef.value!;
+
+  const computedStyle = getComputedStyle(pageBackgroundElement);
+
+  const availableWidth =
+    pageBackgroundElement.clientWidth -
+    parseFloat(computedStyle.paddingLeft) -
+    parseFloat(computedStyle.paddingRight);
+
+  zoom.value = availableWidth / score.value.pageSetup.pageWidth;
+}
+
+function playAudio() {
+  try {
+    if (audioService.state === AudioState.Stopped) {
+      playbackEvents.value = playbackService.computePlaybackSequence(
+        elements.value,
+        audioOptions,
+        score.value.pageSetup.chrysanthineAccidentals,
       );
 
-      navigator.clipboard.writeText(html);
-    },
-
-    onFileMenuPaste() {
-      if (!this.isTextInputFocused() && !this.dialogOpen) {
-        this.onPasteScoreElements(false);
-      } else {
-        this.ipcService.paste();
-      }
-    },
-
-    onFileMenuPasteWithLyrics() {
-      if (!this.isTextInputFocused() && !this.dialogOpen) {
-        this.onPasteScoreElements(true);
-      } else {
-        this.ipcService.paste();
-      }
-    },
-
-    onFileMenuPasteFormat() {
-      const normalizedRange = this.getNormalizedSelectionRange();
-
-      const commands: Command[] = [];
-
-      if (normalizedRange != null) {
-        for (let i = normalizedRange.start; i <= normalizedRange.end; i++) {
-          if (this.elements[i].elementType === this.formatType) {
-            this.applyCopiedFormat(this.elements[i], commands);
-          }
-        }
-      } else if (this.selectedElement != null) {
-        this.applyCopiedFormat(this.selectedElement, commands);
+      if (playbackEvents.value.length === 0) {
+        return;
       }
 
-      if (commands.length > 0) {
-        this.commandService.executeAsBatch(commands);
-        this.save();
-      }
-    },
+      const startAt = playbackEvents.value.find(
+        (x) => x.elementIndex >= selectedElementIndex.value,
+      );
 
-    applyCopiedFormat(element: ScoreElement, commands: Command[]) {
+      audioService.play(playbackEvents.value, audioOptions, startAt);
+
+      if (startAt) {
+        selectedWorkspace.value.playbackTime = startAt.absoluteTime;
+      }
+
+      startPlaybackClock();
+    } else {
+      pauseAudio();
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function stopAudio() {
+  try {
+    audioService.stop();
+
+    playbackEvents.value = [];
+
+    stopPlaybackClock();
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function pauseAudio() {
+  try {
+    audioService.togglePause();
+
+    if (audioService.state === AudioState.Paused) {
+      audioElement.value = null;
+      stopPlaybackClock();
+    } else {
+      startPlaybackClock();
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function startPlaybackClock() {
+  stopPlaybackClock();
+
+  playbackTimeInterval.value = setInterval(() => {
+    selectedWorkspace.value.playbackTime += 0.1;
+  }, 100);
+}
+
+function stopPlaybackClock() {
+  if (playbackTimeInterval.value != null) {
+    clearInterval(playbackTimeInterval.value);
+  }
+}
+
+function playTestTone() {
+  try {
+    audioService.playTestTone(audioOptions.frequencyDi);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function updateAudioOptionsSpeed(speed: number) {
+  if (audioService.state === AudioState.Paused) {
+    stopAudio();
+  }
+
+  speed = Math.max(0.1, speed);
+  speed = Math.min(3, speed);
+  speed = +speed.toFixed(2);
+
+  selectedWorkspace.value.playbackBpm /= audioOptions.speed;
+  selectedWorkspace.value.playbackBpm *= speed;
+
+  audioOptions.speed = speed;
+
+  saveAudioOptions();
+}
+
+function saveAudioOptions() {
+  localStorage.setItem('audioOptionsDefault', JSON.stringify(audioOptions));
+}
+
+function onAudioServiceEventPlay(event: PlaybackSequenceEvent) {
+  if (audioService.state === AudioState.Playing) {
+    selectedWorkspace.value.playbackTime = event.absoluteTime;
+    selectedWorkspace.value.playbackBpm = event.bpm;
+
+    audioElement.value = elements.value[event.elementIndex];
+
+    // Scroll the currently playing element into view
+    const lyrics = getTemplateRef<InstanceType<typeof ContentEditable>[]>(
+      `lyrics-${event.elementIndex}`,
+    )[0];
+
+    const neumeBox = getTemplateRef<any[]>(`element-${event.elementIndex}`)[0];
+
+    if ((lyrics?.htmlElement as any)?.scrollIntoViewIfNeeded) {
+      (lyrics?.htmlElement as any).scrollIntoViewIfNeeded(false);
+    }
+
+    if (neumeBox?.scrollIntoViewIfNeeded) {
+      neumeBox.scrollIntoViewIfNeeded(false);
+    }
+  }
+}
+
+function onAudioServiceStop() {
+  audioElement.value = null;
+
+  stopPlaybackClock();
+}
+
+function recalculateRichTextBoxHeights() {
+  if (richTextBoxCalculation.value) {
+    richTextBoxCalculation.value = false;
+  }
+
+  nextTick(async () => {
+    const expectedCount = resizableRichTextBoxElements.value.length;
+    richTextBoxCalculationCount.value = 0;
+    richTextBoxCalculation.value = true;
+
+    const maxTries = 4 * 30; // 30 seconds
+    let tries = 1;
+    let lastCount = 0;
+
+    // Wait until all rich text boxes have updated
+    const poll = (resolve: (value: unknown) => void) => {
       if (
-        element.elementType === ElementType.TextBox &&
-        this.textBoxFormat != null
+        richTextBoxCalculationCount.value === expectedCount ||
+        tries >= maxTries ||
+        richTextBoxCalculationCount.value < lastCount
       ) {
-        commands.push(
-          textBoxCommandFactory.create('update-properties', {
-            target: element as TextBoxElement,
-            newValues: this.textBoxFormat,
-          }),
-        );
-      } else if (
-        element.elementType === ElementType.Note &&
-        this.noteFormat != null
-      ) {
-        commands.push(
-          noteElementCommandFactory.create('update-properties', {
-            target: element as NoteElement,
-            newValues: this.noteFormat,
-          }),
-        );
-      }
-    },
-
-    onFileMenuFind() {
-      if (this.searchTextPanelIsOpen) {
-        (this.$refs.searchText as InstanceType<typeof SearchText>).focus();
+        resolve(true);
       } else {
-        this.searchTextPanelIsOpen = true;
+        tries++;
+        lastCount = richTextBoxCalculationCount.value;
+        setTimeout(() => poll(resolve), 250);
       }
-    },
+    };
 
-    onFileMenuLyrics() {
-      if (!this.dialogOpen) {
-        if (this.lyricManagerIsOpen) {
-          this.closeLyricManager();
-        } else {
-          this.openLyricManager();
-        }
+    await new Promise(poll);
+
+    richTextBoxCalculation.value = false;
+    saveDebounced(false);
+  });
+}
+
+function recalculateTextBoxHeights() {
+  if (textBoxCalculation.value) {
+    textBoxCalculation.value = false;
+  }
+
+  nextTick(async () => {
+    const expectedCount = resizableTextBoxElements.value.length;
+    textBoxCalculationCount.value = 0;
+    textBoxCalculation.value = true;
+
+    const maxTries = 4 * 30; // 30 seconds
+    let tries = 1;
+    let lastCount = 0;
+
+    // Wait until all text boxes have updated
+    const poll = (resolve: (value: unknown) => void) => {
+      if (
+        textBoxCalculationCount.value === expectedCount ||
+        tries >= maxTries ||
+        textBoxCalculationCount.value < lastCount
+      ) {
+        resolve(true);
+      } else {
+        tries++;
+        lastCount = textBoxCalculationCount.value;
+        setTimeout(() => poll(resolve), 250);
       }
-    },
+    };
 
-    onFileMenuPreferences() {
-      if (!this.dialogOpen) {
-        this.editorPreferencesDialogIsOpen = true;
-      }
-    },
+    await new Promise(poll);
 
-    onFileMenuGenerateTestFile(testFileType: TestFileType) {
+    textBoxCalculation.value = false;
+    saveDebounced(false);
+  });
+}
+
+function onFileMenuNewScore() {
+  const workspace = new Workspace();
+  workspace.tempFileName = getTempFilename();
+  workspace.score = createDefaultScore();
+
+  addWorkspace(workspace);
+
+  selectedWorkspace.value = workspace;
+
+  selectedElement.value =
+    score.value.staff.elements[score.value.staff.elements.length - 1];
+  save(false);
+}
+
+async function onFileMenuOpenScore(args: FileMenuOpenScoreArgs) {
+  if (!dialogOpen.value && args.success) {
+    openScore(args);
+  }
+}
+
+function onFileMenuImportOcr(args: FileMenuImportOcrArgs) {
+  if (!dialogOpen.value && args.success) {
+    try {
+      const elements = ocrImporter.import(args.data);
+
       const workspace = new Workspace();
-      workspace.tempFileName = this.getTempFilename();
+      workspace.tempFileName = getTempFilename();
       workspace.score = new Score();
 
-      // The ison test page can be used to inspect the ison alignment
-      // provided by the font, so we disable the automatic ison alignment
-      if (testFileType === TestFileType.Ison) {
-        workspace.score.pageSetup.alignIsonIndicators = false;
-      }
+      addWorkspace(workspace);
 
-      this.addWorkspace(workspace);
+      selectedWorkspace.value = workspace;
 
-      this.selectedWorkspace = workspace;
+      currentFilePath.value = null;
+      score.value.staff.elements.unshift(...elements);
 
-      this.currentFilePath = null;
-      this.score.staff.elements.unshift(
-        ...(TestFileGenerator.generateTestFile(testFileType, this.fonts) || []),
-      );
-      this.save();
-    },
+      save();
+    } catch (error) {
+      console.error(error);
 
-    onSearchText(args: { query: string; reverse?: boolean }) {
-      const result = this.textSearchService.findTextInElements(
-        args.query,
-        this.elements,
-        this.selectedElementIndex,
-        args.reverse ?? false,
-      );
-
-      if (result != null) {
-        this.selectedElement = result;
-
-        (this.$refs.pages as HTMLElement[])[
-          this.selectedElement.page - 1
-        ].scrollIntoView();
-
-        this.pages[this.selectedElement.page - 1].isVisible = true;
-
-        nextTick(() => {
-          if (this.selectedElement?.elementType === ElementType.Note) {
-            (
-              this.$refs[
-                `element-${this.selectedElementIndex}`
-              ] as HTMLElement[]
-            )[0].scrollIntoView();
-          } else if (
-            this.selectedElement?.elementType === ElementType.DropCap
-          ) {
-            (
-              this.$refs[
-                `element-${this.selectedElementIndex}`
-              ] as InstanceType<typeof DropCap>[]
-            )[0].htmlElement.scrollIntoView();
-          } else if (
-            this.selectedElement?.elementType === ElementType.TextBox
-          ) {
-            (
-              this.$refs[
-                `element-${this.selectedElementIndex}`
-              ] as InstanceType<typeof TextBox>[]
-            )[0].htmlElement.scrollIntoView();
-          }
-        });
-      }
-    },
-
-    createDefaultModeKey(pageSetup: PageSetup) {
-      const defaultTemplate = ModeKeyElement.createFromTemplate(
-        modeKeyTemplates[0],
-        this.score.pageSetup.useOptionalDiatonicFthoras,
-      );
-
-      defaultTemplate.color = pageSetup.modeKeyDefaultColor;
-      defaultTemplate.fontSize = pageSetup.modeKeyDefaultFontSize;
-      defaultTemplate.strokeWidth = pageSetup.modeKeyDefaultStrokeWidth;
-
-      return defaultTemplate;
-    },
-
-    createDefaultScore() {
-      const score = new Score();
-
-      try {
-        const pageSetupDefault = localStorage.getItem('pageSetupDefault');
-
-        if (pageSetupDefault) {
-          SaveService.LoadPageSetup_v1(
-            score.pageSetup,
-            JSON.parse(pageSetupDefault),
-          );
-        }
-      } catch (error) {
-        console.error(error);
-      }
-
-      const title = new TextBoxElement();
-      title.content = 'Title';
-      title.alignment = TextBoxAlignment.Center;
-      title.color = score.pageSetup.textBoxDefaultColor;
-      title.fontFamily = score.pageSetup.textBoxDefaultFontFamily;
-      title.fontSize = score.pageSetup.textBoxDefaultFontSize;
-      title.strokeWidth = score.pageSetup.textBoxDefaultStrokeWidth;
-      title.lineHeight = score.pageSetup.textBoxDefaultLineHeight;
-      title.bold = score.pageSetup.textBoxDefaultFontWeight === '700';
-      title.italic = score.pageSetup.textBoxDefaultFontStyle === 'italic';
-      title.height = Math.round(
-        TextMeasurementService.getFontHeight(title.computedFont) * 1.2,
-      );
-      score.staff.elements.unshift(
-        title,
-        this.createDefaultModeKey(score.pageSetup),
-      );
-
-      for (const element of score.headersAndFooters) {
-        if (element.elementType === ElementType.TextBox) {
-          (element as TextBoxElement).fontFamily =
-            score.pageSetup.lyricsDefaultFontFamily;
-          (element as TextBoxElement).strokeWidth =
-            score.pageSetup.lyricsDefaultStrokeWidth;
-        }
-      }
-
-      return score;
-    },
-
-    openScore(args: FileMenuOpenScoreArgs) {
-      if (!args.success) {
-        return;
-      }
-
-      // First make sure we don't already have the score open
-      const existingWorkspace = this.workspaces.find(
-        (x) => x.filePath === args.filePath,
-      ) as Workspace;
-      if (existingWorkspace != null) {
-        this.selectedWorkspace = existingWorkspace;
-        return;
-      }
-
-      try {
-        const score: Score = SaveService.LoadScoreFromJson(
-          JSON.parse(args.data),
-        );
-
-        // if (score.version !== ScoreVersion) {
-        //   alert('This score was created by an older version of the application. It may not work properly');
-        // }
-
-        const workspace = new Workspace();
-        workspace.filePath = args.filePath;
-        workspace.tempFileName = this.getTempFilename();
-        workspace.score = score;
-
-        this.addWorkspace(workspace);
-
-        this.selectedWorkspace = workspace;
-
-        this.selectedElement = null;
-
-        this.save(false);
-      } catch (error) {
-        args.success = false;
-        console.error(error);
-
-        if (error instanceof Error) {
-          if (this.ipcService.isShowMessageBoxSupported()) {
-            this.ipcService.showMessageBox({
-              type: 'error',
-              title: 'Open failed',
-              message: error.message,
-            });
-          } else {
-            alert(error.message);
-          }
-        }
-      }
-    },
-
-    addWorkspace(workspace: Workspace) {
-      this.workspaces.push(workspace);
-
-      (this.$refs.tabs as Vue3TabsChromeComponent).addTab({
-        label: this.getFileName(workspace),
-        key: workspace.id,
-      });
-    },
-
-    removeWorkspace(workspace: Workspace) {
-      const index = this.workspaces.indexOf(workspace);
-
-      this.workspaces.splice(index, 1);
-
-      (this.$refs.tabs as Vue3TabsChromeComponent).removeTab(workspace.id);
-
-      if (this.selectedWorkspace === workspace) {
-        if (this.workspaces.length > 0) {
-          this.selectedWorkspace = this.workspaces[
-            Math.min(index, this.workspaces.length - 1)
-          ] as Workspace;
+      if (error instanceof Error) {
+        if (ipcService.isShowMessageBoxSupported()) {
+          ipcService.showMessageBox({
+            type: 'error',
+            title: 'OCR import failed',
+            message: error.message,
+          });
         } else {
-          // TODO support closing all workspaces
-          this.onFileMenuNewScore();
+          alert(error.message);
         }
       }
-    },
+    }
+  }
+}
 
-    onTabClosed(tab: Tab) {
-      const workspace = this.workspaces.find(
-        (x) => x.id === tab.key,
-      ) as Workspace;
+function onFileMenuPageSetup() {
+  pageSetupDialogIsOpen.value = true;
+}
 
-      if (workspace) {
-        // If the workspace is still in our list, then call closeWorkspace.
-        // closeWorkspace will decide whether to remove the tab and will
-        // explicitly call removeTab. Returning false tells the tab component
-        // to not close the tab, so that we can take care of it manually.
-        this.closeWorkspace(workspace);
-        return false;
+async function onFileMenuPrint() {
+  printMode.value = true;
+
+  // Blur the active element so that focus outlines and
+  // blinking cursors don't show up in the printed page
+  const activeElement = blurActiveElement();
+
+  const previousTitle = window.document.title;
+  window.document.title = getFileName(selectedWorkspace.value, false);
+
+  nextTick(async () => {
+    await ipcService.printWorkspace(selectedWorkspace.value);
+    printMode.value = false;
+    window.document.title = previousTitle;
+
+    // Re-focus the active element
+    focusElement(activeElement);
+  });
+}
+
+async function onFileMenuExportAsPdf() {
+  printMode.value = true;
+
+  // Blur the active element so that focus outlines and
+  // blinking cursors don't show up in the printed page
+  const activeElement = blurActiveElement();
+
+  const previousTitle = window.document.title;
+  window.document.title = getFileName(selectedWorkspace.value, false);
+
+  await nextTick();
+  await ipcService.exportWorkspaceAsPdf(selectedWorkspace.value);
+  printMode.value = false;
+  window.document.title = previousTitle;
+
+  // Re-focus the active element
+  focusElement(activeElement);
+}
+
+async function onFileMenuExportAsImage() {
+  exportFormat.value = ExportFormat.PNG;
+  exportDialogIsOpen.value = true;
+}
+
+async function exportAsPng(args: ExportAsPngSettings) {
+  let reply: ExportWorkspaceAsImageReplyArgs;
+
+  try {
+    reply = await ipcService.exportWorkspaceAsImage(
+      selectedWorkspace.value,
+      'png',
+    );
+
+    if (!reply.success) {
+      return;
+    }
+  } catch (error) {
+    console.error(error);
+    return;
+  }
+
+  printMode.value = true;
+  exportInProgress.value = true;
+
+  // Blur the active element so that focus outlines and
+  // blinking cursors don't show up in the printed page
+  const activeElement = blurActiveElement();
+
+  nextTick(async () => {
+    try {
+      const pages = pagesRef.value as HTMLElement[];
+
+      if (pages.length > 0) {
+        const fontEmbedCSS = await getFontEmbedCSS(pages[0]);
+
+        let pageNumber = 1;
+
+        for (const page of pages) {
+          const options = {
+            fontEmbedCSS,
+            pixelRatio: args.dpi / 96,
+            style: { margin: '0' },
+          } as any;
+
+          if (args.transparentBackground) {
+            options.style.backgroundColor = 'transparent';
+          }
+
+          let data = await toPng(page, options);
+
+          if (data != null) {
+            const fileName = reply.filePath.replace(
+              /\.png$/,
+              `-${pageNumber++}.png`,
+            );
+
+            data = data.replace(/^data:image\/png;base64,/, '');
+
+            if (!(await ipcService.exportPageAsImage(fileName, data))) {
+              break;
+            }
+          }
+        }
+      }
+
+      if (args.openFolder) {
+        await ipcService.showItemInFolder(
+          reply.filePath.replace(/\.png$/, '-1.png'),
+        );
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      printMode.value = false;
+      exportInProgress.value = false;
+      closeExportDialog();
+      // Re-focus the active element
+      focusElement(activeElement);
+    }
+  });
+}
+
+async function onFileMenuExportAsHtml() {
+  await ipcService.exportWorkspaceAsHtml(
+    selectedWorkspace.value,
+    byzHtmlExporter.exportScore(score.value),
+  );
+}
+
+function onFileMenuExportAsMusicXml() {
+  exportFormat.value = ExportFormat.MusicXml;
+  exportDialogIsOpen.value = true;
+}
+
+function onFileMenuExportAsLatex() {
+  exportFormat.value = ExportFormat.Latex;
+  exportDialogIsOpen.value = true;
+}
+
+async function exportAsMusicXml(args: ExportAsMusicXmlSettings) {
+  await ipcService.exportWorkspaceAsMusicXml(
+    selectedWorkspace.value,
+    musicXmlExporter.export(score.value, args.options),
+    args.compressed,
+    args.openFolder,
+  );
+
+  closeExportDialog();
+}
+
+async function exportAsLatex(args: ExportAsLatexSettings) {
+  await ipcService.exportWorkspaceAsLatex(
+    selectedWorkspace.value,
+    JSON.stringify(
+      latexExporter.export(pages.value, score.value.pageSetup, args.options),
+      null,
+      2,
+    ),
+  );
+
+  closeExportDialog();
+}
+
+function blurActiveElement() {
+  const activeElement = document.activeElement;
+
+  if (activeElement instanceof HTMLElement) {
+    activeElement.blur();
+  }
+
+  return activeElement;
+}
+
+function focusElement(element: Element | null) {
+  if (element instanceof HTMLElement) {
+    element.focus();
+  }
+}
+
+function onFileMenuInsertAnnotation() {
+  if (selectedElement.value?.elementType === ElementType.Note) {
+    const el = new AnnotationElement();
+    const fontHeight = TextMeasurementService.getFontHeight(
+      score.value.pageSetup.lyricsFont,
+    );
+    el.x = 0;
+    el.y = -fontHeight;
+    (selectedElement.value as NoteElement).annotations.push(el);
+    selectedWorkspace.value.selectedAnnotationElement = el;
+    save();
+  }
+}
+
+function onFileMenuInsertAlternateLine() {
+  if (selectedElement.value?.elementType === ElementType.Note) {
+    const el = new AlternateLineElement();
+    const fontHeight = TextMeasurementService.getFontHeight(
+      score.value.pageSetup.lyricsFont,
+    );
+    el.x = 0;
+    el.y = -fontHeight;
+    (selectedElement.value as NoteElement).alternateLines.push(el);
+    selectedWorkspace.value.selectedAlternateLineElement = el;
+    save();
+  }
+}
+
+function onFileMenuInsertTextBox(args?: FileMenuInsertTextboxArgs) {
+  const element = new TextBoxElement();
+  element.inline = args?.inline ?? false;
+
+  if (element.inline) {
+    element.color = score.value.pageSetup.lyricsDefaultColor;
+    element.fontFamily = score.value.pageSetup.lyricsDefaultFontFamily;
+    element.fontSize = score.value.pageSetup.lyricsDefaultFontSize;
+    element.strokeWidth = score.value.pageSetup.lyricsDefaultStrokeWidth;
+    element.bold = score.value.pageSetup.lyricsDefaultFontWeight === '700';
+    element.italic = score.value.pageSetup.lyricsDefaultFontStyle === 'italic';
+  } else {
+    element.color = score.value.pageSetup.textBoxDefaultColor;
+    element.fontFamily = score.value.pageSetup.textBoxDefaultFontFamily;
+    element.fontSize = score.value.pageSetup.textBoxDefaultFontSize;
+    element.strokeWidth = score.value.pageSetup.textBoxDefaultStrokeWidth;
+    element.lineHeight = score.value.pageSetup.textBoxDefaultLineHeight;
+    element.bold = score.value.pageSetup.textBoxDefaultFontWeight === '700';
+    element.italic = score.value.pageSetup.textBoxDefaultFontStyle === 'italic';
+  }
+
+  addScoreElement(element, selectedElementIndex.value);
+
+  selectedElement.value = element;
+
+  save();
+
+  nextTick(() => {
+    const index = elements.value.indexOf(element);
+
+    getTemplateRef<any[]>(`element-${index}`)[0].focus();
+  });
+}
+
+function onFileMenuInsertRichTextBox() {
+  const element = new RichTextBoxElement();
+  element.rtl = score.value.pageSetup.melkiteRtl;
+
+  addScoreElement(element, selectedElementIndex.value);
+
+  selectedElement.value = element;
+
+  save();
+
+  nextTick(() => {
+    const index = elements.value.indexOf(element);
+
+    getTemplateRef<any[]>(`element-${index}`)[0].focus();
+  });
+}
+
+function onFileMenuInsertModeKey() {
+  const element = createDefaultModeKey(score.value.pageSetup);
+
+  addScoreElement(element, selectedElementIndex.value);
+
+  selectedElement.value = element;
+
+  openModeKeyDialog();
+
+  save();
+}
+
+function onFileMenuInsertDropCapBefore() {
+  addDropCap(false);
+}
+
+function onFileMenuInsertDropCapAfter() {
+  addDropCap(true);
+}
+
+function onFileMenuInsertImage(args: FileMenuOpenImageArgs) {
+  const element = new ImageBoxElement();
+
+  element.data = args.data;
+  element.imageWidth = args.imageWidth;
+  element.imageHeight = args.imageHeight;
+
+  addScoreElement(element, selectedElementIndex.value);
+
+  selectedElement.value = element;
+
+  save();
+}
+
+function onFileMenuInsertHeader() {
+  if (score.value.pageSetup.showHeader) {
+    return;
+  }
+
+  score.value.pageSetup.showHeader = true;
+
+  updatePageSetup(score.value.pageSetup);
+}
+
+function onFileMenuInsertFooter() {
+  if (score.value.pageSetup.showFooter) {
+    return;
+  }
+
+  score.value.pageSetup.showFooter = true;
+
+  updatePageSetup(score.value.pageSetup);
+}
+
+function onFileMenuToolsCopyElementLink() {
+  if (selectedElement.value?.id != null) {
+    navigator.clipboard.writeText(
+      '#element-' + selectedElement.value.id.toString(),
+    );
+  }
+}
+
+async function onFileMenuSave() {
+  const workspace = selectedWorkspace.value;
+
+  if (workspace.filePath != null) {
+    const result = await saveWorkspace(workspace);
+    if (result.success) {
+      workspace.hasUnsavedChanges = false;
+    }
+  } else {
+    const result = await saveWorkspaceAs(workspace);
+    if (result.success) {
+      workspace.filePath = result.filePath;
+      workspace.hasUnsavedChanges = false;
+    }
+  }
+}
+
+async function onFileMenuSaveAs() {
+  const workspace = selectedWorkspace.value;
+
+  const result = await saveWorkspaceAs(workspace);
+  if (result.success) {
+    workspace.filePath = result.filePath;
+    workspace.hasUnsavedChanges = false;
+  }
+}
+
+function onFileMenuUndo() {
+  const currentIndex = selectedElementIndex.value;
+
+  const textBoxDefaultFontFamilyPrevious =
+    score.value.pageSetup.textBoxDefaultFontFamily;
+  const textBoxDefaultFontSizePrevious =
+    score.value.pageSetup.textBoxDefaultFontSize;
+
+  commandService.value.undo();
+
+  // TODO this may be overkill, but the alternative is putting in place
+  // an event system to only refresh on certain undo actions
+  refreshStaffLyrics();
+
+  if (currentIndex > -1) {
+    // If the selected element was removed during the undo process, choose a new one
+    const clampedIndex = Math.min(currentIndex, elements.value.length - 1);
+
+    if (selectedElement.value !== elements.value[clampedIndex]) {
+      selectedElement.value = elements.value[clampedIndex];
+    }
+
+    // Undo/redo could affect the note display in the neume toolbar (among other things),
+    // so we force a refresh here
+    selectedElement.value.keyHelper++;
+  }
+
+  if (
+    textBoxDefaultFontFamilyPrevious !=
+      score.value.pageSetup.textBoxDefaultFontFamily ||
+    textBoxDefaultFontSizePrevious !=
+      score.value.pageSetup.textBoxDefaultFontSize
+  ) {
+    recalculateRichTextBoxHeights();
+    recalculateTextBoxHeights();
+  }
+
+  save();
+}
+
+function onFileMenuRedo() {
+  const currentIndex = selectedElementIndex.value;
+
+  const textBoxDefaultFontFamilyPrevious =
+    score.value.pageSetup.textBoxDefaultFontFamily;
+  const textBoxDefaultFontSizePrevious =
+    score.value.pageSetup.textBoxDefaultFontSize;
+
+  commandService.value.redo();
+
+  // TODO this may be overkill, but the alternative is putting in place
+  // an event system to only refresh on certain undo actions
+  refreshStaffLyrics();
+
+  if (currentIndex > -1) {
+    // If the selected element was removed during the redo process, choose a new one
+    const clampedIndex = Math.min(currentIndex, elements.value.length - 1);
+
+    if (selectedElement.value !== elements.value[clampedIndex]) {
+      selectedElement.value = elements.value[clampedIndex];
+    }
+
+    // Undo/redo could affect the note display in the neume toolbar (among other things),
+    // so we force a refresh here
+    selectedElement.value.keyHelper++;
+  }
+
+  if (
+    textBoxDefaultFontFamilyPrevious !=
+      score.value.pageSetup.textBoxDefaultFontFamily ||
+    textBoxDefaultFontSizePrevious !=
+      score.value.pageSetup.textBoxDefaultFontSize
+  ) {
+    recalculateRichTextBoxHeights();
+    recalculateTextBoxHeights();
+  }
+
+  save();
+}
+
+function onFileMenuCut() {
+  if (!isTextInputFocused() && !dialogOpen.value) {
+    onCutScoreElements();
+  } else {
+    document.execCommand('cut');
+  }
+}
+
+function onFileMenuCopy() {
+  if (!isTextInputFocused() && !dialogOpen.value) {
+    onCopyScoreElements();
+  } else {
+    document.execCommand('copy');
+  }
+}
+
+function onFileMenuCopyFormat() {
+  if (selectedElement.value == null) {
+    return;
+  }
+
+  if (selectedElement.value.elementType === ElementType.TextBox) {
+    formatType.value = ElementType.TextBox;
+    textBoxFormat.value = (
+      selectedElement.value as TextBoxElement
+    ).cloneFormat();
+  } else if (selectedElement.value.elementType === ElementType.Note) {
+    formatType.value = ElementType.Note;
+    noteFormat.value = (selectedElement.value as NoteElement).cloneFormat();
+  }
+}
+
+function onFileMenuCopyAsHtml() {
+  let copiedElements: ScoreElement[] = [];
+
+  if (selectionRange.value != null) {
+    copiedElements = elements.value.filter(
+      (x) => x.elementType != ElementType.Empty && isSelected(x),
+    );
+  } else if (selectedElement.value != null) {
+    copiedElements = [selectedElement.value];
+  } else if (selectedLyrics.value != null) {
+    copiedElements = [selectedLyrics.value];
+  }
+
+  const html = byzHtmlExporter.exportElements(
+    copiedElements,
+    score.value.pageSetup,
+    0,
+    true,
+  );
+
+  navigator.clipboard.writeText(html);
+}
+
+function onFileMenuPaste() {
+  if (!isTextInputFocused() && !dialogOpen.value) {
+    onPasteScoreElements(false);
+  } else {
+    ipcService.paste();
+  }
+}
+
+function onFileMenuPasteWithLyrics() {
+  if (!isTextInputFocused() && !dialogOpen.value) {
+    onPasteScoreElements(true);
+  } else {
+    ipcService.paste();
+  }
+}
+
+function onFileMenuPasteFormat() {
+  const normalizedRange = getNormalizedSelectionRange();
+
+  const commands: Command[] = [];
+
+  if (normalizedRange != null) {
+    for (let i = normalizedRange.start; i <= normalizedRange.end; i++) {
+      if (elements.value[i].elementType === formatType.value) {
+        applyCopiedFormat(elements.value[i], commands);
+      }
+    }
+  } else if (selectedElement.value != null) {
+    applyCopiedFormat(selectedElement.value, commands);
+  }
+
+  if (commands.length > 0) {
+    commandService.value.executeAsBatch(commands);
+    save();
+  }
+}
+
+function applyCopiedFormat(element: ScoreElement, commands: Command[]) {
+  if (
+    element.elementType === ElementType.TextBox &&
+    textBoxFormat.value != null
+  ) {
+    commands.push(
+      textBoxCommandFactory.create('update-properties', {
+        target: element as TextBoxElement,
+        newValues: textBoxFormat.value,
+      }),
+    );
+  } else if (
+    element.elementType === ElementType.Note &&
+    noteFormat.value != null
+  ) {
+    commands.push(
+      noteElementCommandFactory.create('update-properties', {
+        target: element as NoteElement,
+        newValues: noteFormat.value,
+      }),
+    );
+  }
+}
+
+function onFileMenuFind() {
+  if (searchTextPanelIsOpen.value) {
+    searchTextRef.value!.focus();
+  } else {
+    searchTextPanelIsOpen.value = true;
+  }
+}
+
+function onFileMenuLyrics() {
+  if (!dialogOpen.value) {
+    if (lyricManagerIsOpen.value) {
+      closeLyricManager();
+    } else {
+      openLyricManager();
+    }
+  }
+}
+
+function onFileMenuPreferences() {
+  if (!dialogOpen.value) {
+    editorPreferencesDialogIsOpen.value = true;
+  }
+}
+
+function onFileMenuGenerateTestFile(testFileType: TestFileType) {
+  const workspace = new Workspace();
+  workspace.tempFileName = getTempFilename();
+  workspace.score = new Score();
+
+  // The ison test page can be used to inspect the ison alignment
+  // provided by the font, so we disable the automatic ison alignment
+  if (testFileType === TestFileType.Ison) {
+    workspace.score.pageSetup.alignIsonIndicators = false;
+  }
+
+  addWorkspace(workspace);
+
+  selectedWorkspace.value = workspace;
+
+  currentFilePath.value = null;
+  score.value.staff.elements.unshift(
+    ...(TestFileGenerator.generateTestFile(testFileType, fonts.value) || []),
+  );
+  save();
+}
+
+function onSearchText(args: { query: string; reverse?: boolean }) {
+  const result = textSearchService.findTextInElements(
+    args.query,
+    elements.value,
+    selectedElementIndex.value,
+    args.reverse ?? false,
+  );
+
+  if (result != null) {
+    selectedElement.value = result;
+
+    (pagesRef.value as HTMLElement[])[
+      selectedElement.value.page - 1
+    ].scrollIntoView();
+
+    pages.value[selectedElement.value.page - 1].isVisible = true;
+
+    nextTick(() => {
+      if (selectedElement.value?.elementType === ElementType.Note) {
+        getTemplateRef<HTMLElement[]>(
+          `element-${selectedElementIndex.value}`,
+        )[0].scrollIntoView();
+      } else if (selectedElement.value?.elementType === ElementType.DropCap) {
+        getTemplateRef<InstanceType<typeof DropCap>[]>(
+          `element-${selectedElementIndex.value}`,
+        )[0].htmlElement.scrollIntoView();
+      } else if (selectedElement.value?.elementType === ElementType.TextBox) {
+        getTemplateRef<InstanceType<typeof TextBox>[]>(
+          `element-${selectedElementIndex.value}`,
+        )[0].htmlElement.scrollIntoView();
+      }
+    });
+  }
+}
+
+function createDefaultModeKey(pageSetup: PageSetup) {
+  const defaultTemplate = ModeKeyElement.createFromTemplate(
+    modeKeyTemplates[0],
+    score.value.pageSetup.useOptionalDiatonicFthoras,
+  );
+
+  defaultTemplate.color = pageSetup.modeKeyDefaultColor;
+  defaultTemplate.fontSize = pageSetup.modeKeyDefaultFontSize;
+  defaultTemplate.strokeWidth = pageSetup.modeKeyDefaultStrokeWidth;
+
+  return defaultTemplate;
+}
+
+function createDefaultScore() {
+  const score = new Score();
+
+  try {
+    const pageSetupDefault = localStorage.getItem('pageSetupDefault');
+
+    if (pageSetupDefault) {
+      SaveService.LoadPageSetup_v1(
+        score.pageSetup,
+        JSON.parse(pageSetupDefault),
+      );
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  const title = new TextBoxElement();
+  title.content = 'Title';
+  title.alignment = TextBoxAlignment.Center;
+  title.color = score.pageSetup.textBoxDefaultColor;
+  title.fontFamily = score.pageSetup.textBoxDefaultFontFamily;
+  title.fontSize = score.pageSetup.textBoxDefaultFontSize;
+  title.strokeWidth = score.pageSetup.textBoxDefaultStrokeWidth;
+  title.lineHeight = score.pageSetup.textBoxDefaultLineHeight;
+  title.bold = score.pageSetup.textBoxDefaultFontWeight === '700';
+  title.italic = score.pageSetup.textBoxDefaultFontStyle === 'italic';
+  title.height = Math.round(
+    TextMeasurementService.getFontHeight(title.computedFont) * 1.2,
+  );
+  score.staff.elements.unshift(title, createDefaultModeKey(score.pageSetup));
+
+  for (const element of score.headersAndFooters) {
+    if (element.elementType === ElementType.TextBox) {
+      (element as TextBoxElement).fontFamily =
+        score.pageSetup.lyricsDefaultFontFamily;
+      (element as TextBoxElement).strokeWidth =
+        score.pageSetup.lyricsDefaultStrokeWidth;
+    }
+  }
+
+  return score;
+}
+
+function openScore(args: FileMenuOpenScoreArgs) {
+  if (!args.success) {
+    return;
+  }
+
+  // First make sure we don't already have the score open
+  const existingWorkspace = workspaces.value.find(
+    (x) => x.filePath === args.filePath,
+  ) as Workspace;
+  if (existingWorkspace != null) {
+    selectedWorkspace.value = existingWorkspace;
+    return;
+  }
+
+  try {
+    const score: Score = SaveService.LoadScoreFromJson(JSON.parse(args.data));
+
+    // if (score.version !== ScoreVersion) {
+    //   alert('This score was created by an older version of the application. It may not work properly');
+    // }
+
+    const workspace = new Workspace();
+    workspace.filePath = args.filePath;
+    workspace.tempFileName = getTempFilename();
+    workspace.score = score;
+
+    addWorkspace(workspace);
+
+    selectedWorkspace.value = workspace;
+
+    selectedElement.value = null;
+
+    save(false);
+  } catch (error) {
+    args.success = false;
+    console.error(error);
+
+    if (error instanceof Error) {
+      if (ipcService.isShowMessageBoxSupported()) {
+        ipcService.showMessageBox({
+          type: 'error',
+          title: 'Open failed',
+          message: error.message,
+        });
       } else {
-        // If we got here, the workspace was already removed by closeWorkspace.
-        // We allow the tab component to close the tab by returning true.
-        return true;
+        alert(error.message);
       }
-    },
+    }
+  }
+}
 
-    openContextMenuForTab(event: PointerEvent, tab: Tab) {
-      // TODO for browser version, show a custom (non-native) context menu.
-      if (!this.isBrowser) {
-        this.ipcService.openContextMenuForTab({ workspaceId: tab.key });
-      }
-    },
+function addWorkspace(workspace: Workspace) {
+  workspaces.value.push(workspace);
 
-    renderTabLabel(tab: Tab) {
-      const workspace = this.workspaces.find(
-        (x) => x.id === tab.key,
-      ) as Workspace;
+  tabsRef.value!.addTab({
+    label: getFileName(workspace),
+    key: workspace.id,
+  });
+}
 
-      return workspace ? this.getFileName(workspace) : '';
-    },
-  },
-});
+function removeWorkspace(workspace: Workspace) {
+  const index = workspaces.value.indexOf(workspace);
+
+  workspaces.value.splice(index, 1);
+
+  tabsRef.value!.removeTab(workspace.id);
+
+  if (selectedWorkspace.value === workspace) {
+    if (workspaces.value.length > 0) {
+      selectedWorkspace.value = workspaces.value[
+        Math.min(index, workspaces.value.length - 1)
+      ] as Workspace;
+    } else {
+      // TODO support closing all workspaces
+      onFileMenuNewScore();
+    }
+  }
+}
+
+function onTabClosed(tab: Tab) {
+  const workspace = workspaces.value.find((x) => x.id === tab.key) as Workspace;
+
+  if (workspace) {
+    // If the workspace is still in our list, then call closeWorkspace.
+    // closeWorkspace will decide whether to remove the tab and will
+    // explicitly call removeTab. Returning false tells the tab component
+    // to not close the tab, so that we can take care of it manually.
+    closeWorkspace(workspace);
+    return false;
+  } else {
+    // If we got here, the workspace was already removed by closeWorkspace.
+    // We allow the tab component to close the tab by returning true.
+    return true;
+  }
+}
+
+function openContextMenuForTab(event: PointerEvent, tab: Tab) {
+  // TODO for browser version, show a custom (non-native) context menu.
+  if (!isBrowser.value) {
+    ipcService.openContextMenuForTab({ workspaceId: tab.key });
+  }
+}
+
+function renderTabLabel(tab: Tab) {
+  const workspace = workspaces.value.find((x) => x.id === tab.key) as Workspace;
+
+  return workspace ? getFileName(workspace) : '';
+}
 </script>
 
 <template>
@@ -6246,7 +5767,7 @@ export default defineComponent({
       <div class="page-container">
         <!-- @vue-ignore -->
         <Vue3TabsChrome
-          ref="tabs"
+          ref="tabsRef"
           v-model="selectedWorkspaceId"
           class="workspace-tab-container"
           :tabs="tabs"
@@ -6266,20 +5787,20 @@ export default defineComponent({
         >
         <SearchText
           v-if="searchTextPanelIsOpen"
-          ref="searchText"
+          ref="searchTextRef"
           v-model:query="searchTextQuery"
           @search="onSearchText"
           @close="searchTextPanelIsOpen = false"
         />
         <div
-          ref="page-background"
+          ref="pageBackgroundRef"
           class="page-background"
           @scroll="throttled.onScroll"
         >
           <div
             v-for="(page, pageIndex) in filteredPages"
             :key="`page-${pageIndex}`"
-            ref="pages"
+            ref="pagesRef"
             v-observe-visibility="{
               callback: (isVisible: boolean) =>
                 updatePageVisibility(page, isVisible),

--- a/src/components/ToolbarDropCap.vue
+++ b/src/components/ToolbarDropCap.vue
@@ -154,8 +154,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
 
 import ColorPicker from '@/components/ColorPicker.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
@@ -165,54 +165,35 @@ import { DropCapElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
 import { Unit } from '@/utils/Unit';
 
-export default defineComponent({
-  components: { ColorPicker, InputFontSize, InputStrokeWidth, InputUnit },
-  props: {
-    element: {
-      type: Object as PropType<DropCapElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    fonts: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<DropCapElement>,
+    required: true,
   },
-  emits: ['update', 'update:sectionName'],
-
-  data() {
-    return {};
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    bold() {
-      return this.element.fontWeight === '700';
-    },
-
-    italic() {
-      return this.element.fontStyle === 'italic';
-    },
-
-    dropCapFontFamilies() {
-      return [
-        'Source Serif',
-        'GFS Didot',
-        'Noto Naskh Arabic',
-        'Old Standard',
-        ...this.fonts,
-      ];
-    },
-
-    maxWidth() {
-      return Unit.toPt(this.pageSetup.innerPageWidth);
-    },
+  fonts: {
+    type: Array as PropType<string[]>,
+    required: true,
   },
-
-  methods: {},
 });
+
+defineEmits(['update', 'update:sectionName']);
+
+const bold = computed(() => props.element.fontWeight === '700');
+const italic = computed(() => props.element.fontStyle === 'italic');
+
+const dropCapFontFamilies = computed(() => [
+  'Source Serif',
+  'GFS Didot',
+  'Noto Naskh Arabic',
+  'Old Standard',
+  ...props.fonts,
+]);
+
+const maxWidth = computed(() => Unit.toPt(props.pageSetup.innerPageWidth));
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarImageBox.vue
+++ b/src/components/ToolbarImageBox.vue
@@ -121,68 +121,56 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { PropType } from 'vue';
 
 import { ImageBoxElement, TextBoxAlignment } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
 
 import InputUnit from './InputUnit.vue';
 
-export default defineComponent({
-  components: { InputUnit },
-  props: {
-    element: {
-      type: Object as PropType<ImageBoxElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<ImageBoxElement>,
+    required: true,
   },
-  emits: ['update'],
-
-  data() {
-    return {
-      TextBoxAlignment,
-    };
-  },
-
-  computed: {},
-
-  methods: {
-    onChangeHeight(height: number) {
-      const aspectRatio = this.element.aspectRatio;
-
-      let width = this.element.imageWidth;
-
-      if (this.element.lockAspectRatio) {
-        width = height * aspectRatio;
-      }
-
-      this.$emit('update', {
-        imageWidth: width,
-        imageHeight: height,
-      } as Partial<ImageBoxElement>);
-    },
-
-    onChangeWidth(width: number) {
-      const aspectRatio = this.element.aspectRatio;
-
-      let height = this.element.imageHeight;
-
-      if (this.element.lockAspectRatio) {
-        height = width / aspectRatio;
-      }
-
-      this.$emit('update', {
-        imageWidth: width,
-        imageHeight: height,
-      } as Partial<ImageBoxElement>);
-    },
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
 });
+
+const emit = defineEmits(['update']);
+
+function onChangeHeight(height: number) {
+  const aspectRatio = props.element.aspectRatio;
+
+  let width = props.element.imageWidth;
+
+  if (props.element.lockAspectRatio) {
+    width = height * aspectRatio;
+  }
+
+  emit('update', {
+    imageWidth: width,
+    imageHeight: height,
+  } as Partial<ImageBoxElement>);
+}
+
+function onChangeWidth(width: number) {
+  const aspectRatio = props.element.aspectRatio;
+
+  let height = props.element.imageHeight;
+
+  if (props.element.lockAspectRatio) {
+    height = width / aspectRatio;
+  }
+
+  emit('update', {
+    imageWidth: width,
+    imageHeight: height,
+  } as Partial<ImageBoxElement>);
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarLyrics.vue
+++ b/src/components/ToolbarLyrics.vue
@@ -129,8 +129,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
 
 import ColorPicker from '@/components/ColorPicker.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
@@ -156,54 +156,32 @@ const specialCharacters = [
   { value: GREEK_OU, language: 'greek' },
 ];
 
-export default defineComponent({
-  components: { ColorPicker, InputFontSize, InputStrokeWidth },
-  props: {
-    element: {
-      type: Object as PropType<NoteElement>,
-      required: true,
-    },
-    fonts: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<NoteElement>,
+    required: true,
   },
-  emits: ['insert:specialCharacter', 'update'],
-
-  data() {
-    return {
-      GORTHMIKON,
-      PELASTIKON,
-      specialCharacters,
-    };
+  fonts: {
+    type: Array as PropType<string[]>,
+    required: true,
   },
-
-  computed: {
-    bold() {
-      return this.element.lyricsFontWeight === '700';
-    },
-
-    italic() {
-      return this.element.lyricsFontStyle === 'italic';
-    },
-
-    underline() {
-      return this.element.lyricsTextDecoration === 'underline';
-    },
-
-    lyricsFontFamilies() {
-      return [
-        'Source Serif',
-        'GFS Didot',
-        'Noto Naskh Arabic',
-        'Old Standard',
-        ...this.fonts,
-      ];
-    },
-  },
-
-  methods: {},
 });
+
+defineEmits(['insert:specialCharacter', 'update']);
+
+const bold = computed(() => props.element.lyricsFontWeight === '700');
+const italic = computed(() => props.element.lyricsFontStyle === 'italic');
+const underline = computed(
+  () => props.element.lyricsTextDecoration === 'underline',
+);
+
+const lyricsFontFamilies = computed(() => [
+  'Source Serif',
+  'GFS Didot',
+  'Noto Naskh Arabic',
+  'Old Standard',
+  ...props.fonts,
+]);
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarMain.vue
+++ b/src/components/ToolbarMain.vue
@@ -233,13 +233,14 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { computed, getCurrentInstance, PropType, ref } from 'vue';
 
 import InputUnit from '@/components/InputUnit.vue';
 import { LineBreakType } from '@/models/Element';
 import { EntryMode } from '@/models/EntryMode';
-import { Note, RootSign, TempoSign } from '@/models/Neumes';
+import { TempoSign } from '@/models/Neumes';
 import { AudioState } from '@/services/audio/AudioService';
 import { PlaybackOptions } from '@/services/audio/PlaybackService';
 import { NeumeKeyboard } from '@/services/NeumeKeyboard';
@@ -281,146 +282,124 @@ const tempoOptions: ButtonWithMenuOption[] = [
   },
 ];
 
-export default defineComponent({
-  components: { ButtonWithMenu, InputUnit },
-  props: {
-    entryMode: {
-      type: String as PropType<EntryMode>,
-      required: true,
-    },
-    audioState: {
-      type: String as PropType<AudioState>,
-      required: true,
-    },
-    audioOptions: {
-      type: Object as PropType<PlaybackOptions>,
-      required: true,
-    },
-    neumeKeyboard: {
-      type: Object as PropType<NeumeKeyboard>,
-      required: true,
-    },
-    zoom: {
-      type: Number,
-      required: true,
-    },
-    zoomToFit: {
-      type: Boolean,
-      required: true,
-    },
-    currentPageNumber: {
-      type: Number,
-      required: true,
-    },
-    pageCount: {
-      type: Number,
-      required: true,
-    },
-    playbackTime: {
-      type: Number,
-      required: true,
-    },
-    playbackBpm: {
-      type: Number,
-      required: true,
-    },
+const props = defineProps({
+  entryMode: {
+    type: String as PropType<EntryMode>,
+    required: true,
   },
-  emits: [
-    'add-auto-martyria',
-    'add-drop-cap',
-    'add-image',
-    'add-mode-key',
-    'add-tempo',
-    'add-text-box',
-    'add-text-box-rich',
-    'delete-selected-element',
-    'open-playback-settings',
-    'play-audio',
-    'toggle-line-break',
-    'toggle-page-break',
-    'update:audioOptionsSpeed',
-    'update:entryMode',
-    'update:zoom',
-    'update:zoomToFit',
-  ],
-
-  data() {
-    return {
-      Note,
-      RootSign,
-      TempoSign,
-      EntryMode,
-      AudioState,
-      LineBreakType,
-
-      showZoomMenu: false,
-
-      zoomOptions: ['50', '75', '90', '100', '125', '150', '200', '500'],
-
-      tempoOptions,
-    };
+  audioState: {
+    type: String as PropType<AudioState>,
+    required: true,
   },
-
-  computed: {
-    zoomDisplay() {
-      return this.zoomToFit ? 'Fit' : (this.zoom * 100).toFixed(0) + '%';
-    },
-
-    speedDisplay() {
-      return (this.audioOptions.speed * 100).toFixed(0) + '%';
-    },
-
-    playbackTimeDisplay() {
-      // Round to the nearest tenth to eliminate floating point errors
-      // E.g. 4.999999... should give 0:00:05:0, instead of 0:00:04:0
-      const roundedTime = Math.round(this.playbackTime * 10) / 10;
-
-      const hours = Math.floor(roundedTime / 3600);
-      const minutes = Math.floor((roundedTime % 3600) / 60);
-      const seconds = Math.floor(roundedTime % 60);
-      const tenths = roundedTime.toFixed(1).split('.')[1];
-
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}:${tenths}`;
-    },
-
-    playbackBpmDisplay() {
-      return this.playbackBpm.toFixed(0);
-    },
-
-    martyriaTooltip() {
-      return `${this.$t(($) => $.toolbar.main.martyria, { ns: 'toolbar' })} (${this.neumeKeyboard.getMartyriaKeyTooltip()})`;
-    },
-
-    tempoTooltip() {
-      return `${this.$t(($) => $.toolbar.common.tempoSign, { ns: 'toolbar' })} (${this.neumeKeyboard.generateTooltip(
-        this.neumeKeyboard.findMappingForNeume(TempoSign.VerySlow)!,
-      )})`;
-    },
+  audioOptions: {
+    type: Object as PropType<PlaybackOptions>,
+    required: true,
   },
-
-  methods: {
-    updateZoom(value: string) {
-      this.showZoomMenu = false;
-
-      if (value === 'Fit') {
-        this.$emit('update:zoomToFit', true);
-        return;
-      }
-
-      let valueAsNumber = parseInt(value);
-
-      if (Number.isNaN(valueAsNumber)) {
-        valueAsNumber = 100;
-      }
-
-      this.$emit('update:zoom', valueAsNumber / 100);
-
-      this.showZoomMenu = false;
-
-      this.$forceUpdate();
-    },
+  neumeKeyboard: {
+    type: Object as PropType<NeumeKeyboard>,
+    required: true,
+  },
+  zoom: {
+    type: Number,
+    required: true,
+  },
+  zoomToFit: {
+    type: Boolean,
+    required: true,
+  },
+  currentPageNumber: {
+    type: Number,
+    required: true,
+  },
+  pageCount: {
+    type: Number,
+    required: true,
+  },
+  playbackTime: {
+    type: Number,
+    required: true,
+  },
+  playbackBpm: {
+    type: Number,
+    required: true,
   },
 });
+
+const emit = defineEmits([
+  'add-auto-martyria',
+  'add-drop-cap',
+  'add-image',
+  'add-mode-key',
+  'add-tempo',
+  'add-text-box',
+  'add-text-box-rich',
+  'delete-selected-element',
+  'open-playback-settings',
+  'play-audio',
+  'toggle-line-break',
+  'toggle-page-break',
+  'update:audioOptionsSpeed',
+  'update:entryMode',
+  'update:zoom',
+  'update:zoomToFit',
+]);
+
+const { t } = useTranslation();
+const instance = getCurrentInstance();
+const showZoomMenu = ref(false);
+const zoomOptions = ['50', '75', '90', '100', '125', '150', '200', '500'];
+
+const zoomDisplay = computed(() =>
+  props.zoomToFit ? 'Fit' : (props.zoom * 100).toFixed(0) + '%',
+);
+
+const playbackTimeDisplay = computed(() => {
+  // Round to the nearest tenth to eliminate floating point errors
+  // E.g. 4.999999... should give 0:00:05:0, instead of 0:00:04:0
+  const roundedTime = Math.round(props.playbackTime * 10) / 10;
+
+  const hours = Math.floor(roundedTime / 3600);
+  const minutes = Math.floor((roundedTime % 3600) / 60);
+  const seconds = Math.floor(roundedTime % 60);
+  const tenths = roundedTime.toFixed(1).split('.')[1];
+
+  return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}:${tenths}`;
+});
+
+const playbackBpmDisplay = computed(() => props.playbackBpm.toFixed(0));
+
+const martyriaTooltip = computed(
+  () =>
+    `${t(($) => $.toolbar.main.martyria, { ns: 'toolbar' })} (${props.neumeKeyboard.getMartyriaKeyTooltip()})`,
+);
+
+const tempoTooltip = computed(
+  () =>
+    `${t(($) => $.toolbar.common.tempoSign, { ns: 'toolbar' })} (${props.neumeKeyboard.generateTooltip(
+      props.neumeKeyboard.findMappingForNeume(TempoSign.VerySlow)!,
+    )})`,
+);
+
+function updateZoom(value: string) {
+  showZoomMenu.value = false;
+
+  if (value === 'Fit') {
+    emit('update:zoomToFit', true);
+    return;
+  }
+
+  let valueAsNumber = parseInt(value);
+
+  if (Number.isNaN(valueAsNumber)) {
+    valueAsNumber = 100;
+  }
+
+  emit('update:zoom', valueAsNumber / 100);
+
+  showZoomMenu.value = false;
+
+  instance?.proxy?.$forceUpdate();
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarMain.vue
+++ b/src/components/ToolbarMain.vue
@@ -139,6 +139,7 @@
     <span class="space"></span>
     <div class="zoom-container" tabindex="-1" @focusout="showZoomMenu = false">
       <input
+        ref="zoomInput"
         class="zoom"
         :value="zoomDisplay"
         @change="updateZoom(($event.target as HTMLInputElement).value)"
@@ -235,7 +236,7 @@
 
 <script setup lang="ts">
 import { useTranslation } from 'i18next-vue';
-import { computed, getCurrentInstance, PropType, ref } from 'vue';
+import { computed, nextTick, PropType, ref, useTemplateRef } from 'vue';
 
 import InputUnit from '@/components/InputUnit.vue';
 import { LineBreakType } from '@/models/Element';
@@ -245,7 +246,8 @@ import { AudioState } from '@/services/audio/AudioService';
 import { PlaybackOptions } from '@/services/audio/PlaybackService';
 import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 
-import ButtonWithMenu, { ButtonWithMenuOption } from './ButtonWithMenu.vue';
+import type { ButtonWithMenuOption } from './ButtonWithMenu.types';
+import ButtonWithMenu from './ButtonWithMenu.vue';
 
 const tempoOptions: ButtonWithMenuOption[] = [
   {
@@ -345,8 +347,8 @@ const emit = defineEmits([
 ]);
 
 const { t } = useTranslation();
-const instance = getCurrentInstance();
 const showZoomMenu = ref(false);
+const zoomInput = useTemplateRef<HTMLInputElement>('zoomInput');
 const zoomOptions = ['50', '75', '90', '100', '125', '150', '200', '500'];
 
 const zoomDisplay = computed(() =>
@@ -385,6 +387,7 @@ function updateZoom(value: string) {
 
   if (value === 'Fit') {
     emit('update:zoomToFit', true);
+    resetZoomInput();
     return;
   }
 
@@ -397,8 +400,15 @@ function updateZoom(value: string) {
   emit('update:zoom', valueAsNumber / 100);
 
   showZoomMenu.value = false;
+  resetZoomInput();
+}
 
-  instance?.proxy?.$forceUpdate();
+function resetZoomInput() {
+  nextTick(() => {
+    if (zoomInput.value != null) {
+      zoomInput.value.value = zoomDisplay.value;
+    }
+  });
 }
 </script>
 

--- a/src/components/ToolbarMartyria.vue
+++ b/src/components/ToolbarMartyria.vue
@@ -360,8 +360,9 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { computed, PropType } from 'vue';
 
 import { MartyriaElement } from '@/models/Element';
 import {
@@ -582,258 +583,231 @@ const barlineMenuOptions: ButtonWithMenuOption[] = [
   },
 ];
 
-export default defineComponent({
-  components: { InputUnit, InputBpm, ButtonWithMenu },
-  props: {
-    element: {
-      type: Object as PropType<MartyriaElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    neumeKeyboard: {
-      type: Object as PropType<NeumeKeyboard>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<MartyriaElement>,
+    required: true,
   },
-  emits: [
-    'update',
-    'update:fthora',
-    'update:measureBar',
-    'update:quantitativeNeume',
-    'update:sectionName',
-    'update:tempoLeft',
-    'update:tempo',
-    'update:tempoRight',
-  ],
-
-  data() {
-    return {
-      Fthora,
-      MeasureBar,
-      TempoSign,
-      rootSigns,
-      notes,
-      scales,
-      chromaticFthoras,
-      quantitativeNeumeOptions,
-      tempoMenuOptions,
-      tempoMenuOptionsAbove,
-      barlineMenuOptions,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    spaceAfterMax() {
-      return Math.round(Unit.toPt(this.pageSetup.pageWidth));
-    },
-    spathiDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        this.element.note !== Note.Ke &&
-        this.element.note !== Note.Ga
-      );
-    },
-
-    spathiTitle() {
-      return this.spathiDisabled
-        ? this.$t(($) => $.toolbar.common.spathiDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Spathi_Top);
-    },
-
-    klitonDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions && this.element.note !== Note.Thi
-      );
-    },
-
-    klitonTitle() {
-      return this.klitonDisabled
-        ? this.$t(($) => $.toolbar.common.klitonDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Kliton_Top);
-    },
-
-    zygosDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions && this.element.note !== Note.Thi
-      );
-    },
-
-    zygosTitle() {
-      return this.zygosDisabled
-        ? this.$t(($) => $.toolbar.common.zygosDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Zygos_Top);
-    },
-
-    enharmonicDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        this.element.note !== Note.Zo &&
-        this.element.note !== Note.ZoHigh &&
-        this.element.note !== Note.Vou &&
-        this.element.note !== Note.VouHigh &&
-        this.element.note !== Note.Ga
-      );
-    },
-
-    enharmonicTitle() {
-      return this.enharmonicDisabled
-        ? this.$t(($) => $.toolbar.common.enharmonicDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Enharmonic_Top);
-    },
-
-    generalFlatDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions && this.element.note !== Note.Ke
-      );
-    },
-
-    generalFlatTitle() {
-      return this.generalFlatDisabled
-        ? this.$t(($) => $.toolbar.common.generalFlatDisabled, {
-            ns: 'toolbar',
-          })
-        : this.tooltip(Fthora.GeneralFlat_Top);
-    },
-
-    generalSharpDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions && this.element.note !== Note.Ga
-      );
-    },
-
-    generalSharpTitle() {
-      return this.generalSharpDisabled
-        ? this.$t(($) => $.toolbar.common.generalSharpDisabled, {
-            ns: 'toolbar',
-          })
-        : this.tooltip(Fthora.GeneralSharp_Top);
-    },
-
-    showChromaticFthoraNote() {
-      return (
-        this.element.fthora != null &&
-        this.chromaticFthoras.includes(this.element.fthora)
-      );
-    },
-
-    alignRightTooltip() {
-      return `${this.$t(($) => $.toolbar.common.alignRight, { ns: 'toolbar' })}(${this.neumeKeyboard.getMaryriaRightAlignTooltip()})`;
-    },
-
-    fthoraNotes(): FthoraNoteOption[] {
-      if (
-        this.element.fthora === Fthora.SoftChromaticThi_Top ||
-        this.element.fthora === Fthora.SoftChromaticThi_Bottom
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.ZoHigh),
-            value: ScaleNote.ZoHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Thi),
-            value: ScaleNote.Thi,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Vou),
-            value: ScaleNote.Vou,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ni),
-            value: ScaleNote.Ni,
-          },
-        ];
-      } else if (
-        this.element.fthora === Fthora.SoftChromaticPa_Top ||
-        this.element.fthora === Fthora.SoftChromaticPa_Bottom
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.NiHigh),
-            value: ScaleNote.NiHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ke),
-            value: ScaleNote.Ke,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ga),
-            value: ScaleNote.Ga,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Pa),
-            value: ScaleNote.Pa,
-          },
-        ];
-      } else if (
-        this.element.fthora === Fthora.HardChromaticThi_Top ||
-        this.element.fthora === Fthora.HardChromaticThi_Bottom
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.ZoHigh),
-            value: ScaleNote.ZoHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Thi),
-            value: ScaleNote.Thi,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Vou),
-            value: ScaleNote.Vou,
-          },
-        ];
-      } else if (
-        this.element.fthora === Fthora.HardChromaticPa_Top ||
-        this.element.fthora === Fthora.HardChromaticPa_Bottom
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.NiHigh),
-            value: ScaleNote.NiHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ke),
-            value: ScaleNote.Ke,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ga),
-            value: ScaleNote.Ga,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Pa),
-            value: ScaleNote.Pa,
-          },
-        ];
-      }
-
-      return [];
-    },
-  },
-
-  methods: {
-    translateNeumeDisplayName(neume: Fthora | MeasureBar.MeasureBarRight) {
-      if (neume === MeasureBar.MeasureBarRight) {
-        return this.$t(($) => $.toolbar.common.measureBar, { ns: 'toolbar' });
-      }
-
-      return this.$t(getFthoraLabelSelector(neume), { ns: 'model' });
-    },
-
-    tooltip(neume: Fthora | MeasureBar.MeasureBarRight) {
-      const label = this.translateNeumeDisplayName(neume);
-      const mapping = this.neumeKeyboard.findMappingForNeume(neume);
-      if (mapping) {
-        return `${label} (${this.neumeKeyboard.generateTooltip(mapping)})`;
-      } else {
-        return label;
-      }
-    },
+  neumeKeyboard: {
+    type: Object as PropType<NeumeKeyboard>,
+    required: true,
   },
 });
+
+defineEmits([
+  'update',
+  'update:fthora',
+  'update:measureBar',
+  'update:quantitativeNeume',
+  'update:sectionName',
+  'update:tempoLeft',
+  'update:tempo',
+  'update:tempoRight',
+]);
+
+const { t } = useTranslation();
+
+const spaceAfterMax = computed(() =>
+  Math.round(Unit.toPt(props.pageSetup.pageWidth)),
+);
+
+const spathiDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    props.element.note !== Note.Ke &&
+    props.element.note !== Note.Ga,
+);
+
+const spathiTitle = computed(() =>
+  spathiDisabled.value
+    ? t(($) => $.toolbar.common.spathiDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Spathi_Top),
+);
+
+const klitonDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions && props.element.note !== Note.Thi,
+);
+
+const klitonTitle = computed(() =>
+  klitonDisabled.value
+    ? t(($) => $.toolbar.common.klitonDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Kliton_Top),
+);
+
+const zygosDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions && props.element.note !== Note.Thi,
+);
+
+const zygosTitle = computed(() =>
+  zygosDisabled.value
+    ? t(($) => $.toolbar.common.zygosDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Zygos_Top),
+);
+
+const enharmonicDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    props.element.note !== Note.Zo &&
+    props.element.note !== Note.ZoHigh &&
+    props.element.note !== Note.Vou &&
+    props.element.note !== Note.VouHigh &&
+    props.element.note !== Note.Ga,
+);
+
+const enharmonicTitle = computed(() =>
+  enharmonicDisabled.value
+    ? t(($) => $.toolbar.common.enharmonicDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Enharmonic_Top),
+);
+
+const generalFlatDisabled = computed(
+  () => !props.pageSetup.noFthoraRestrictions && props.element.note !== Note.Ke,
+);
+
+const generalFlatTitle = computed(() =>
+  generalFlatDisabled.value
+    ? t(($) => $.toolbar.common.generalFlatDisabled, {
+        ns: 'toolbar',
+      })
+    : tooltip(Fthora.GeneralFlat_Top),
+);
+
+const generalSharpDisabled = computed(
+  () => !props.pageSetup.noFthoraRestrictions && props.element.note !== Note.Ga,
+);
+
+const generalSharpTitle = computed(() =>
+  generalSharpDisabled.value
+    ? t(($) => $.toolbar.common.generalSharpDisabled, {
+        ns: 'toolbar',
+      })
+    : tooltip(Fthora.GeneralSharp_Top),
+);
+
+const showChromaticFthoraNote = computed(
+  () =>
+    props.element.fthora != null &&
+    chromaticFthoras.includes(props.element.fthora),
+);
+
+const alignRightTooltip = computed(
+  () =>
+    `${t(($) => $.toolbar.common.alignRight, { ns: 'toolbar' })}(${props.neumeKeyboard.getMaryriaRightAlignTooltip()})`,
+);
+
+const fthoraNotes = computed((): FthoraNoteOption[] => {
+  if (
+    props.element.fthora === Fthora.SoftChromaticThi_Top ||
+    props.element.fthora === Fthora.SoftChromaticThi_Bottom
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.ZoHigh),
+        value: ScaleNote.ZoHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Thi),
+        value: ScaleNote.Thi,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Vou),
+        value: ScaleNote.Vou,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ni),
+        value: ScaleNote.Ni,
+      },
+    ];
+  } else if (
+    props.element.fthora === Fthora.SoftChromaticPa_Top ||
+    props.element.fthora === Fthora.SoftChromaticPa_Bottom
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.NiHigh),
+        value: ScaleNote.NiHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ke),
+        value: ScaleNote.Ke,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ga),
+        value: ScaleNote.Ga,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Pa),
+        value: ScaleNote.Pa,
+      },
+    ];
+  } else if (
+    props.element.fthora === Fthora.HardChromaticThi_Top ||
+    props.element.fthora === Fthora.HardChromaticThi_Bottom
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.ZoHigh),
+        value: ScaleNote.ZoHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Thi),
+        value: ScaleNote.Thi,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Vou),
+        value: ScaleNote.Vou,
+      },
+    ];
+  } else if (
+    props.element.fthora === Fthora.HardChromaticPa_Top ||
+    props.element.fthora === Fthora.HardChromaticPa_Bottom
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.NiHigh),
+        value: ScaleNote.NiHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ke),
+        value: ScaleNote.Ke,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ga),
+        value: ScaleNote.Ga,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Pa),
+        value: ScaleNote.Pa,
+      },
+    ];
+  }
+
+  return [];
+});
+
+function translateNeumeDisplayName(neume: Fthora | MeasureBar.MeasureBarRight) {
+  if (neume === MeasureBar.MeasureBarRight) {
+    return t(($) => $.toolbar.common.measureBar, { ns: 'toolbar' });
+  }
+
+  return t(getFthoraLabelSelector(neume), { ns: 'model' });
+}
+
+function tooltip(neume: Fthora | MeasureBar.MeasureBarRight) {
+  const label = translateNeumeDisplayName(neume);
+  const mapping = props.neumeKeyboard.findMappingForNeume(neume);
+  if (mapping) {
+    return `${label} (${props.neumeKeyboard.generateTooltip(mapping)})`;
+  } else {
+    return label;
+  }
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarMartyria.vue
+++ b/src/components/ToolbarMartyria.vue
@@ -386,7 +386,8 @@ import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 import { NeumeMappingService } from '@/services/NeumeMappingService';
 import { Unit } from '@/utils/Unit';
 
-import ButtonWithMenu, { ButtonWithMenuOption } from './ButtonWithMenu.vue';
+import type { ButtonWithMenuOption } from './ButtonWithMenu.types';
+import ButtonWithMenu from './ButtonWithMenu.vue';
 import InputBpm from './InputBpm.vue';
 import InputUnit from './InputUnit.vue';
 

--- a/src/components/ToolbarModeKey.vue
+++ b/src/components/ToolbarModeKey.vue
@@ -284,7 +284,8 @@ import { TempoSign } from '@/models/Neumes';
 import { PageSetup } from '@/models/PageSetup';
 import { Unit } from '@/utils/Unit';
 
-import ButtonWithMenu, { ButtonWithMenuOption } from './ButtonWithMenu.vue';
+import type { ButtonWithMenuOption } from './ButtonWithMenu.types';
+import ButtonWithMenu from './ButtonWithMenu.vue';
 
 const tempoMenuOptions: ButtonWithMenuOption[] = [
   {

--- a/src/components/ToolbarModeKey.vue
+++ b/src/components/ToolbarModeKey.vue
@@ -271,8 +271,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
 
 import ColorPicker from '@/components/ColorPicker.vue';
 import InputBpm from '@/components/InputBpm.vue';
@@ -321,55 +321,33 @@ const tempoMenuOptions: ButtonWithMenuOption[] = [
   },
 ];
 
-export default defineComponent({
-  components: {
-    ColorPicker,
-    InputUnit,
-    InputBpm,
-    InputFontSize,
-    InputStrokeWidth,
-    ButtonWithMenu,
+const props = defineProps({
+  element: {
+    type: Object as PropType<ModeKeyElement>,
+    required: true,
   },
-  props: {
-    element: {
-      type: Object as PropType<ModeKeyElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-  emits: [
-    'open-mode-key-dialog',
-    'update',
-    'update:sectionName',
-    'update:tempo',
-  ],
-
-  data() {
-    return {
-      TextBoxAlignment,
-      tempoMenuOptions,
-    };
-  },
-
-  computed: {
-    heightAdjustmentMin() {
-      return -Math.round(Unit.fromPt(this.element.height));
-    },
-
-    heightAdjustmentMax() {
-      return Unit.toPt(this.pageSetup.pageHeight);
-    },
-
-    maxHeight() {
-      return Unit.toPt(this.pageSetup.innerPageHeight);
-    },
-  },
-
-  methods: {},
 });
+
+defineEmits([
+  'open-mode-key-dialog',
+  'update',
+  'update:sectionName',
+  'update:tempo',
+]);
+
+const heightAdjustmentMin = computed(
+  () => -Math.round(Unit.fromPt(props.element.height)),
+);
+
+const heightAdjustmentMax = computed(() =>
+  Unit.toPt(props.pageSetup.pageHeight),
+);
+
+const maxHeight = computed(() => Unit.toPt(props.pageSetup.innerPageHeight));
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -524,9 +524,8 @@
 import { useTranslation } from 'i18next-vue';
 import { computed, PropType } from 'vue';
 
-import ButtonWithMenu, {
-  ButtonWithMenuOption,
-} from '@/components/ButtonWithMenu.vue';
+import type { ButtonWithMenuOption } from '@/components/ButtonWithMenu.types';
+import ButtonWithMenu from '@/components/ButtonWithMenu.vue';
 import InputUnit from '@/components/InputUnit.vue';
 import { AcceptsLyricsOption, NoteElement } from '@/models/Element';
 import {

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -520,8 +520,9 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { computed, PropType } from 'vue';
 
 import ButtonWithMenu, {
   ButtonWithMenuOption,
@@ -564,7 +565,7 @@ import { ScaleNote } from '@/models/Scales';
 import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 import { Unit } from '@/utils/Unit';
 
-import NeumeVue from './NeumeGlyph.vue';
+import Neume from './NeumeGlyph.vue';
 
 const chromaticFthoras = [
   Fthora.SoftChromaticPa_Top,
@@ -899,503 +900,457 @@ const isonMenuOptions: ButtonWithMenuOption[] = [
   },
 ];
 
-export default defineComponent({
-  components: { InputUnit, ButtonWithMenu, Neume: NeumeVue },
-  props: {
-    element: {
-      type: Object as PropType<NoteElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    innerNeume: {
-      type: String,
-      required: true,
-    },
-    neumeKeyboard: {
-      type: Object as PropType<NeumeKeyboard>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<NoteElement>,
+    required: true,
   },
-  emits: [
-    'update',
-    'open-syllable-positioning-dialog',
-    'update:accidental',
-    'update:expression',
-    'update:fthora',
-    'update:gorgon',
-    'update:innerNeume',
-    'update:ison',
-    'update:klasma',
-    'update:measureBar',
-    'update:measureNumber',
-    'update:secondaryAccidental',
-    'update:secondaryFthora',
-    'update:secondaryGorgon',
-    'update:sectionName',
-    'update:tertiaryAccidental',
-    'update:tertiaryFthora',
-    'update:tie',
-    'update:time',
-  ],
-
-  data() {
-    return {
-      Accidental,
-      GorgonNeume,
-      Fthora,
-      MeasureBar,
-      MeasureNumber,
-      NoteIndicator,
-      Ison,
-      Tie,
-      TimeNeume,
-      VocalExpressionNeume,
-
-      AcceptsLyricsOption,
-
-      chromaticFthoras,
-      apliMenuOptions,
-      gorgonMenuOptions,
-      digorgonMenuOptions,
-      trigorgonMenuOptions,
-      sharpMenuOptions,
-      flatMenuOptions,
-      isonMenuOptions,
-      psifistonMenuOptions,
-      heteronConnectingMenuOptions,
-      barlineMenuOptions,
-      measureNumberMenuOptions,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    primaryNeume() {
-      return getPrimaryNeume(this.element.quantitativeNeume);
-    },
-
-    secondaryNeume() {
-      return getSecondaryNeume(this.element.quantitativeNeume);
-    },
-
-    tertiaryNeume() {
-      return getTertiaryNeume(this.element.quantitativeNeume);
-    },
-
-    notes(): ChromaticFthoraNoteOption[] {
-      if (
-        this.element.fthora === Fthora.SoftChromaticThi_Top ||
-        this.element.fthora === Fthora.SoftChromaticThi_Bottom ||
-        this.element.secondaryFthora === Fthora.SoftChromaticThi_TopSecondary ||
-        this.element.tertiaryFthora === Fthora.SoftChromaticThi_TopTertiary
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.ZoHigh),
-            value: ScaleNote.ZoHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Thi),
-            value: ScaleNote.Thi,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Vou),
-            value: ScaleNote.Vou,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ni),
-            value: ScaleNote.Ni,
-          },
-        ];
-      } else if (
-        this.element.fthora === Fthora.SoftChromaticPa_Top ||
-        this.element.fthora === Fthora.SoftChromaticPa_Bottom ||
-        this.element.secondaryFthora === Fthora.SoftChromaticPa_TopSecondary ||
-        this.element.tertiaryFthora === Fthora.SoftChromaticPa_TopTertiary
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.NiHigh),
-            value: ScaleNote.NiHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ke),
-            value: ScaleNote.Ke,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ga),
-            value: ScaleNote.Ga,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Pa),
-            value: ScaleNote.Pa,
-          },
-        ];
-      } else if (
-        this.element.fthora === Fthora.HardChromaticThi_Top ||
-        this.element.fthora === Fthora.HardChromaticThi_Bottom ||
-        this.element.secondaryFthora === Fthora.HardChromaticThi_TopSecondary ||
-        this.element.tertiaryFthora === Fthora.HardChromaticThi_TopTertiary
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.ZoHigh),
-            value: ScaleNote.ZoHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Thi),
-            value: ScaleNote.Thi,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Vou),
-            value: ScaleNote.Vou,
-          },
-        ];
-      } else if (
-        this.element.fthora === Fthora.HardChromaticPa_Top ||
-        this.element.fthora === Fthora.HardChromaticPa_Bottom ||
-        this.element.secondaryFthora === Fthora.HardChromaticPa_TopSecondary ||
-        this.element.tertiaryFthora === Fthora.HardChromaticPa_TopTertiary
-      ) {
-        return [
-          {
-            label: getNoteLabelSelector(ScaleNote.NiHigh),
-            value: ScaleNote.NiHigh,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ke),
-            value: ScaleNote.Ke,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Ga),
-            value: ScaleNote.Ga,
-          },
-          {
-            label: getNoteLabelSelector(ScaleNote.Pa),
-            value: ScaleNote.Pa,
-          },
-        ];
-      }
-
-      return [];
-    },
-
-    showChromaticFthoraNote() {
-      return (
-        (this.innerNeume === 'Primary' &&
-          this.element.fthora != null &&
-          this.chromaticFthoras.includes(this.element.fthora)) ||
-        (this.innerNeume === 'Secondary' &&
-          this.element.secondaryFthora != null &&
-          this.chromaticFthoras.includes(this.element.secondaryFthora)) ||
-        (this.innerNeume === 'Tertiary' &&
-          this.element.tertiaryFthora != null &&
-          this.chromaticFthoras.includes(this.element.tertiaryFthora))
-      );
-    },
-
-    fthoresDisabled() {
-      return restNeumes.includes(this.element.quantitativeNeume);
-    },
-
-    expressionsDisabled() {
-      return restNeumes.includes(this.element.quantitativeNeume);
-    },
-
-    accidentalsDisabled() {
-      return restNeumes.includes(this.element.quantitativeNeume);
-    },
-
-    klasmaDisabled() {
-      return (
-        restNeumes.includes(this.element.quantitativeNeume) ||
-        kentemataNeumes.includes(this.element.quantitativeNeume)
-      );
-    },
-
-    apleDisabled() {
-      return (
-        restNeumes.includes(this.element.quantitativeNeume) ||
-        kentemataNeumes.includes(this.element.quantitativeNeume)
-      );
-    },
-
-    koronisDisabled() {
-      return (
-        restNeumes.includes(this.element.quantitativeNeume) ||
-        kentemataNeumes.includes(this.element.quantitativeNeume)
-      );
-    },
-
-    stavrosDisabled() {
-      return (
-        this.element.quantitativeNeume !== QuantitativeNeume.RunningElaphron
-      );
-    },
-
-    argonDisabled() {
-      return (
-        this.element.quantitativeNeume !== QuantitativeNeume.KentemataPlusOligon
-      );
-    },
-
-    isonDisabled() {
-      return restNeumes.includes(this.element.quantitativeNeume);
-    },
-
-    spathiDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Ke) &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Ga)
-      );
-    },
-
-    spathiTitle() {
-      return this.spathiDisabled
-        ? this.$t(($) => $.toolbar.common.spathiDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Spathi_Top);
-    },
-
-    klitonDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Thi)
-      );
-    },
-
-    klitonTitle() {
-      return this.klitonDisabled
-        ? this.$t(($) => $.toolbar.common.klitonDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Kliton_Top);
-    },
-
-    zygosDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Thi)
-      );
-    },
-
-    zygosTitle() {
-      return this.zygosDisabled
-        ? this.$t(($) => $.toolbar.common.zygosDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Zygos_Top);
-    },
-
-    enharmonicDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Zo) &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.ZoHigh) &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Vou) &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.VouHigh) &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Ga)
-      );
-    },
-
-    enharmonicTitle() {
-      return this.enharmonicDisabled
-        ? this.$t(($) => $.toolbar.common.enharmonicDisabled, { ns: 'toolbar' })
-        : this.tooltip(Fthora.Enharmonic_Top);
-    },
-
-    generalFlatDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Ke)
-      );
-    },
-
-    generalFlatTitle() {
-      return this.generalFlatDisabled
-        ? this.$t(($) => $.toolbar.common.generalFlatDisabled, {
-            ns: 'toolbar',
-          })
-        : this.tooltip(Fthora.GeneralFlat_Top);
-    },
-
-    generalSharpDisabled() {
-      return (
-        !this.pageSetup.noFthoraRestrictions &&
-        !this.element.scaleNotesVirtual.includes(ScaleNote.Ga)
-      );
-    },
-
-    generalSharpTitle() {
-      return this.generalSharpDisabled
-        ? this.$t(($) => $.toolbar.common.generalSharpDisabled, {
-            ns: 'toolbar',
-          })
-        : this.tooltip(Fthora.GeneralSharp_Top);
-    },
-
-    chromaticFthoraNote() {
-      if (this.innerNeume === 'Secondary') {
-        return this.element.secondaryChromaticFthoraNote;
-      } else if (this.innerNeume === 'Tertiary') {
-        return this.element.tertiaryChromaticFthoraNote;
-      } else {
-        return this.element.chromaticFthoraNote;
-      }
-    },
-
-    noteDisplay() {
-      return this.element.scaleNotes
-        .map((x) => this.$t(getNoteLabelSelector(x), { ns: 'model' }))
-        .join(' - ');
-    },
-    spaceAfterMax() {
-      return Math.round(Unit.toPt(this.pageSetup.pageWidth));
-    },
+  innerNeume: {
+    type: String,
+    required: true,
   },
-
-  methods: {
-    translateNeumeDisplayName(neume: ToolbarNeumeTooltipNeume) {
-      switch (neume) {
-        case Tie.YfenBelow:
-          return this.$t(($) => $.toolbar.neume.yfen, { ns: 'toolbar' });
-        case Accidental.Flat_2_Right:
-          return this.$t(($) => $.toolbar.neume.flat, { ns: 'toolbar' });
-        case Accidental.Sharp_2_Left:
-          return this.$t(($) => $.toolbar.neume.sharp, { ns: 'toolbar' });
-        case MeasureBar.MeasureBarRight:
-          return this.$t(($) => $.toolbar.common.measureBar, { ns: 'toolbar' });
-        case MeasureNumber.Two:
-          return this.$t(($) => $.toolbar.neume.measureNumber, {
-            ns: 'toolbar',
-          });
-        case NoteIndicator.Pa:
-          return this.$t(($) => $.toolbar.neume.noteIndicator, {
-            ns: 'toolbar',
-          });
-        case Ison.Unison:
-          return this.$t(($) => $.toolbar.neume.isonIndicator, {
-            ns: 'toolbar',
-          });
-      }
-
-      if (enumHas(fthoraValues, neume)) {
-        return this.$t(getFthoraLabelSelector(neume), { ns: 'model' });
-      }
-
-      if (enumHas(timeNeumeValues, neume)) {
-        return this.$t(getTimeNeumeLabelSelector(neume), { ns: 'model' });
-      }
-
-      if (enumHas(vocalExpressionNeumeValues, neume)) {
-        return this.$t(getVocalExpressionNeumeLabelSelector(neume), {
-          ns: 'model',
-        });
-      }
-
-      if (enumHas(gorgonNeumeValues, neume)) {
-        return this.$t(getGorgonNeumeLabelSelector(neume), { ns: 'model' });
-      }
-
-      if (enumHas(measureBarValues, neume)) {
-        return this.$t(getMeasureBarLabelSelector(neume), { ns: 'model' });
-      }
-
-      if (enumHas(noteIndicatorValues, neume)) {
-        return this.$t(getNoteIndicatorLabelSelector(neume), { ns: 'model' });
-      }
-
-      if (enumHas(isonValues, neume)) {
-        const displayName = getIsonLabelSelector(neume);
-        return displayName == null
-          ? String(neume)
-          : this.$t(displayName, { ns: 'model' });
-      }
-
-      return String(neume);
-    },
-
-    updateFthora(args: string[]) {
-      if (this.innerNeume === 'Secondary') {
-        this.$emit('update:secondaryFthora', args[0] + this.innerNeume);
-      } else if (this.innerNeume === 'Tertiary') {
-        this.$emit('update:tertiaryFthora', args[0] + this.innerNeume);
-      } else {
-        this.$emit('update:fthora', args);
-      }
-    },
-
-    updateChromaticFthoraNote(note: string) {
-      if (this.innerNeume === 'Secondary') {
-        this.$emit('update', {
-          secondaryChromaticFthoraNote: note,
-        } as Partial<NoteElement>);
-      } else if (this.innerNeume === 'Tertiary') {
-        this.$emit('update', {
-          tertiaryChromaticFthoraNote: note,
-        } as Partial<NoteElement>);
-      } else {
-        this.$emit('update', {
-          chromaticFthoraNote: note,
-        } as Partial<NoteElement>);
-      }
-    },
-
-    updateGorgon(args: string | string[]) {
-      if (
-        this.innerNeume === 'Secondary' &&
-        this.element.quantitativeNeume !== QuantitativeNeume.Hyporoe
-      ) {
-        if (Array.isArray(args)) {
-          this.$emit('update:secondaryGorgon', GorgonNeume.GorgonSecondary);
-        } else {
-          this.$emit('update:secondaryGorgon', args + this.innerNeume);
-        }
-      } else {
-        this.$emit('update:gorgon', args);
-      }
-    },
-
-    updateAccidental(args: string) {
-      // There is some admittedly confusing logic here regarding the hyporoe.
-      // Compare to handleHyporoe in the Analysis Service.
-
-      if (this.innerNeume === 'Secondary') {
-        if (
-          this.element.quantitativeNeume == QuantitativeNeume.Hyporoe &&
-          args.startsWith('Flat')
-        ) {
-          this.$emit('update:accidental', args);
-        } else {
-          this.$emit('update:secondaryAccidental', args + this.innerNeume);
-        }
-      } else if (this.innerNeume === 'Tertiary') {
-        this.$emit('update:tertiaryAccidental', args + this.innerNeume);
-      } else {
-        if (
-          this.element.quantitativeNeume == QuantitativeNeume.Hyporoe &&
-          args.startsWith('Flat')
-        ) {
-          this.$emit('update:secondaryAccidental', args + 'Secondary');
-        } else {
-          this.$emit('update:accidental', args);
-        }
-      }
-    },
-
-    tooltip(neume: ToolbarNeumeTooltipNeume) {
-      const label = this.translateNeumeDisplayName(neume);
-      const mapping = this.neumeKeyboard.findMappingForNeume(neume);
-      if (mapping) {
-        return `${label} (${this.neumeKeyboard.generateTooltip(mapping)})`;
-      } else if (neume === TimeNeume.Klasma_Top) {
-        return `${label} (${this.neumeKeyboard.getKlasmaKeyTooltip()})`;
-      } else if (neume === NoteIndicator.Pa) {
-        return `${label} (${this.neumeKeyboard.getNoteIndicatorKeyTooltip()})`;
-      } else {
-        return label;
-      }
-    },
+  neumeKeyboard: {
+    type: Object as PropType<NeumeKeyboard>,
+    required: true,
   },
 });
+
+const emit = defineEmits([
+  'update',
+  'open-syllable-positioning-dialog',
+  'update:accidental',
+  'update:expression',
+  'update:fthora',
+  'update:gorgon',
+  'update:innerNeume',
+  'update:ison',
+  'update:klasma',
+  'update:measureBar',
+  'update:measureNumber',
+  'update:secondaryAccidental',
+  'update:secondaryFthora',
+  'update:secondaryGorgon',
+  'update:sectionName',
+  'update:tertiaryAccidental',
+  'update:tertiaryFthora',
+  'update:tie',
+  'update:time',
+]);
+
+const { t } = useTranslation();
+
+const primaryNeume = computed(() =>
+  getPrimaryNeume(props.element.quantitativeNeume),
+);
+
+const secondaryNeume = computed(() =>
+  getSecondaryNeume(props.element.quantitativeNeume),
+);
+
+const tertiaryNeume = computed(() =>
+  getTertiaryNeume(props.element.quantitativeNeume),
+);
+
+const notes = computed((): ChromaticFthoraNoteOption[] => {
+  if (
+    props.element.fthora === Fthora.SoftChromaticThi_Top ||
+    props.element.fthora === Fthora.SoftChromaticThi_Bottom ||
+    props.element.secondaryFthora === Fthora.SoftChromaticThi_TopSecondary ||
+    props.element.tertiaryFthora === Fthora.SoftChromaticThi_TopTertiary
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.ZoHigh),
+        value: ScaleNote.ZoHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Thi),
+        value: ScaleNote.Thi,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Vou),
+        value: ScaleNote.Vou,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ni),
+        value: ScaleNote.Ni,
+      },
+    ];
+  } else if (
+    props.element.fthora === Fthora.SoftChromaticPa_Top ||
+    props.element.fthora === Fthora.SoftChromaticPa_Bottom ||
+    props.element.secondaryFthora === Fthora.SoftChromaticPa_TopSecondary ||
+    props.element.tertiaryFthora === Fthora.SoftChromaticPa_TopTertiary
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.NiHigh),
+        value: ScaleNote.NiHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ke),
+        value: ScaleNote.Ke,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ga),
+        value: ScaleNote.Ga,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Pa),
+        value: ScaleNote.Pa,
+      },
+    ];
+  } else if (
+    props.element.fthora === Fthora.HardChromaticThi_Top ||
+    props.element.fthora === Fthora.HardChromaticThi_Bottom ||
+    props.element.secondaryFthora === Fthora.HardChromaticThi_TopSecondary ||
+    props.element.tertiaryFthora === Fthora.HardChromaticThi_TopTertiary
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.ZoHigh),
+        value: ScaleNote.ZoHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Thi),
+        value: ScaleNote.Thi,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Vou),
+        value: ScaleNote.Vou,
+      },
+    ];
+  } else if (
+    props.element.fthora === Fthora.HardChromaticPa_Top ||
+    props.element.fthora === Fthora.HardChromaticPa_Bottom ||
+    props.element.secondaryFthora === Fthora.HardChromaticPa_TopSecondary ||
+    props.element.tertiaryFthora === Fthora.HardChromaticPa_TopTertiary
+  ) {
+    return [
+      {
+        label: getNoteLabelSelector(ScaleNote.NiHigh),
+        value: ScaleNote.NiHigh,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ke),
+        value: ScaleNote.Ke,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Ga),
+        value: ScaleNote.Ga,
+      },
+      {
+        label: getNoteLabelSelector(ScaleNote.Pa),
+        value: ScaleNote.Pa,
+      },
+    ];
+  }
+
+  return [];
+});
+
+const showChromaticFthoraNote = computed(
+  () =>
+    (props.innerNeume === 'Primary' &&
+      props.element.fthora != null &&
+      chromaticFthoras.includes(props.element.fthora)) ||
+    (props.innerNeume === 'Secondary' &&
+      props.element.secondaryFthora != null &&
+      chromaticFthoras.includes(props.element.secondaryFthora)) ||
+    (props.innerNeume === 'Tertiary' &&
+      props.element.tertiaryFthora != null &&
+      chromaticFthoras.includes(props.element.tertiaryFthora)),
+);
+
+const fthoresDisabled = computed(() =>
+  restNeumes.includes(props.element.quantitativeNeume),
+);
+
+const expressionsDisabled = computed(() =>
+  restNeumes.includes(props.element.quantitativeNeume),
+);
+
+const accidentalsDisabled = computed(() =>
+  restNeumes.includes(props.element.quantitativeNeume),
+);
+
+const klasmaDisabled = computed(
+  () =>
+    restNeumes.includes(props.element.quantitativeNeume) ||
+    kentemataNeumes.includes(props.element.quantitativeNeume),
+);
+
+const apleDisabled = computed(
+  () =>
+    restNeumes.includes(props.element.quantitativeNeume) ||
+    kentemataNeumes.includes(props.element.quantitativeNeume),
+);
+
+const koronisDisabled = computed(
+  () =>
+    restNeumes.includes(props.element.quantitativeNeume) ||
+    kentemataNeumes.includes(props.element.quantitativeNeume),
+);
+
+const stavrosDisabled = computed(
+  () => props.element.quantitativeNeume !== QuantitativeNeume.RunningElaphron,
+);
+
+const argonDisabled = computed(
+  () =>
+    props.element.quantitativeNeume !== QuantitativeNeume.KentemataPlusOligon,
+);
+
+const isonDisabled = computed(() =>
+  restNeumes.includes(props.element.quantitativeNeume),
+);
+
+const spathiDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Ke) &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Ga),
+);
+
+const spathiTitle = computed(() =>
+  spathiDisabled.value
+    ? t(($) => $.toolbar.common.spathiDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Spathi_Top),
+);
+
+const klitonDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Thi),
+);
+
+const klitonTitle = computed(() =>
+  klitonDisabled.value
+    ? t(($) => $.toolbar.common.klitonDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Kliton_Top),
+);
+
+const zygosDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Thi),
+);
+
+const zygosTitle = computed(() =>
+  zygosDisabled.value
+    ? t(($) => $.toolbar.common.zygosDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Zygos_Top),
+);
+
+const enharmonicDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Zo) &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.ZoHigh) &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Vou) &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.VouHigh) &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Ga),
+);
+
+const enharmonicTitle = computed(() =>
+  enharmonicDisabled.value
+    ? t(($) => $.toolbar.common.enharmonicDisabled, { ns: 'toolbar' })
+    : tooltip(Fthora.Enharmonic_Top),
+);
+
+const generalFlatDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Ke),
+);
+
+const generalFlatTitle = computed(() =>
+  generalFlatDisabled.value
+    ? t(($) => $.toolbar.common.generalFlatDisabled, {
+        ns: 'toolbar',
+      })
+    : tooltip(Fthora.GeneralFlat_Top),
+);
+
+const generalSharpDisabled = computed(
+  () =>
+    !props.pageSetup.noFthoraRestrictions &&
+    !props.element.scaleNotesVirtual.includes(ScaleNote.Ga),
+);
+
+const generalSharpTitle = computed(() =>
+  generalSharpDisabled.value
+    ? t(($) => $.toolbar.common.generalSharpDisabled, {
+        ns: 'toolbar',
+      })
+    : tooltip(Fthora.GeneralSharp_Top),
+);
+
+const chromaticFthoraNote = computed(() => {
+  if (props.innerNeume === 'Secondary') {
+    return props.element.secondaryChromaticFthoraNote;
+  } else if (props.innerNeume === 'Tertiary') {
+    return props.element.tertiaryChromaticFthoraNote;
+  } else {
+    return props.element.chromaticFthoraNote;
+  }
+});
+
+const noteDisplay = computed(() =>
+  props.element.scaleNotes
+    .map((x) => t(getNoteLabelSelector(x), { ns: 'model' }))
+    .join(' - '),
+);
+
+const spaceAfterMax = computed(() =>
+  Math.round(Unit.toPt(props.pageSetup.pageWidth)),
+);
+
+function translateNeumeDisplayName(neume: ToolbarNeumeTooltipNeume) {
+  switch (neume) {
+    case Tie.YfenBelow:
+      return t(($) => $.toolbar.neume.yfen, { ns: 'toolbar' });
+    case Accidental.Flat_2_Right:
+      return t(($) => $.toolbar.neume.flat, { ns: 'toolbar' });
+    case Accidental.Sharp_2_Left:
+      return t(($) => $.toolbar.neume.sharp, { ns: 'toolbar' });
+    case MeasureBar.MeasureBarRight:
+      return t(($) => $.toolbar.common.measureBar, { ns: 'toolbar' });
+    case MeasureNumber.Two:
+      return t(($) => $.toolbar.neume.measureNumber, {
+        ns: 'toolbar',
+      });
+    case NoteIndicator.Pa:
+      return t(($) => $.toolbar.neume.noteIndicator, {
+        ns: 'toolbar',
+      });
+    case Ison.Unison:
+      return t(($) => $.toolbar.neume.isonIndicator, {
+        ns: 'toolbar',
+      });
+  }
+
+  if (enumHas(fthoraValues, neume)) {
+    return t(getFthoraLabelSelector(neume), { ns: 'model' });
+  }
+
+  if (enumHas(timeNeumeValues, neume)) {
+    return t(getTimeNeumeLabelSelector(neume), { ns: 'model' });
+  }
+
+  if (enumHas(vocalExpressionNeumeValues, neume)) {
+    return t(getVocalExpressionNeumeLabelSelector(neume), {
+      ns: 'model',
+    });
+  }
+
+  if (enumHas(gorgonNeumeValues, neume)) {
+    return t(getGorgonNeumeLabelSelector(neume), { ns: 'model' });
+  }
+
+  if (enumHas(measureBarValues, neume)) {
+    return t(getMeasureBarLabelSelector(neume), { ns: 'model' });
+  }
+
+  if (enumHas(noteIndicatorValues, neume)) {
+    return t(getNoteIndicatorLabelSelector(neume), { ns: 'model' });
+  }
+
+  if (enumHas(isonValues, neume)) {
+    const displayName = getIsonLabelSelector(neume);
+    return displayName == null
+      ? String(neume)
+      : t(displayName, { ns: 'model' });
+  }
+
+  return String(neume);
+}
+
+function updateFthora(args: string[]) {
+  if (props.innerNeume === 'Secondary') {
+    emit('update:secondaryFthora', args[0] + props.innerNeume);
+  } else if (props.innerNeume === 'Tertiary') {
+    emit('update:tertiaryFthora', args[0] + props.innerNeume);
+  } else {
+    emit('update:fthora', args);
+  }
+}
+
+function updateChromaticFthoraNote(note: string) {
+  if (props.innerNeume === 'Secondary') {
+    emit('update', {
+      secondaryChromaticFthoraNote: note,
+    } as Partial<NoteElement>);
+  } else if (props.innerNeume === 'Tertiary') {
+    emit('update', {
+      tertiaryChromaticFthoraNote: note,
+    } as Partial<NoteElement>);
+  } else {
+    emit('update', {
+      chromaticFthoraNote: note,
+    } as Partial<NoteElement>);
+  }
+}
+
+function updateGorgon(args: string | string[]) {
+  if (
+    props.innerNeume === 'Secondary' &&
+    props.element.quantitativeNeume !== QuantitativeNeume.Hyporoe
+  ) {
+    if (Array.isArray(args)) {
+      emit('update:secondaryGorgon', GorgonNeume.GorgonSecondary);
+    } else {
+      emit('update:secondaryGorgon', args + props.innerNeume);
+    }
+  } else {
+    emit('update:gorgon', args);
+  }
+}
+
+function updateAccidental(args: string) {
+  // There is some admittedly confusing logic here regarding the hyporoe.
+  // Compare to handleHyporoe in the Analysis Service.
+
+  if (props.innerNeume === 'Secondary') {
+    if (
+      props.element.quantitativeNeume == QuantitativeNeume.Hyporoe &&
+      args.startsWith('Flat')
+    ) {
+      emit('update:accidental', args);
+    } else {
+      emit('update:secondaryAccidental', args + props.innerNeume);
+    }
+  } else if (props.innerNeume === 'Tertiary') {
+    emit('update:tertiaryAccidental', args + props.innerNeume);
+  } else {
+    if (
+      props.element.quantitativeNeume == QuantitativeNeume.Hyporoe &&
+      args.startsWith('Flat')
+    ) {
+      emit('update:secondaryAccidental', args + 'Secondary');
+    } else {
+      emit('update:accidental', args);
+    }
+  }
+}
+
+function tooltip(neume: ToolbarNeumeTooltipNeume) {
+  const label = translateNeumeDisplayName(neume);
+  const mapping = props.neumeKeyboard.findMappingForNeume(neume);
+  if (mapping) {
+    return `${label} (${props.neumeKeyboard.generateTooltip(mapping)})`;
+  } else if (neume === TimeNeume.Klasma_Top) {
+    return `${label} (${props.neumeKeyboard.getKlasmaKeyTooltip()})`;
+  } else if (neume === NoteIndicator.Pa) {
+    return `${label} (${props.neumeKeyboard.getNoteIndicatorKeyTooltip()})`;
+  } else {
+    return label;
+  }
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarTempo.vue
+++ b/src/components/ToolbarTempo.vue
@@ -51,8 +51,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
 
 import { TempoElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
@@ -61,32 +61,22 @@ import { Unit } from '@/utils/Unit';
 import InputBpm from './InputBpm.vue';
 import InputUnit from './InputUnit.vue';
 
-export default defineComponent({
-  components: { InputUnit, InputBpm },
-  props: {
-    element: {
-      type: Object as PropType<TempoElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<TempoElement>,
+    required: true,
   },
-  emits: ['update', 'update:sectionName'],
-
-  data() {
-    return {};
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    spaceAfterMax() {
-      return Math.round(Unit.toPt(this.pageSetup.pageWidth));
-    },
-  },
-
-  methods: {},
 });
+
+defineEmits(['update', 'update:sectionName']);
+
+const spaceAfterMax = computed(() =>
+  Math.round(Unit.toPt(props.pageSetup.pageWidth)),
+);
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarTextBox.vue
+++ b/src/components/ToolbarTextBox.vue
@@ -298,8 +298,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
 
 import ColorPicker from '@/components/ColorPicker.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
@@ -309,47 +309,30 @@ import { TextBoxAlignment, TextBoxElement } from '@/models/Element';
 import { PageSetup } from '@/models/PageSetup';
 import { Unit } from '@/utils/Unit';
 
-export default defineComponent({
-  components: { ColorPicker, InputFontSize, InputUnit, InputStrokeWidth },
-  props: {
-    element: {
-      type: Object as PropType<TextBoxElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
-    fonts: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<TextBoxElement>,
+    required: true,
   },
-  emits: [
-    'insert:gorthmikon',
-    'insert:pelastikon',
-    'update',
-    'update:sectionName',
-  ],
-
-  data() {
-    return {
-      TextBoxAlignment,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    maxWidth() {
-      return Unit.toPt(this.pageSetup.innerPageWidth);
-    },
-
-    maxHeight() {
-      return Unit.toPt(this.pageSetup.innerPageHeight);
-    },
+  fonts: {
+    type: Array as PropType<string[]>,
+    required: true,
   },
-
-  methods: {},
 });
+
+defineEmits([
+  'insert:gorthmikon',
+  'insert:pelastikon',
+  'update',
+  'update:sectionName',
+]);
+
+const maxWidth = computed(() => Unit.toPt(props.pageSetup.innerPageWidth));
+const maxHeight = computed(() => Unit.toPt(props.pageSetup.innerPageHeight));
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/ToolbarTextBoxRich.vue
+++ b/src/components/ToolbarTextBoxRich.vue
@@ -305,8 +305,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
 
 import InputBpm from '@/components/InputBpm.vue';
 import InputUnit from '@/components/InputUnit.vue';
@@ -329,39 +329,21 @@ const scales = Object.values(Scale).map((x) => ({
   displayName: getScaleLabelSelector(x),
 }));
 
-export default defineComponent({
-  components: { InputBpm, InputUnit },
-  props: {
-    element: {
-      type: Object as PropType<RichTextBoxElement>,
-      required: true,
-    },
-    pageSetup: {
-      type: Object as PropType<PageSetup>,
-      required: true,
-    },
+const props = defineProps({
+  element: {
+    type: Object as PropType<RichTextBoxElement>,
+    required: true,
   },
-  emits: ['update', 'update:sectionName'],
-
-  data() {
-    return {
-      notes,
-      scales,
-    };
+  pageSetup: {
+    type: Object as PropType<PageSetup>,
+    required: true,
   },
-
-  computed: {
-    maxWidth() {
-      return Unit.toPt(this.pageSetup.innerPageWidth);
-    },
-
-    maxHeight() {
-      return Unit.toPt(this.pageSetup.innerPageHeight);
-    },
-  },
-
-  methods: {},
 });
+
+defineEmits(['update', 'update:sectionName']);
+
+const maxWidth = computed(() => Unit.toPt(props.pageSetup.innerPageWidth));
+const maxHeight = computed(() => Unit.toPt(props.pageSetup.innerPageHeight));
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/composables/useEditorServices.ts
+++ b/src/composables/useEditorServices.ts
@@ -1,0 +1,39 @@
+import { inject } from 'vue';
+
+import {
+  audioServiceKey,
+  ipcServiceKey,
+  latexExporterKey,
+  lyricServiceKey,
+  musicXmlExporterKey,
+  neumeKeyboardKey,
+  ocrImporterKey,
+  platformServiceKey,
+  playbackServiceKey,
+  textSearchServiceKey,
+} from '@/injectionKeys';
+import { AudioService } from '@/services/audio/AudioService';
+import { PlaybackService } from '@/services/audio/PlaybackService';
+import { LatexExporter } from '@/services/integration/LatexExporter';
+import { MusicXmlExporter } from '@/services/integration/MusicXmlExporter';
+import { OcrImporter } from '@/services/integration/OcrImporter';
+import { IpcService } from '@/services/ipc/IpcService';
+import { LyricService } from '@/services/LyricService';
+import { NeumeKeyboard } from '@/services/NeumeKeyboard';
+import { PlatformService } from '@/services/platform/PlatformService';
+import { TextSearchService } from '@/services/TextSearchService';
+
+export function useEditorServices() {
+  return {
+    audioService: inject(audioServiceKey, new AudioService()),
+    ipcService: inject(ipcServiceKey, new IpcService()),
+    latexExporter: inject(latexExporterKey, new LatexExporter()),
+    lyricService: inject(lyricServiceKey, new LyricService()),
+    musicXmlExporter: inject(musicXmlExporterKey, new MusicXmlExporter()),
+    neumeKeyboard: inject(neumeKeyboardKey, new NeumeKeyboard()),
+    ocrImporter: inject(ocrImporterKey, new OcrImporter()),
+    platformService: inject(platformServiceKey, new PlatformService()),
+    playbackService: inject(playbackServiceKey, new PlaybackService()),
+    textSearchService: inject(textSearchServiceKey, new TextSearchService()),
+  };
+}

--- a/src/composables/useEditorServices.ts
+++ b/src/composables/useEditorServices.ts
@@ -1,4 +1,4 @@
-import { inject } from 'vue';
+import { inject, InjectionKey } from 'vue';
 
 import {
   audioServiceKey,
@@ -23,17 +23,33 @@ import { NeumeKeyboard } from '@/services/NeumeKeyboard';
 import { PlatformService } from '@/services/platform/PlatformService';
 import { TextSearchService } from '@/services/TextSearchService';
 
+function injectOrCreate<T>(key: InjectionKey<T>, factory: () => T) {
+  return inject(key, factory, true);
+}
+
 export function useEditorServices() {
   return {
-    audioService: inject(audioServiceKey, new AudioService()),
-    ipcService: inject(ipcServiceKey, new IpcService()),
-    latexExporter: inject(latexExporterKey, new LatexExporter()),
-    lyricService: inject(lyricServiceKey, new LyricService()),
-    musicXmlExporter: inject(musicXmlExporterKey, new MusicXmlExporter()),
-    neumeKeyboard: inject(neumeKeyboardKey, new NeumeKeyboard()),
-    ocrImporter: inject(ocrImporterKey, new OcrImporter()),
-    platformService: inject(platformServiceKey, new PlatformService()),
-    playbackService: inject(playbackServiceKey, new PlaybackService()),
-    textSearchService: inject(textSearchServiceKey, new TextSearchService()),
+    audioService: injectOrCreate(audioServiceKey, () => new AudioService()),
+    ipcService: injectOrCreate(ipcServiceKey, () => new IpcService()),
+    latexExporter: injectOrCreate(latexExporterKey, () => new LatexExporter()),
+    lyricService: injectOrCreate(lyricServiceKey, () => new LyricService()),
+    musicXmlExporter: injectOrCreate(
+      musicXmlExporterKey,
+      () => new MusicXmlExporter(),
+    ),
+    neumeKeyboard: injectOrCreate(neumeKeyboardKey, () => new NeumeKeyboard()),
+    ocrImporter: injectOrCreate(ocrImporterKey, () => new OcrImporter()),
+    platformService: injectOrCreate(
+      platformServiceKey,
+      () => new PlatformService(),
+    ),
+    playbackService: injectOrCreate(
+      playbackServiceKey,
+      () => new PlaybackService(),
+    ),
+    textSearchService: injectOrCreate(
+      textSearchServiceKey,
+      () => new TextSearchService(),
+    ),
   };
 }

--- a/src/composables/useResizeObserver.ts
+++ b/src/composables/useResizeObserver.ts
@@ -1,0 +1,32 @@
+import { onBeforeUnmount, shallowRef } from 'vue';
+
+export function useResizeObserver() {
+  const observer = shallowRef<ResizeObserver | null>(null);
+
+  function disconnect() {
+    observer.value?.disconnect();
+    observer.value = null;
+  }
+
+  function observe(
+    targets: Element | Element[],
+    callback: ResizeObserverCallback,
+  ) {
+    disconnect();
+
+    observer.value = new ResizeObserver(callback);
+
+    const targetList = Array.isArray(targets) ? targets : [targets];
+    for (const target of targetList) {
+      observer.value.observe(target);
+    }
+  }
+
+  onBeforeUnmount(disconnect);
+
+  return {
+    disconnect,
+    observe,
+    observer,
+  };
+}

--- a/src/injectionKeys.ts
+++ b/src/injectionKeys.ts
@@ -1,5 +1,6 @@
-import { InjectionKey } from 'vue';
+import { ComputedRef, InjectionKey } from 'vue';
 
+import { EditorPreferences } from './models/EditorPreferences';
 import { AudioService } from './services/audio/AudioService';
 import { PlaybackService } from './services/audio/PlaybackService';
 import { LatexExporter } from './services/integration/LatexExporter';
@@ -12,6 +13,9 @@ import { IPlatformService } from './services/platform/IPlatformService';
 import { TextSearchService } from './services/TextSearchService';
 
 export const audioServiceKey: InjectionKey<AudioService> = Symbol();
+export const editorPreferencesKey: InjectionKey<
+  ComputedRef<EditorPreferences>
+> = Symbol();
 export const ipcServiceKey: InjectionKey<IIpcService> = Symbol();
 export const latexExporterKey: InjectionKey<LatexExporter> = Symbol();
 export const lyricServiceKey: InjectionKey<LyricService> = Symbol();

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,17 +4,14 @@
   </div>
 </template>
 
-<script lang="ts">
+<!-- eslint-disable vue/multi-word-component-names -->
+<script setup lang="ts">
 // @ is an alias to /src
 import TheEditor from '@/components/TheEditor.vue';
 
-export default {
-  // eslint-disable-next-line vue/multi-word-component-names
+defineOptions({
   name: 'Home',
-  components: {
-    TheEditor,
-  },
-};
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

This PR migrates the editor UI from Vue Options API components to Composition API / `<script setup>` components. The migration was completed in phases from leaf components through the main editor surface, preserving the existing user-facing behavior while modernizing component structure, typing, and lifecycle handling.

## What Changed

- Converted leaf/simple components such as inputs, menu items, glyph rendering, color picking, search, drag handles, and alternate lines to `<script setup>`.
- Migrated mid-tier editor components including toolbars, dialogs, selectors, text boxes, annotation boxes, image/drop-cap boxes, playback/export preferences, and file menus.
- Migrated the large editor entry point in `TheEditor.vue` to Composition API while keeping editor services, reactive state, watchers, computed values, and event handlers organized in setup scope.
- Migrated `ToolbarNeume.vue` and `PageSetupDialog.vue`, two larger component surfaces with substantial props, emits, local state, and derived options.
- Added shared composables:
  - `useEditorServices()` centralizes injected editor service access with fallback construction.
  - `useResizeObserver()` centralizes resize observer setup and cleanup with automatic disconnect on unmount.
- Extracted shared types into focused `.types.ts` files for button menu options, export dialog settings, and unit input values.
- Updated injection key typing to support Composition API usage, including computed editor preferences injection.
- Cleaned up follow-on migration details after the main conversions, including prop/emit typing, shared type usage, and small consistency fixes across migrated components.

## Migration Scope

The five migration commits cover:

- Phase 1: Leaf/simple components.
- Phase 2: Mid-tier toolbars, dialogs, boxes, and shared composables.
- Phase 3: `ToolbarNeume.vue` and `PageSetupDialog.vue`.
- Phase 4: `TheEditor.vue`.
- Phase 5: Cleanup and type extraction.

Overall, this updates 49 files across the app, with the largest changes concentrated in `TheEditor.vue`, `PageSetupDialog.vue`, `ToolbarNeume.vue`, text box components, neume box components, and toolbar/dialog surfaces.

## Reviewer Notes

This should be reviewed primarily as a structural migration. The intended behavior is unchanged, so review should focus on:

- Prop defaults and emitted event names matching the pre-migration component contracts.
- Watchers, computed values, and lifecycle hooks firing at the same points as before.
- Template refs and DOM-dependent code being initialized only after mount.
- Resize observer behavior in `TextBox.vue` and `TextBoxRich.vue`.
- Injected service access in `TheEditor.vue` and any child components relying on provided services or preferences.
- Large editor workflows such as opening/saving, exporting, playback, page setup, neume entry, toolbar updates, selection, text editing, and layout recalculation.