### PR TITLE
fix: Escape in image export overwrite prompt could overwrite files

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -251,7 +251,7 @@ async function showReplaceOrSkipFileDialog(filePath: string) {
       )}" already exists. Do you want to replace it?`,
       buttons: ['Replace', 'Replace all', 'Skip', 'Skip all'],
       defaultId: 0,
-      cancelId: 0,
+      cancelId: 2,
     });
 
     return replaceFileResult.response as OnConflictChoice;


### PR DESCRIPTION
## Problem

When exporting pages as images, if a target file already exists the app shows a "Replace file?" prompt via `showReplaceOrSkipFileDialog` with the buttons `['Replace', 'Replace all', 'Skip', 'Skip all']`.

That dialog was configured with `cancelId: 0`. In Electron, `cancelId` is the response returned when the user dismisses the dialog with the Escape key (or the window close button). Because index `0` here is **Replace**, dismissing the prompt with Escape returned `OnConflictChoice.Replace`, and the export code then overwrote the existing file:

```js
if (
  exportAsImageOnConflict === OnConflictChoice.ReplaceAll ||
  exportAsImageOnConflict === OnConflictChoice.Replace
) {
  await fs.writeFile(args.filePath, args.data, 'base64'); // overwrites
}
```

So a user who pressed Escape expecting to cancel/skip would silently overwrite an existing file, a data-loss bug.

The mistake appears to come from copying `cancelId: 0` from the sibling `showReplaceFileDialog`, where index `0` is `'Cancel'` (safe). In the skip-capable dialog, index `0` is `'Replace'`, so the same value is destructive.

## Solution

Point `cancelId` at the `'Skip'` button (index `2`) so that dismissing the prompt is non-destructive. `Skip` is neither `Replace` nor `ReplaceAll`, so the export code returns without writing the file.

```diff
       buttons: ['Replace', 'Replace all', 'Skip', 'Skip all'],
       defaultId: 0,
-      cancelId: 0,
+      cancelId: 2,
```

## Impact

- Low likelihood (requires an export-as-image name collision plus dismissing the prompt with Escape rather than clicking a button), but the consequence is overwriting an existing file against the user's intent.
- After the fix, Escape behaves like "Skip": the existing file is preserved.