### PR TITLE
Options API migration fixes

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -2284,11 +2284,15 @@ function onKeydownNeume(event: KeyboardEvent) {
           // because no keyboard mapping exist for it
           throttled.updateMartyria(martyriaElement, {
             note: martyriaConfigMapping.note,
+            auto: false,
           });
         } else if (martyriaConfigMapping.scale != null) {
-          throttled.updateMartyria(martyriaElement, {
-            scale: martyriaConfigMapping.scale,
-          });
+          if (martyriaElement.scale !== martyriaConfigMapping.scale) {
+            throttled.updateMartyria(martyriaElement, {
+              scale: martyriaConfigMapping.scale,
+              auto: false,
+            });
+          }
         } else if (martyriaConfigMapping.martyriaAlignmentToggle === true) {
           throttled.updateMartyria(martyriaElement, {
             alignRight: !martyriaElement.alignRight,
@@ -4237,10 +4241,16 @@ function updateMartyria(
   element: MartyriaElement,
   newValues: Partial<MartyriaElement>,
 ) {
+  const values =
+    newValues.alignRight !== undefined &&
+    newValues.alignRight !== element.alignRight
+      ? { ...newValues, quantitativeNeume: null }
+      : newValues;
+
   commandService.value.execute(
     martyriaCommandFactory.create('update-properties', {
       target: element,
-      newValues: newValues,
+      newValues: values,
     }),
   );
 

--- a/src/components/ToolbarModeKey.vue
+++ b/src/components/ToolbarModeKey.vue
@@ -112,7 +112,7 @@
     <ButtonWithMenu
       :options="tempoMenuOptions"
       :tooltip="$t(($) => $.toolbar.common.tempoSign, { ns: 'toolbar' })"
-      @select="$emit('update', { tempo: $event } as Partial<ModeKeyElement>)"
+      @select="$emit('update:tempo', $event)"
     />
     <span class="space" />
 


### PR DESCRIPTION
Fixes #2241
Fixes #2242
Fixes #2243

- Martyria keyboard note/scale overrides now set `auto: false`, restoring the old `updateMartyriaNote` / `updateMartyriaScale` behavior.
- Martyria alignment changes now clear `quantitativeNeume` whenever `alignRight` actually changes, covering both toolbar and keyboard paths through generic `updateMartyria`.
- Mode-key tempo selection now emits `update:tempo` again, so the parent calls `setModeKeyTempo` and recomputes BPM via `updateModeKeyTempo` instead of only writing tempo.