### PR TITLE
fix: horizontal rule color

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -1043,7 +1043,7 @@ function getHeaderHorizontalRuleStyle(headerHeight: number) {
         headerHeight +
         score.value.pageSetup.headerHorizontalRuleMarginTop,
     ),
-    color: score.value.pageSetup.headerHorizontalRuleColor,
+    borderColor: score.value.pageSetup.headerHorizontalRuleColor,
     borderTopWidth: withZoom(
       score.value.pageSetup.headerHorizontalRuleThickness,
     ),
@@ -1059,7 +1059,7 @@ function getFooterHorizontalRuleStyle(footerHeight: number) {
         footerHeight +
         score.value.pageSetup.footerHorizontalRuleMarginBottom,
     ),
-    color: score.value.pageSetup.footerHorizontalRuleColor,
+    borderColor: score.value.pageSetup.footerHorizontalRuleColor,
     borderTopWidth: withZoom(
       score.value.pageSetup.footerHorizontalRuleThickness,
     ),


### PR DESCRIPTION
shadcn-vue has altered the default border colors. So setting `color` is no longer sufficient to control the color of the horizontal rules. This PR replaces it with the more specific `border-color` property.