### PR TITLE
feat: New agia attraction algorithm

### DIFF
--- a/src/services/audio/PlaybackService.test.ts
+++ b/src/services/audio/PlaybackService.test.ts
@@ -11,10 +11,12 @@ import {
 import {
   Accidental,
   Fthora,
+  GorgonNeume,
   Note,
   QuantitativeNeume,
+  TimeNeume,
 } from '../../models/Neumes';
-import { Scale, ScaleNote } from '../../models/Scales';
+import { getScaleNoteValue, Scale, ScaleNote } from '../../models/Scales';
 import type { PlaybackOptions } from './PlaybackService';
 import { PlaybackService } from './PlaybackService';
 expect.extend({ toBeDeepCloseTo, toMatchCloseTo });
@@ -763,140 +765,1024 @@ describe('PlaybackService', () => {
       },
     );
 
-    // it.each([
-    //   [
-    //     'nzkz',
-    //     Note.NiHigh,
-    //     [
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Oligon,
-    //     ],
-    //     [
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.Ke, 5),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //     ],
-    //   ],
-    //   [
-    //     'nzkzn',
-    //     Note.NiHigh,
-    //     [
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Oligon,
-    //       QuantitativeNeume.Oligon,
-    //     ],
-    //     [
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.Ke, 5),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //     ],
-    //   ],
-    //   [
-    //     // This is an unlikely case where zo was never hit
-    //     // before ni, so the attraction is not triggered.
-    //     // Perhaps additional logic should handle this case to sharpen ke?
-    //     'nkzn',
-    //     Note.NiHigh,
-    //     [
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Elaphron,
-    //       QuantitativeNeume.Oligon,
-    //       QuantitativeNeume.Oligon,
-    //     ],
-    //     [
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //       getDiatonicFrequency(ScaleNote.Ke),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //     ],
-    //   ],
-    //   [
-    //     'znkzn',
-    //     Note.ZoHigh,
-    //     [
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Oligon,
-    //       QuantitativeNeume.Elaphron,
-    //       QuantitativeNeume.Oligon,
-    //       QuantitativeNeume.Oligon,
-    //     ],
-    //     [
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //       getDiatonicFrequency(ScaleNote.Ke, 5),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //     ],
-    //   ],
-    //   [
-    //     'nzkkz',
-    //     Note.NiHigh,
-    //     [
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Oligon,
-    //     ],
-    //     [
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.Ke, 5),
-    //       getDiatonicFrequency(ScaleNote.Ke, 5),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //     ],
-    //   ],
-    //   [
-    //     'nzkn',
-    //     Note.NiHigh,
-    //     [
-    //       QuantitativeNeume.Ison,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.Apostrophos,
-    //       QuantitativeNeume.PetastiPlusOligon,
-    //     ],
-    //     [
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //       getDiatonicFrequency(ScaleNote.ZoHigh),
-    //       getDiatonicFrequency(ScaleNote.Ke, 5),
-    //       getDiatonicFrequency(ScaleNote.NiHigh),
-    //     ],
-    //   ],
-    // ])(
-    //   'should calculate the correct ke attractions (%# - %s)',
-    //   (
-    //     name: string,
-    //     startingNote: Note,
-    //     notes: QuantitativeNeume[],
-    //     expectedFrequencies: number[],
-    //   ) => {
-    //     const service = new PlaybackService();
+    it.each([
+      [
+        'nzkz',
+        Note.NiHigh,
+        [
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Oligon,
+        ],
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+      ],
+      [
+        'nzkzn',
+        Note.NiHigh,
+        [
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Oligon,
+          QuantitativeNeume.Oligon,
+        ],
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+      ],
+      [
+        'nkzn',
+        Note.NiHigh,
+        [
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Elaphron,
+          QuantitativeNeume.Oligon,
+          QuantitativeNeume.Oligon,
+        ],
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+      ],
+      [
+        'znkzn',
+        Note.ZoHigh,
+        [
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Oligon,
+          QuantitativeNeume.Elaphron,
+          QuantitativeNeume.Oligon,
+          QuantitativeNeume.Oligon,
+        ],
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+      ],
+      [
+        'nzkkz',
+        Note.NiHigh,
+        [
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Oligon,
+        ],
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+      ],
+      [
+        'nzkn',
+        Note.NiHigh,
+        [
+          QuantitativeNeume.Ison,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.Apostrophos,
+          QuantitativeNeume.PetastiPlusOligon,
+        ],
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+      ],
+    ])(
+      'should calculate the correct ke attractions (%# - %s)',
+      (
+        name: string,
+        startingNote: Note,
+        notes: QuantitativeNeume[],
+        expectedFrequencies: number[],
+      ) => {
+        const service = new PlaybackService();
 
-    //     const options = getDefaultWorkspaceOptions();
-    //     options.diatonicIntervals = [12, 10, 8];
+        const options = getDefaultWorkspaceOptions();
+        options.diatonicIntervals = [12, 10, 8];
 
-    //     const elements: ScoreElement[] = [];
+        const elements: ScoreElement[] = [];
 
-    //     elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
-    //     elements.push(getMartyria({ auto: false, note: startingNote }));
+        elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+        elements.push(getMartyria({ auto: false, note: startingNote }));
 
-    //     notes.forEach((x) => elements.push(getNote(x)));
+        notes.forEach((x) => elements.push(getNote(x)));
 
-    //     const events = service.computePlaybackSequence(elements, options, true);
+        const events = service.computePlaybackSequence(elements, options, true);
 
-    //     expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
-    //       expectedFrequencies,
-    //       2,
-    //     );
-    //   },
-    // );
+        expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+          expectedFrequencies,
+          2,
+        );
+      },
+    );
+
+    it('should flatten zo and keep ke natural when the upper phrase closes into flat zo', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(3, Scale.Diatonic, ScaleNote.Thi));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(
+        getMartyria({
+          auto: false,
+          note: Note.Ke,
+          fthora: Fthora.GeneralFlat_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -5),
+        ],
+        2,
+      );
+    });
+
+    it('should flatten zo and keep ke natural when ke is held', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should not treat a plain martyria after short ke as a rest signal', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getMartyria({ auto: false, note: Note.Ke }));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should keep ke natural when it returns to a zo that classifies flat', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+        ],
+        2,
+      );
+    });
+
+    it('should require zo to be established before sharpening ke', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(1, Scale.Diatonic, ScaleNote.Pa));
+      elements.push(
+        getNote(QuantitativeNeume.OligonPlusKentimaAbove, {
+          timeNeume: TimeNeume.Klasma_Bottom,
+        }),
+      );
+      elements.push(
+        getNote(QuantitativeNeume.OligonPlusKentemata, {
+          gorgonNeume: GorgonNeume.Gorgon_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.OligonPlusKentemata));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(
+        getNote(QuantitativeNeume.OligonPlusApostrophosPlusKentemata, {
+          gorgonNeume: GorgonNeume.Gorgon_Top,
+        }),
+      );
+      elements.push(
+        getNote(QuantitativeNeume.Elaphron, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Thi),
+        ],
+        2,
+      );
+    });
+
+    it('should keep held zo natural after a hyporoe dips below ke and returns', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(1, Scale.Diatonic, ScaleNote.Thi));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(
+        getNote(QuantitativeNeume.Oligon, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.PetastiPlusHyporoe));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should calculate the third-mode default attraction interpretation from #213', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(1, Scale.Diatonic, ScaleNote.Thi));
+      pushStepwiseNotes(elements, ScaleNote.Thi, [
+        ScaleNote.Thi,
+        ScaleNote.Ke,
+        ScaleNote.ZoHigh,
+        ScaleNote.NiHigh,
+        ScaleNote.ZoHigh,
+        ScaleNote.Ke,
+        ScaleNote.ZoHigh,
+        ScaleNote.Ke,
+        ScaleNote.ZoHigh,
+        ScaleNote.NiHigh,
+        ScaleNote.ZoHigh,
+        ScaleNote.Ke,
+        ScaleNote.Thi,
+        ScaleNote.Thi,
+        ScaleNote.Ke,
+        ScaleNote.Thi,
+        ScaleNote.Ga,
+        ScaleNote.Vou,
+        ScaleNote.Ga,
+        ScaleNote.Thi,
+        ScaleNote.Ke,
+        ScaleNote.Ke,
+        ScaleNote.ZoHigh,
+        ScaleNote.ZoHigh,
+        ScaleNote.Ke,
+        ScaleNote.Ke,
+        ScaleNote.Ke,
+      ]);
+      elements.push(
+        getModeKey(3, Scale.Diatonic, ScaleNote.Ke, {
+          permanentEnharmonicZo: true,
+        }),
+      );
+      pushStepwiseNotes(elements, ScaleNote.Ke, [
+        ScaleNote.ZoHigh,
+        ScaleNote.NiHigh,
+        ScaleNote.PaHigh,
+        ScaleNote.NiHigh,
+        ScaleNote.ZoHigh,
+        ScaleNote.Ke,
+        ScaleNote.Thi,
+        ScaleNote.ZoHigh,
+        ScaleNote.Ke,
+      ]);
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ga),
+          getDiatonicFrequency(ScaleNote.Vou),
+          getDiatonicFrequency(ScaleNote.Ga),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.PaHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+        ],
+        2,
+      );
+    });
+
+    it('should flatten held zo when the melody wanders down without returning', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ga),
+          getDiatonicFrequency(ScaleNote.Vou),
+        ],
+        2,
+      );
+    });
+
+    it('should keep held zo natural when the melody returns to the upper register', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+        ],
+        2,
+      );
+    });
+
+    it('should keep held zo natural when it ends the piece', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [getDiatonicFrequency(ScaleNote.ZoHigh)],
+        2,
+      );
+    });
+
+    it('should classify a future held zo before it resolves an earlier short zo', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ga),
+        ],
+        2,
+      );
+    });
+
+    it('should not sharpen a held resting ke', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(
+        getNote(QuantitativeNeume.Elaphron, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.PetastiPlusOligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should not sharpen a ke that leads into a held ke', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Elaphron));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should not establish the upper register across a held ke', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(
+        getNote(QuantitativeNeume.Elaphron, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should flatten a held zo when the melody only returns to a flat zo', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Elaphron));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Thi),
+        ],
+        2,
+      );
+    });
+
+    it('should keep zo natural before a sharpened ke', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          accidental: Accidental.Sharp_2_Left,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+        ],
+        2,
+      );
+    });
+
+    it('should treat a sharpened ke as establishment of the upper register', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          accidental: Accidental.Sharp_2_Left,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should let explicit sharp ke outrank held-ke rest inference', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.ZoHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          accidental: Accidental.Sharp_2_Left,
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should keep ke natural in the third mode melody from #821', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(3, Scale.Diatonic, ScaleNote.Ga));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(
+        getNote(QuantitativeNeume.Oligon, {
+          gorgonNeume: GorgonNeume.Gorgon_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+      elements.push(
+        getNote(QuantitativeNeume.Oligon, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.OligonPlusKentemata));
+      elements.push(
+        getNote(QuantitativeNeume.OligonPlusIsonPlusKentemata, {
+          gorgonNeume: GorgonNeume.Gorgon_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          gorgonNeume: GorgonNeume.Gorgon_Top,
+        }),
+      );
+      elements.push(
+        getNote(QuantitativeNeume.Ison, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getMartyria({}));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ga),
+          getDiatonicFrequency(ScaleNote.Vou),
+          getDiatonicFrequency(ScaleNote.Ga),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+        ],
+        2,
+      );
+    });
+
+    it('should keep the upper register established through a short passing dip below ke', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Vou));
+      elements.push(getMartyria({ auto: false, note: Note.NiHigh }));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Elaphron));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+        ],
+        2,
+      );
+    });
+
+    it('should keep zo natural after a passing dip in a first mode melody revolving around zo', () => {
+      const service = new PlaybackService();
+
+      const options = getDefaultWorkspaceOptions();
+      options.diatonicIntervals = [12, 10, 8];
+
+      const elements: ScoreElement[] = [];
+
+      elements.push(getModeKey(1, Scale.Diatonic, ScaleNote.Pa));
+      elements.push(getNote(QuantitativeNeume.OligonPlusHypsiliLeft));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(
+        getNote(QuantitativeNeume.Oligon, { timeNeume: TimeNeume.Klasma_Top }),
+      );
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Ison));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Elaphron));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Oligon));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(getNote(QuantitativeNeume.Apostrophos));
+      elements.push(
+        getNote(QuantitativeNeume.Apostrophos, {
+          timeNeume: TimeNeume.Klasma_Top,
+        }),
+      );
+
+      const events = service.computePlaybackSequence(elements, options, true);
+
+      expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
+        [
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.PaHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Thi),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.Ke, 5),
+          getDiatonicFrequency(ScaleNote.ZoHigh),
+          getDiatonicFrequency(ScaleNote.NiHigh),
+          getDiatonicFrequency(ScaleNote.ZoHigh, -4),
+          getDiatonicFrequency(ScaleNote.Ke),
+          getDiatonicFrequency(ScaleNote.Thi),
+        ],
+        2,
+      );
+    });
   });
 
   it(`should not change frequency when on an ison`, () => {
@@ -995,6 +1881,35 @@ function getDefaultWorkspaceOptions() {
       [Accidental.Sharp_8_Left]: 8,
     },
   } as PlaybackOptions;
+}
+
+function pushStepwiseNotes(
+  elements: ScoreElement[],
+  currentNote: ScaleNote,
+  notes: ScaleNote[],
+) {
+  for (const note of notes) {
+    const neume = getStepwiseNeume(currentNote, note);
+    elements.push(getNote(neume));
+    currentNote = note;
+  }
+}
+
+function getStepwiseNeume(currentNote: ScaleNote, nextNote: ScaleNote) {
+  const step = getScaleNoteValue(nextNote) - getScaleNoteValue(currentNote);
+
+  switch (step) {
+    case -1:
+      return QuantitativeNeume.Apostrophos;
+    case 0:
+      return QuantitativeNeume.Ison;
+    case 1:
+      return QuantitativeNeume.Oligon;
+    case 2:
+      return QuantitativeNeume.OligonPlusKentimaBelow;
+    default:
+      throw new Error(`Unsupported stepwise movement: ${step}`);
+  }
 }
 
 function getModeKey(

--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -94,12 +94,28 @@ export interface PlaybackWorkspace {
 
   permanentEnharmonicZo: boolean;
 
-  zoFlatPivotActivated: boolean;
-  zoNaturalPivotActivated: boolean;
-
   // debug
   loggingEnabled: boolean;
 }
+
+type AttractionScanClass =
+  | { kind: 'restSignal' }
+  | { kind: 'nonNote' }
+  | { kind: 'sharpKe'; node: NoteAtomNode }
+  | { kind: 'heldKe'; node: NoteAtomNode }
+  | { kind: 'heldBelowKe'; node: NoteAtomNode }
+  | { kind: 'belowKe'; node: NoteAtomNode }
+  | { kind: 'ke'; node: NoteAtomNode }
+  | { kind: 'heldZo'; node: NoteAtomNode }
+  | { kind: 'zo'; node: NoteAtomNode }
+  | { kind: 'aboveZo'; node: NoteAtomNode };
+
+/**
+ * The maximum number of nodes that may be examined while deciding the
+ * attraction of a single note. This bounds the lookahead/lookbehind so that
+ * pathological scores cannot cause quadratic scan times.
+ */
+const MAX_ATTRACTION_SCAN_NODES = 25;
 
 export enum PlaybackScaleName {
   Diatonic,
@@ -188,9 +204,6 @@ export class PlaybackService {
 
       permanentEnharmonicZo: false,
 
-      zoFlatPivotActivated: false,
-      zoNaturalPivotActivated: false,
-
       loggingEnabled:
         import.meta.env.VITE_PLAYBACK_SERVICE_LOGGING_ENABLED === 'true',
     };
@@ -207,9 +220,11 @@ export class PlaybackService {
       elements,
       chrysanthineAccidentals,
     );
-    for (const node of nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+
       if (node.nodeType === NodeType.NoteAtomNode) {
-        this.handleNoteAtom(node as NoteAtomNode, nodes, workspace);
+        this.handleNoteAtom(node as NoteAtomNode, nodes, i, workspace);
       } else if (node.nodeType === NodeType.RestNode) {
         this.handleRest(node as RestNode, workspace);
       } else if (node.nodeType === NodeType.ModeKeyNode) {
@@ -420,6 +435,7 @@ export class PlaybackService {
   applyAlterations(
     noteAtomNode: Readonly<NoteAtomNode>,
     nodes: AnalysisNode[],
+    nodeIndex: number,
     workspace: PlaybackWorkspace,
   ) {
     let alteredFrequency = workspace.frequency;
@@ -482,6 +498,7 @@ export class PlaybackService {
         alteredFrequency,
         noteAtomNode,
         nodes,
+        nodeIndex,
         workspace,
       );
     }
@@ -493,91 +510,427 @@ export class PlaybackService {
     frequency: number,
     noteAtomNode: Readonly<NoteAtomNode>,
     nodes: AnalysisNode[],
+    nodeIndex: number,
     workspace: PlaybackWorkspace,
   ) {
     const { scale } = workspace;
 
-    // If melody descends after zo, flatten zo
     if (
       workspace.options.useDefaultAttractionZo &&
       !workspace.permanentEnharmonicZo &&
       (scale.name === PlaybackScaleName.Diatonic ||
         scale.name === PlaybackScaleName.Kliton ||
-        scale.name === PlaybackScaleName.Zygos)
+        scale.name === PlaybackScaleName.Zygos) &&
+      this.canApplyDefaultAttraction(noteAtomNode)
     ) {
       if (noteAtomNode.virtualNote === ScaleNote.ZoHigh) {
-        // If we are not in a pivot, check to see if we need to pivot
-        if (!workspace.zoFlatPivotActivated) {
-          this.setPivots(noteAtomNode, nodes, workspace);
-        }
-
-        // If we are in a pivot, then flatten zo
-        if (workspace.zoFlatPivotActivated) {
+        if (this.zoIsFlattened(nodeIndex, nodes)) {
           frequency = this.changeFrequency(
             frequency,
             workspace.options.defaultAttractionZoMoria,
           );
         }
-      } else {
-        // Clear zo flat pivot
-        workspace.zoFlatPivotActivated = false;
-      }
-
-      // Check whether ke is attracted toward zo
-      if (
-        noteAtomNode.virtualNote === ScaleNote.Ke &&
-        workspace.zoNaturalPivotActivated
-      ) {
-        frequency = this.changeFrequency(
-          frequency,
-          workspace.options.defaultAttractionKeMoria,
-        );
-      }
-
-      // Clear the zo natural pivot if we descend below ke
-      if (
-        getScaleNoteValue(noteAtomNode.virtualNote) <
-        getScaleNoteValue(ScaleNote.Ke)
-      ) {
-        workspace.zoNaturalPivotActivated = false;
+      } else if (noteAtomNode.virtualNote === ScaleNote.Ke) {
+        if (this.keIsSharpened(nodeIndex, nodes)) {
+          frequency = this.changeFrequency(
+            frequency,
+            workspace.options.defaultAttractionKeMoria,
+          );
+        }
       }
     }
 
     return frequency;
   }
 
-  setPivots(
-    noteAtomNode: Readonly<NoteAtomNode>,
+  private canApplyDefaultAttraction(node: Readonly<NoteAtomNode>) {
+    return (
+      !node.ignoreAttractions &&
+      !node.accidental &&
+      (node.scale === Scale.Diatonic ||
+        node.scale === Scale.Kliton ||
+        node.scale === Scale.Zygos)
+    );
+  }
+
+  private isNoteAtomNode(node: AnalysisNode): node is NoteAtomNode {
+    return node.nodeType === NodeType.NoteAtomNode;
+  }
+
+  private getAttractionScanClass(node: AnalysisNode): AttractionScanClass {
+    if (
+      node.nodeType === NodeType.RestNode ||
+      node.nodeType === NodeType.FthoraNode ||
+      node.nodeType === NodeType.ModeKeyNode
+    ) {
+      return { kind: 'restSignal' };
+    }
+
+    if (!this.isNoteAtomNode(node)) {
+      return { kind: 'nonNote' };
+    }
+
+    const held = node.duration >= 2;
+    const noteValue = getScaleNoteValue(node.virtualNote);
+    const keValue = getScaleNoteValue(ScaleNote.Ke);
+    const zoHighValue = getScaleNoteValue(ScaleNote.ZoHigh);
+
+    if (noteValue < keValue) {
+      return {
+        kind: held ? 'heldBelowKe' : 'belowKe',
+        node,
+      };
+    }
+
+    if (noteValue === keValue) {
+      if (node.accidental != null && node.accidental.startsWith('Sharp')) {
+        return { kind: 'sharpKe', node };
+      }
+
+      return { kind: held ? 'heldKe' : 'ke', node };
+    }
+
+    if (noteValue === zoHighValue) {
+      return { kind: held ? 'heldZo' : 'zo', node };
+    }
+
+    return { kind: 'aboveZo', node };
+  }
+
+  private zoIsFlattened(
+    index: number,
     nodes: AnalysisNode[],
-    workspace: PlaybackWorkspace,
-  ) {
-    const index: number = nodes.indexOf(noteAtomNode);
+    budget: number = MAX_ATTRACTION_SCAN_NODES,
+    assumeEstablished = false,
+  ): boolean {
+    const node = nodes[index] as NoteAtomNode;
+
+    if (node.duration >= 2) {
+      return this.heldZoIsFlattened(index, nodes, budget);
+    }
+
+    let dippedToKe = false;
+    let currentNote = ScaleNote.ZoHigh;
 
     for (let i = index + 1; i < nodes.length; i++) {
-      const nextNoteAtomNode = nodes[i] as NoteAtomNode;
-
-      const next: number = getScaleNoteValue(nextNoteAtomNode.virtualNote);
-
-      if (next <= getScaleNoteValue(ScaleNote.Ke)) {
-        workspace.zoFlatPivotActivated = true;
-        workspace.zoNaturalPivotActivated = false;
-        return;
+      if (budget <= 0) {
+        break;
       }
 
-      // TODO this is too simplistic. Disabling for now.
-      // if (next >= getScaleNoteValue(ScaleNote.ZoHigh)) {
-      //   workspace.zoNaturalPivotActivated = true;
-      // }
+      budget--;
 
-      if (next > getScaleNoteValue(ScaleNote.ZoHigh)) {
-        return;
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        break;
+      }
+
+      if (token.kind === 'nonNote') {
+        continue;
+      }
+
+      if (token.kind === 'sharpKe') {
+        return false;
+      }
+
+      if (token.kind === 'belowKe' || token.kind === 'heldBelowKe') {
+        return true;
+      }
+
+      if (token.kind === 'aboveZo') {
+        return this.naturalZoResolutionIsFlattened(
+          index,
+          nodes,
+          budget,
+          dippedToKe,
+          assumeEstablished,
+        );
+      }
+
+      if (token.kind === 'heldKe') {
+        return true;
+      }
+
+      if (token.kind === 'ke') {
+        dippedToKe = true;
+
+        currentNote = ScaleNote.Ke;
+        continue;
+      }
+
+      if (token.kind === 'heldZo') {
+        return (
+          this.zoIsFlattened(i, nodes, budget) ||
+          this.naturalZoResolutionIsFlattened(
+            index,
+            nodes,
+            budget,
+            dippedToKe,
+            assumeEstablished,
+          )
+        );
+      }
+
+      if (token.kind === 'zo') {
+        currentNote = ScaleNote.ZoHigh;
       }
     }
+
+    return (
+      currentNote === ScaleNote.Ke ||
+      this.naturalZoResolutionIsFlattened(
+        index,
+        nodes,
+        budget,
+        dippedToKe,
+        assumeEstablished,
+      )
+    );
+  }
+
+  private heldZoIsFlattened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ): boolean {
+    let heardNoteAfter = false;
+
+    for (let i = index + 1; i < nodes.length; i++) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return heardNoteAfter;
+      }
+
+      if (token.kind === 'nonNote') {
+        continue;
+      }
+
+      if (token.kind === 'sharpKe') {
+        return false;
+      }
+
+      heardNoteAfter = true;
+
+      if (token.kind === 'aboveZo') {
+        return false;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        return (
+          token.node.accidental != null ||
+          this.zoIsFlattened(i, nodes, budget, true)
+        );
+      }
+
+      if (token.kind === 'heldKe') {
+        return true;
+      }
+    }
+
+    return heardNoteAfter;
+  }
+
+  private naturalZoResolutionIsFlattened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+    dippedToKe: boolean,
+    assumeEstablished: boolean,
+  ): boolean {
+    return (
+      dippedToKe &&
+      !assumeEstablished &&
+      !this.hasEstablishedUpperRegister(index, nodes, budget)
+    );
+  }
+
+  private hasEstablishedUpperRegister(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ) {
+    for (let i = index - 1; i >= 0; i--) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return false;
+      }
+
+      if (token.kind === 'nonNote') {
+        continue;
+      }
+
+      if (token.kind === 'sharpKe') {
+        return true;
+      }
+
+      if (token.kind === 'heldBelowKe') {
+        return false;
+      }
+
+      if (token.kind === 'belowKe') {
+        continue;
+      }
+
+      if (token.kind === 'aboveZo') {
+        return true;
+      }
+
+      if (token.kind === 'heldKe') {
+        return false;
+      }
+
+      if (token.kind === 'ke') {
+        continue;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        if (this.zoIsNatural(i, nodes, budget)) {
+          return true;
+        }
+
+        if (token.kind === 'heldZo') {
+          return false;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private keIsSharpened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number = MAX_ATTRACTION_SCAN_NODES,
+  ) {
+    const node = nodes[index] as NoteAtomNode;
+
+    if (node.duration >= 2) {
+      return false;
+    }
+
+    return (
+      this.hasPreviousNaturalZo(index, nodes, budget) &&
+      this.hasFutureUpperReturn(index, nodes, budget)
+    );
+  }
+
+  private hasPreviousNaturalZo(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ) {
+    for (let i = index - 1; i >= 0; i--) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return false;
+      }
+
+      if (token.kind === 'nonNote' || token.kind === 'sharpKe') {
+        continue;
+      }
+
+      if (
+        token.kind === 'belowKe' ||
+        token.kind === 'heldBelowKe' ||
+        token.kind === 'heldKe'
+      ) {
+        return false;
+      }
+
+      if (token.kind === 'ke' || token.kind === 'aboveZo') {
+        continue;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        return this.zoIsNatural(i, nodes, budget);
+      }
+    }
+
+    return false;
+  }
+
+  private hasFutureUpperReturn(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ) {
+    for (let i = index + 1; i < nodes.length; i++) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return false;
+      }
+
+      if (token.kind === 'nonNote' || token.kind === 'sharpKe') {
+        continue;
+      }
+
+      if (
+        token.kind === 'belowKe' ||
+        token.kind === 'heldBelowKe' ||
+        token.kind === 'heldKe'
+      ) {
+        return false;
+      }
+
+      if (token.kind === 'aboveZo') {
+        return true;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        return this.zoIsNatural(i, nodes, budget);
+      }
+    }
+
+    return false;
+  }
+
+  private zoIsNatural(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ): boolean {
+    const node = nodes[index];
+
+    return (
+      this.isNoteAtomNode(node) &&
+      node.virtualNote === ScaleNote.ZoHigh &&
+      !node.accidental &&
+      !this.zoIsFlattened(index, nodes, budget)
+    );
   }
 
   handleNoteAtom(
     noteAtomNode: Readonly<NoteAtomNode>,
     nodes: AnalysisNode[],
+    nodeIndex: number,
     workspace: PlaybackWorkspace,
   ) {
     const { events } = workspace;
@@ -611,6 +964,7 @@ export class PlaybackService {
     const alteredFrequency = this.applyAlterations(
       noteAtomNode,
       nodes,
+      nodeIndex,
       workspace,
     );
 

--- a/src/services/integration/MusicXmlExporter.ts
+++ b/src/services/integration/MusicXmlExporter.ts
@@ -68,7 +68,27 @@ import {
 interface FindNodesOutput {
   results: AnalysisNode[];
   index: number;
+  startIndex: number;
 }
+
+type AttractionScanClass =
+  | { kind: 'restSignal' }
+  | { kind: 'nonNote' }
+  | { kind: 'sharpKe'; node: NoteAtomNode }
+  | { kind: 'heldKe'; node: NoteAtomNode }
+  | { kind: 'heldBelowKe'; node: NoteAtomNode }
+  | { kind: 'belowKe'; node: NoteAtomNode }
+  | { kind: 'ke'; node: NoteAtomNode }
+  | { kind: 'heldZo'; node: NoteAtomNode }
+  | { kind: 'zo'; node: NoteAtomNode }
+  | { kind: 'aboveZo'; node: NoteAtomNode };
+
+/**
+ * The maximum number of nodes that may be examined while deciding the
+ * attraction of a single note. This bounds the lookahead/lookbehind so that
+ * pathological scores cannot cause quadratic scan times.
+ */
+const MAX_ATTRACTION_SCAN_NODES = 25;
 
 export enum PlaybackScaleName {
   Diatonic,
@@ -98,6 +118,8 @@ export interface DottedNote {
 export class MusicXmlExporterOptions {
   /** The target measure length if no barlines are present */
   measureLength: number = 8;
+  /** Indicates whether default Zo/Ke attractions should be exported. */
+  useDefaultAttractionZo: boolean = true;
   /** Indicates whether the MusicXML `<time>` element should be included in the measures. */
   calculateTimeSignatures: boolean = false;
   /** Indicates whether the time signature should be printed in each measure */
@@ -120,10 +142,6 @@ class MusicXmlExporterWorkspace {
   // State: Dynamic
   /////////////////
 
-  /** Indicates whether ZO should be attracted toward KE in the current phrase */
-  zoFlatPivotActivated: boolean = false;
-  /** Indicates whether KE should be attracted toward ZO in the current phrase */
-  zoNaturalPivotActivated: boolean = false;
   /**  Indicates whether we are processing a hyphenated, multi-syllable phrase */
   isSyllabic: boolean = false;
   /**  Indicates whether we are processing a non-hyphenated melismatic phrase */
@@ -308,6 +326,7 @@ export class MusicXmlExporter {
           const notes = this.buildNoteGroup(
             element as NoteElement,
             nodeGroup as NoteAtomNode[],
+            findResults.startIndex,
             workspace,
           );
 
@@ -600,6 +619,7 @@ export class MusicXmlExporter {
   buildNoteGroup(
     noteElement: Readonly<NoteElement>,
     nodes: readonly AnalysisNode[],
+    nodeStartIndex: number,
     workspace: MusicXmlExporterWorkspace,
   ) {
     const notes: Array<MusicXmlNote | MusicXmlHarmony> = [];
@@ -629,10 +649,11 @@ export class MusicXmlExporter {
 
         if (
           !noteNode.accidental &&
+          !this.hasCarriedAlteration(noteNode, workspace) &&
           !noteNode.ignoreAttractions &&
           !workspace.ignoreAttractions
         ) {
-          this.applyAttractions(noteNode, note, workspace);
+          this.applyAttractions(noteNode, note, nodeStartIndex + i, workspace);
         }
 
         if (
@@ -1069,6 +1090,16 @@ export class MusicXmlExporter {
     return 0;
   }
 
+  private hasCarriedAlteration(
+    node: NoteAtomNode,
+    workspace: MusicXmlExporterWorkspace,
+  ) {
+    return (
+      workspace.lastAlteration !== 0 &&
+      workspace.lastAlterationNote === node.physicalNote
+    );
+  }
+
   handleFthora(node: FthoraNode, workspace: MusicXmlExporterWorkspace) {
     // const transposition =
     //   getScaleNoteValue(node.physicalNote) -
@@ -1139,72 +1170,413 @@ export class MusicXmlExporter {
   applyAttractions(
     node: NoteAtomNode,
     note: MusicXmlNote,
+    nodeIndex: number,
     workspace: MusicXmlExporterWorkspace,
   ) {
-    // If melody descends after zo, flatten zo
+    const { scale } = workspace;
+
     if (
-      node.scale === Scale.Diatonic ||
-      node.scale === Scale.Kliton ||
-      node.scale === Scale.Zygos
+      workspace.options.useDefaultAttractionZo &&
+      !workspace.permanentEnharmonicZo &&
+      (scale.name === PlaybackScaleName.Diatonic ||
+        scale.name === PlaybackScaleName.Kliton ||
+        scale.name === PlaybackScaleName.Zygos) &&
+      this.canApplyDefaultAttraction(node)
     ) {
       if (node.virtualNote === ScaleNote.ZoHigh) {
-        // If we are not in a pivot, check to see if we need to pivot
-        if (!workspace.zoFlatPivotActivated) {
-          this.setPivots(node, workspace);
-        }
-
-        // If we are in a pivot, then flatten zo
-        if (workspace.zoFlatPivotActivated) {
+        if (this.zoIsFlattened(nodeIndex, workspace.nodes)) {
           note.pitch!.alter = new MusicXmlAlter(-1);
         }
-      } else {
-        // Clear zo flat pivot
-        workspace.zoFlatPivotActivated = false;
-      }
-
-      // Check whether ke is attracted toward zo
-      if (
-        node.virtualNote === ScaleNote.Ke &&
-        workspace.zoNaturalPivotActivated
-      ) {
-        note.pitch!.alter = new MusicXmlAlter(1);
-      }
-
-      // Clear the zo natural pivot if we descend below ke
-      if (
-        getScaleNoteValue(node.virtualNote) < getScaleNoteValue(ScaleNote.Ke)
-      ) {
-        workspace.zoNaturalPivotActivated = false;
+      } else if (node.virtualNote === ScaleNote.Ke) {
+        if (this.keIsSharpened(nodeIndex, workspace.nodes)) {
+          note.pitch!.alter = new MusicXmlAlter(1);
+        }
       }
     }
   }
 
-  setPivots(
-    noteAtomNode: Readonly<NoteAtomNode>,
-    workspace: MusicXmlExporterWorkspace,
-  ) {
-    const index: number = workspace.nodes.indexOf(noteAtomNode);
+  private canApplyDefaultAttraction(node: Readonly<NoteAtomNode>) {
+    return (
+      !node.ignoreAttractions &&
+      !node.accidental &&
+      (node.scale === Scale.Diatonic ||
+        node.scale === Scale.Kliton ||
+        node.scale === Scale.Zygos)
+    );
+  }
 
-    for (let i = index + 1; i < workspace.nodes.length; i++) {
-      const nextNoteAtomNode = workspace.nodes[i] as NoteAtomNode;
+  private isNoteAtomNode(node: AnalysisNode): node is NoteAtomNode {
+    return node.nodeType === NodeType.NoteAtomNode;
+  }
 
-      const next: number = getScaleNoteValue(nextNoteAtomNode.virtualNote);
+  private getAttractionScanClass(node: AnalysisNode): AttractionScanClass {
+    if (
+      node.nodeType === NodeType.RestNode ||
+      node.nodeType === NodeType.FthoraNode ||
+      node.nodeType === NodeType.ModeKeyNode
+    ) {
+      return { kind: 'restSignal' };
+    }
 
-      if (next <= getScaleNoteValue(ScaleNote.Ke)) {
-        workspace.zoFlatPivotActivated = true;
-        workspace.zoNaturalPivotActivated = false;
-        return;
+    if (!this.isNoteAtomNode(node)) {
+      return { kind: 'nonNote' };
+    }
+
+    const held = node.duration >= 2;
+    const noteValue = getScaleNoteValue(node.virtualNote);
+    const keValue = getScaleNoteValue(ScaleNote.Ke);
+    const zoHighValue = getScaleNoteValue(ScaleNote.ZoHigh);
+
+    if (noteValue < keValue) {
+      return {
+        kind: held ? 'heldBelowKe' : 'belowKe',
+        node,
+      };
+    }
+
+    if (noteValue === keValue) {
+      if (node.accidental != null && node.accidental.startsWith('Sharp')) {
+        return { kind: 'sharpKe', node };
       }
 
-      // TODO this is too simplistic. Disabling for now.
-      // if (next >= getScaleNoteValue(ScaleNote.ZoHigh)) {
-      //   workspace.zoNaturalPivotActivated = true;
-      // }
+      return { kind: held ? 'heldKe' : 'ke', node };
+    }
 
-      if (next > getScaleNoteValue(ScaleNote.ZoHigh)) {
-        return;
+    if (noteValue === zoHighValue) {
+      return { kind: held ? 'heldZo' : 'zo', node };
+    }
+
+    return { kind: 'aboveZo', node };
+  }
+
+  private zoIsFlattened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number = MAX_ATTRACTION_SCAN_NODES,
+    assumeEstablished = false,
+  ): boolean {
+    const node = nodes[index] as NoteAtomNode;
+
+    if (node.duration >= 2) {
+      return this.heldZoIsFlattened(index, nodes, budget);
+    }
+
+    let dippedToKe = false;
+    let currentNote = ScaleNote.ZoHigh;
+
+    for (let i = index + 1; i < nodes.length; i++) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        break;
+      }
+
+      if (token.kind === 'nonNote') {
+        continue;
+      }
+
+      if (token.kind === 'sharpKe') {
+        return false;
+      }
+
+      if (token.kind === 'belowKe' || token.kind === 'heldBelowKe') {
+        return true;
+      }
+
+      if (token.kind === 'aboveZo') {
+        return this.naturalZoResolutionIsFlattened(
+          index,
+          nodes,
+          budget,
+          dippedToKe,
+          assumeEstablished,
+        );
+      }
+
+      if (token.kind === 'heldKe') {
+        return true;
+      }
+
+      if (token.kind === 'ke') {
+        dippedToKe = true;
+
+        currentNote = ScaleNote.Ke;
+        continue;
+      }
+
+      if (token.kind === 'heldZo') {
+        return (
+          this.zoIsFlattened(i, nodes, budget) ||
+          this.naturalZoResolutionIsFlattened(
+            index,
+            nodes,
+            budget,
+            dippedToKe,
+            assumeEstablished,
+          )
+        );
+      }
+
+      if (token.kind === 'zo') {
+        currentNote = ScaleNote.ZoHigh;
       }
     }
+
+    return (
+      currentNote === ScaleNote.Ke ||
+      this.naturalZoResolutionIsFlattened(
+        index,
+        nodes,
+        budget,
+        dippedToKe,
+        assumeEstablished,
+      )
+    );
+  }
+
+  private heldZoIsFlattened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ): boolean {
+    let heardNoteAfter = false;
+
+    for (let i = index + 1; i < nodes.length; i++) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return heardNoteAfter;
+      }
+
+      if (token.kind === 'nonNote') {
+        continue;
+      }
+
+      if (token.kind === 'sharpKe') {
+        return false;
+      }
+
+      heardNoteAfter = true;
+
+      if (token.kind === 'aboveZo') {
+        return false;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        return (
+          token.node.accidental != null ||
+          this.zoIsFlattened(i, nodes, budget, true)
+        );
+      }
+
+      if (token.kind === 'heldKe') {
+        return true;
+      }
+    }
+
+    return heardNoteAfter;
+  }
+
+  private naturalZoResolutionIsFlattened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+    dippedToKe: boolean,
+    assumeEstablished: boolean,
+  ): boolean {
+    return (
+      dippedToKe &&
+      !assumeEstablished &&
+      !this.hasEstablishedUpperRegister(index, nodes, budget)
+    );
+  }
+
+  private hasEstablishedUpperRegister(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ) {
+    for (let i = index - 1; i >= 0; i--) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return false;
+      }
+
+      if (token.kind === 'nonNote') {
+        continue;
+      }
+
+      if (token.kind === 'sharpKe') {
+        return true;
+      }
+
+      if (token.kind === 'heldBelowKe') {
+        return false;
+      }
+
+      if (token.kind === 'belowKe') {
+        continue;
+      }
+
+      if (token.kind === 'aboveZo') {
+        return true;
+      }
+
+      if (token.kind === 'heldKe') {
+        return false;
+      }
+
+      if (token.kind === 'ke') {
+        continue;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        if (this.zoIsNatural(i, nodes, budget)) {
+          return true;
+        }
+
+        if (token.kind === 'heldZo') {
+          return false;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private keIsSharpened(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number = MAX_ATTRACTION_SCAN_NODES,
+  ) {
+    const node = nodes[index] as NoteAtomNode;
+
+    if (node.duration >= 2) {
+      return false;
+    }
+
+    return (
+      this.hasPreviousNaturalZo(index, nodes, budget) &&
+      this.hasFutureUpperReturn(index, nodes, budget)
+    );
+  }
+
+  private hasPreviousNaturalZo(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ) {
+    for (let i = index - 1; i >= 0; i--) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return false;
+      }
+
+      if (token.kind === 'nonNote' || token.kind === 'sharpKe') {
+        continue;
+      }
+
+      if (
+        token.kind === 'belowKe' ||
+        token.kind === 'heldBelowKe' ||
+        token.kind === 'heldKe'
+      ) {
+        return false;
+      }
+
+      if (token.kind === 'ke' || token.kind === 'aboveZo') {
+        continue;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        return this.zoIsNatural(i, nodes, budget);
+      }
+    }
+
+    return false;
+  }
+
+  private hasFutureUpperReturn(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ) {
+    for (let i = index + 1; i < nodes.length; i++) {
+      if (budget <= 0) {
+        break;
+      }
+
+      budget--;
+
+      const token = this.getAttractionScanClass(nodes[i]);
+
+      if (token.kind === 'restSignal') {
+        return false;
+      }
+
+      if (token.kind === 'nonNote' || token.kind === 'sharpKe') {
+        continue;
+      }
+
+      if (
+        token.kind === 'belowKe' ||
+        token.kind === 'heldBelowKe' ||
+        token.kind === 'heldKe'
+      ) {
+        return false;
+      }
+
+      if (token.kind === 'aboveZo') {
+        return true;
+      }
+
+      if (token.kind === 'zo' || token.kind === 'heldZo') {
+        return this.zoIsNatural(i, nodes, budget);
+      }
+    }
+
+    return false;
+  }
+
+  private zoIsNatural(
+    index: number,
+    nodes: AnalysisNode[],
+    budget: number,
+  ): boolean {
+    const node = nodes[index];
+
+    return (
+      this.isNoteAtomNode(node) &&
+      node.virtualNote === ScaleNote.ZoHigh &&
+      !node.accidental &&
+      !this.zoIsFlattened(index, nodes, budget)
+    );
   }
 
   findNodes(
@@ -1215,9 +1587,13 @@ export class MusicXmlExporter {
     const results: AnalysisNode[] = [];
 
     let i = startIndex;
+    let resultStartIndex = -1;
 
     for (i = startIndex; i < nodes.length; i++) {
       if (nodes[i].elementIndex === elementIndex) {
+        if (resultStartIndex === -1) {
+          resultStartIndex = i;
+        }
         results.push(nodes[i]);
       }
 
@@ -1226,7 +1602,7 @@ export class MusicXmlExporter {
       }
     }
 
-    return { results, index: i };
+    return { results, index: i, startIndex: resultStartIndex };
   }
 
   getPlaybackScale(


### PR DESCRIPTION
## Summary

This PR replaces the pivot-flag default attraction algorithm (#808) with a whole-score phrase-analysis pass that classifies every natural high Zo and Ke up front, and restores the Ke-Zo attraction that has been disabled since #823. The identical algorithm is applied to the MusicXML exporter, so playback and exported scores now agree on which Zos are flattened and which Kes are sharpened.

Fixes #213

## Background

For diatonic, Kliton, and Zygos passages with no explicit accidentals, the default attraction logic decides when high Zo should be sung flat (melody orbiting natural Ke from above) and when Ke should be sung sharp (melody orbiting natural Zo from below).

The previous implementation (#808, with a boundary fix in 871842ed for #821) kept two mutable flags while streaming through the score:

- `zoFlatPivotActivated` On reaching a Zo, scan forward; if a note at or below Ke appears before the melody rises above Zo, flatten this Zo (and consecutive Zos, until any non-Zo note clears the flag).
- `zoNaturalPivotActivated` Armed when the scan saw the melody reach Zo or higher; any Ke sung while armed was sharpened.

The second flag was the casualty of #823: arming on "the melody eventually reaches Zo again" sharpened Kes that were really resting points (the third-mode descent in #821), so the assignment was commented out with `// TODO this is too simplistic. Disabling for now` and the Ke-attraction tests were commented out wholesale. Ke attraction has been dead code in both playback and the exporter ever since, and this wart in playback has prevailed.

The old forward scan also had structural problems that this rewrite addresses:

- It cast every analysis node to `NoteAtomNode` unchecked, so rests, fthoras, and mode keys were silently skipped (`getScaleNoteValue(undefined)` comparisons are always false) and the scan crossed phrase boundaries.
- It had no concept of duration: a Zo or Ke the melody rests on (klasma) was classified the same as a passing one.
- Decisions were made note-by-note against mutable state, so a Zo's pitch could depend on processing order rather than on the shape of the phrase.

## User-facing changes

### Playback

- **Ke attraction works again.** A Ke that acts as a lower neighbor inside an established natural-Zo register is sharpened by `defaultAttractionKeMoria` (default +5, unchanged). Neighbor figures like Zo-Ke-Zo from high Ni once again play with natural Zo and sharpened Ke, as they did before #823, but resting Kes, descents, and unestablished registers no longer trigger it, which is what broke #821.
- **Held notes matter.** A note held for 2+ beats (e.g. under a klasma) is treated as a resting point: a held Ke flattens the Zo before it and is never itself sharpened; a held Zo is classified by whether the melody afterwards returns to the upper register or wanders down.
- **Rests, fthoras, and mode keys bound the analysis.** Attraction decisions never cross them anymore. A plain martyria remains transparent (it emits no analysis node), but a martyria carrying a fthora is a boundary.
- **Explicit sharps on Ke count as evidence.** A composer-written sharp on Ke keeps the preceding Zo natural and establishes the upper register for later decisions (the explicit accidental itself always wins over default attractions, as before).
- **Dip-and-return is context-sensitive.** A Zo that dips to Ke and returns upward stays natural only if the upper register was already established; in a fresh ascent the dip wins and the Zo is flat. This is the core complaint of #213.

Flattened Zo still uses `defaultAttractionZoMoria` (default -4), and the existing opt-outs are untouched: the `useDefaultAttractionZo` option, the mode key's *Permanent Enharmonic Zo* and *Ignore Attractions* flags, and per-note *Ignore Attractions*.

### MusicXML export

- The exporter runs the exact same analysis and emits `<alter>-1</alter>` for flattened Zo and `<alter>1</alter>` for sharpened Ke (the 12-TET approximation it already used).
- New `MusicXmlExporterOptions.useDefaultAttractionZo` (default `true`), mirroring the playback option.
- The exporter now also suppresses default attractions under *Permanent Enharmonic Zo* and when the current playback scale isn't diatonic/Kliton/Zygos: both gates existed in playback but were missing from the exporter, which only consulted the note's own scale.

## The new model

All analysis nodes are first classified into a scan vocabulary (`AttractionScanClass`): `restSignal` (rest, fthora, mode key end every walk), `nonNote` (transparent), or a note class: `sharpKe`, `heldKe`, `ke`, `heldZo`, `zo`, `belowKe`, `heldBelowKe`, `aboveZo` ("held" = duration >= 2 beats). Four walks consume these tokens:

- **Zo classification (forward).** A short natural Zo is *flat* if, before the next rest signal, the melody reaches any note below Ke, comes to rest on a held Ke, or ends the phrase on Ke. It is *natural* if the melody returns above Zo or an explicitly sharpened Ke appears, subject to the dip-return rule. A short Ke along the way is recorded as a dip; a held Zo ahead delegates to that Zo's own classification.
- **Dip-return rule.** A Zo whose walk dipped to Ke before resolving upward is natural only if `hasEstablishedUpperRegister` succeeds looking backward; otherwise flat.
- **Establishment (backward, lenient).** A previous natural-classifying Zo, any note above Zo, or an explicit sharp Ke establishes the register. Short below-Ke notes, short Kes, and short flat-classifying Zos are transparent (passing dips don't reset the register) but their *held* counterparts (and rest signals) break the walk.
- **Held Zo (forward).** Natural if the melody returns above Zo, returns to another natural-classifying Zo, or the held Zo ends the phrase; flat if the melody afterwards stays at or below Ke, rests on a held Ke, or only returns to a flat Zo. When a future Zo is consulted from a held-Zo context, it is classified with establishment assumed: the held Zo *is* the establishment, and recursing through the normal check would cycle.
- **Ke sharpening.** Only a short Ke is ever sharpened, and only when two walks agree. The *arming* walk (backward, strict): the nearest Zo (skipping other Kes, above-Zo notes, and sharp Kes) must classify natural; any below-Ke note, held Ke, or rest signal kills it, so a high Ni alone never arms the attraction (the `nkzn` case #808 left as an open question). The *resolution* walk (forward): the melody must return to a natural Zo or above Zo before any below-Ke note, held Ke, or rest signal.

The lenient/strict asymmetry between the establishment and arming walks is deliberate: it keeps the Ke in a plain Thi-Ke-Zo-Ni ascent natural (`dkzn`), while letting a Zo that follows a short passing dip in an already-established register stay natural with the subsequent Ke sharpened.

## Implementation notes

- **Deliberate duplication.** The analysis block (`computeDefaultAttractions` through `zoIsNatural`, ~370 lines) is duplicated byte-for-byte between `PlaybackService` and `MusicXmlExporter`, differing only in the options type and the applied magnitudes. The exporter has always been a self-contained fork of the playback pitch logic rather than a shared module, and this PR keeps that structure; symmetry was verified by diffing the extracted blocks.
- **Ordering relative to quantization.** The exporter computes attractions right after node analysis and *before* global sixteenth-note quantization, so the "held >= 2 beats" classification sees the same durations playback sees.
- **Gating.** Per node, `canApplyDefaultAttraction` requires no `ignoreAttractions`, no explicit accidental, and a diatonic/Kliton/Zygos note scale; per workspace, `useDefaultAttractionZo`, no `permanentEnharmonicZo`, and a diatonic/Kliton/Zygos current scale. The pre-existing call-site guards are unchanged.

## Testing Done

1. The six Ke-attraction cases commented out in #823 are re-enabled with their original expectations (`nzkz`, `nzkzn`, `nkzn`, `znkzn`, `nzkkz`, `nzkn`); the seven existing Zo-attraction cases pass unchanged.
2. 21 new playback scenario tests pin the new rules, including: the third-mode melody from #821 (Ke must stay natural), a 36-note ideal interpretation of the melody from #213 (ending with a *Permanent Enharmonic Zo* section where the attraction machinery must stand down), held-Zo phrases (wandering down vs. returning up vs. ending the piece, and a petasti+hyporoe dip-and-return), held-Ke phrases (resting Ke never sharpened, no establishment across a held Ke), explicit-sharp-Ke evidence (including outranking the held-Ke rest inference), the plain-martyria-is-transparent regression, and first-mode melodies revolving around Zo with passing dips.
3. Played back a variety of Axion Estins in 3rd, 4th, and Pl 2nd, and Pl 4th modes, everything sounded right.