### PR TITLE
fix: toaster causes blank page on print

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,9 @@
   <TooltipProvider :delay-duration="500" :skip-delay-duration="0">
     <router-view />
   </TooltipProvider>
-  <Toaster />
+  <div class="toaster-wrapper contents">
+    <Toaster />
+  </div>
   <div v-if="updateExists" class="update-notification">
     An update is available.
     <button class="ok" @click="refreshApp">Update</button>
@@ -70,6 +72,11 @@ function refreshApp() {
   }
 
   .ck-body-wrapper {
+    display: none !important;
+  }
+
+  .toaster-wrapper,
+  .toaster-wrapper * {
     display: none !important;
   }
 }


### PR DESCRIPTION
Toast notifications created by Vue Sonner were appearing in printed output. Since the toaster renders its own notification region outside of the normal application content, it was not automatically excluded when printing.

This change hides the Sonner notification region when print media is active, preventing toast notifications from appearing in print previews and printed documents. The solution uses print-specific CSS rather than application state changes, which avoids timing issues with beforeprint events and Vue's asynchronous rendering cycle.