### PR TITLE
fix: Copy/paste of a multipanel plain text box silently drops `contentBottom`

### DIFF
--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -865,6 +865,7 @@ export class TextBoxElement extends ScoreElement {
       alignment: this.alignment,
       color: this.color,
       content: this.content,
+      contentBottom: this.contentBottom,
       contentLeft: this.contentLeft,
       contentCenter: this.contentCenter,
       contentRight: this.contentRight,


### PR DESCRIPTION
Fixes #2224