### PR TITLE
fix: fix extra blank pages when printing

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -442,7 +442,7 @@ const lyricManagerIsOpen = computed({
 });
 
 const pageCount = computed(() => {
-  return pages.value.length;
+  return filteredPages.value.length;
 });
 
 const commandService = computed(() => {


### PR DESCRIPTION
Fix print/export crash when the last layout page is filtered out

When printing or exporting to PDF, we render filteredPages so an empty trailing page does not appear in the output. calculatePageNumber() was still using the full page count, which could make it read a missing page ref and crash if the last page had been filtered out. This updates the page count used there to match the pages actually being rendered during print/export. As bonus this fixes the total page count metadata token that can be used in text boxes to be correct when printing.