### PR TITLE
fix: lyric manager textarea not scrolling

### DIFF
--- a/src/components/ToolbarLyricManager.vue
+++ b/src/components/ToolbarLyricManager.vue
@@ -40,7 +40,7 @@
       </Button>
     </div>
     <Textarea
-      class="mt-1 bg-background"
+      class="mt-1 bg-background field-sizing-fixed"
       :model-value="lyrics"
       rows="5"
       dir="auto"


### PR DESCRIPTION
shadcn-vue Textarea sets the `field-sizing-content` class by default. This causes the lyric manager text area to grow instead of scrolling. For large scroes this fills the entire screen. This PR sets `field-sizing-fixed` to restore the original behavior.