### PR TITLE
fix: defer Tone.js synth creation until user gesture

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -4655,7 +4655,7 @@ function performZoomToFit() {
   zoom.value = availableWidth / score.value.pageSetup.pageWidth;
 }
 
-function playAudio() {
+async function playAudio() {
   try {
     if (audioService.state === AudioState.Stopped) {
       playbackEvents.value = playbackService.computePlaybackSequence(
@@ -4672,7 +4672,7 @@ function playAudio() {
         (x) => x.elementIndex >= selectedElementIndex.value,
       );
 
-      audioService.play(playbackEvents.value, audioOptions, startAt);
+      await audioService.play(playbackEvents.value, audioOptions, startAt);
 
       if (startAt) {
         selectedWorkspace.value.playbackTime = startAt.absoluteTime;
@@ -4728,9 +4728,9 @@ function stopPlaybackClock() {
   }
 }
 
-function playTestTone() {
+async function playTestTone() {
   try {
-    audioService.playTestTone(audioOptions.frequencyDi);
+    await audioService.playTestTone(audioOptions.frequencyDi);
   } catch (error) {
     console.error(error);
   }

--- a/src/services/audio/AudioService.ts
+++ b/src/services/audio/AudioService.ts
@@ -24,8 +24,8 @@ export class AudioService {
   hardChromaticScale = [6, 20, 4, 12, 6, 20, 4];
   softChromaticScale = [8, 14, 8, 12, 8, 14, 8];
 
-  synth: Tone.Synth | Tone.FMSynth;
-  isonSynth: Tone.Synth | Tone.FMSynth;
+  synth: Tone.Synth | Tone.FMSynth | null = null;
+  isonSynth: Tone.Synth | Tone.FMSynth | null = null;
 
   part: Tone.Part | null = null;
 
@@ -39,30 +39,52 @@ export class AudioService {
     import.meta.env.VITE_AUDIO_SERVICE_LOGGING_ENABLED === 'true';
 
   constructor() {
-    this.synth = new Tone.Synth().toDestination();
-    this.isonSynth = new Tone.Synth().toDestination();
+    // Synths are created lazily after a user gesture so browsers do not block
+    // Tone's AudioContext during app startup.
+  }
 
-    //this.synth = this.createVoiceSynth();
-    //this.isonSynth = this.createVoiceSynth();
+  private getSynth(): Tone.Synth | Tone.FMSynth {
+    if (this.synth == null) {
+      this.synth = new Tone.Synth().toDestination();
+    }
 
-    this.isonSynth.volume.value = -4;
-    //this.synth.sync();
+    return this.synth;
+  }
+
+  private getIsonSynth(): Tone.Synth | Tone.FMSynth {
+    if (this.isonSynth == null) {
+      this.isonSynth = new Tone.Synth().toDestination();
+      this.isonSynth.volume.value = -4;
+    }
+
+    return this.isonSynth;
+  }
+
+  private async initializeAudio(): Promise<{
+    synth: Tone.Synth | Tone.FMSynth;
+    isonSynth: Tone.Synth | Tone.FMSynth;
+  }> {
+    await Tone.start();
+
+    return {
+      synth: this.getSynth(),
+      isonSynth: this.getIsonSynth(),
+    };
   }
 
   dispose() {
     this.stop();
 
-    this.synth.dispose();
-    this.isonSynth.dispose();
+    this.synth?.dispose();
+    this.isonSynth?.dispose();
   }
 
-  play(
+  async play(
     events: PlaybackSequenceEvent[],
     options: PlaybackOptions,
     startAt: PlaybackSequenceEvent | undefined,
   ) {
-    const synth = this.synth;
-    const isonSynth = this.isonSynth;
+    const { synth, isonSynth } = await this.initializeAudio();
 
     this.stop();
 
@@ -166,8 +188,8 @@ export class AudioService {
 
       Tone.getTransport().stop();
 
-      this.isonSynth.triggerRelease('+0.1');
-      this.synth.triggerRelease('+0.1');
+      isonSynth.triggerRelease('+0.1');
+      synth.triggerRelease('+0.1');
 
       EventBus.$emit(AudioServiceEventNames.Stop);
 
@@ -193,17 +215,23 @@ export class AudioService {
       console.log('AudioService', 'stop');
     }
 
-    // Reset the transport
-    Tone.getTransport().stop();
-    Tone.getTransport().position = 0;
-    Tone.getTransport().cancel();
+    if (
+      this.synth != null ||
+      this.isonSynth != null ||
+      this.toneEvents.length > 0
+    ) {
+      // Reset the transport
+      Tone.getTransport().stop();
+      Tone.getTransport().position = 0;
+      Tone.getTransport().cancel();
 
-    // Stop the synths
-    this.isonSynth.triggerRelease('+0.1');
-    this.synth.triggerRelease('+0.1');
+      // Stop the synths
+      this.isonSynth?.triggerRelease('+0.1');
+      this.synth?.triggerRelease('+0.1');
 
-    this.toneEvents.forEach((e) => e.dispose());
-    this.toneEvents = [];
+      this.toneEvents.forEach((e) => e.dispose());
+      this.toneEvents = [];
+    }
 
     EventBus.$emit(AudioServiceEventNames.Stop);
     this.state = AudioState.Stopped;
@@ -219,8 +247,8 @@ export class AudioService {
 
       Tone.getTransport().stop();
 
-      this.isonSynth.triggerRelease('+0.1');
-      this.synth.triggerRelease('+0.1');
+      this.isonSynth?.triggerRelease('+0.1');
+      this.synth?.triggerRelease('+0.1');
 
       this.state = AudioState.Paused;
     }
@@ -294,12 +322,14 @@ export class AudioService {
     });
   }
 
-  playTestTone(frequency: number) {
-    this.synth.volume.value = 0;
+  async playTestTone(frequency: number) {
+    const { synth } = await this.initializeAudio();
+
+    synth.volume.value = 0;
     Tone.getTransport().bpm.value = 120;
     const now = Tone.now();
 
-    this.synth.triggerAttackRelease(frequency, '2n', now);
+    synth.triggerAttackRelease(frequency, '2n', now);
   }
 
   // For debugging


### PR DESCRIPTION
Extracted from #2215. Browsers block or suspend an AudioContext created without a user gesture, so construct synths lazily and await Tone.start() on first playback instead of eagerly in the constructor.