### PR TITLE
fix: Mode key color and font size not normalized in LaTeX exporter

### DIFF
--- a/src/services/integration/LatexExporter.ts
+++ b/src/services/integration/LatexExporter.ts
@@ -475,12 +475,12 @@ Distance Between Baselines = Lyrics Vertical Offset + Neume Descent + Lyrics Asc
               color:
                 !modeKey.useDefaultStyle &&
                 modeKey.color != pageSetup.modeKeyDefaultColor
-                  ? modeKey.color
+                  ? modeKey.color.substring(1)
                   : undefined,
               fontSize:
                 !modeKey.useDefaultStyle &&
                 modeKey.fontSize != pageSetup.modeKeyDefaultFontSize
-                  ? modeKey.fontSize
+                  ? toPt(modeKey.fontSize)
                   : undefined,
               isPlagal: modeKey.isPlagal || undefined,
               isVarys: modeKey.isVarys || undefined,


### PR DESCRIPTION
Removes `modeKey` as the sole inconsistency and aligns its `color` and `fontSize` attributes with the file's established conventions.

Fixes #2152