### PR TITLE
feat: Download Update Toast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ yarn-error.log*
 # Vitest coverage output
 /coverage/
 
-#Electron-builder output
+# Electron-builder output
 /dist
 /dist-electron
 /release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ npm run dev
 
 This will launch the application in development mode. As changes are made to the source code, the app will reload automatically.
 
+To exercise the Electron update toast flow without publishing a release, set `FAKE_UPDATE_AVAILABLE=1` before starting the app. This simulates an available update, the download lifecycle, and the restart request without calling `electron-updater`.
+
+- macOS and Linux: `FAKE_UPDATE_AVAILABLE=1 npm run dev`
+- PowerShell: `$env:FAKE_UPDATE_AVAILABLE=1; npm run dev`
+- cmd.exe: `set FAKE_UPDATE_AVAILABLE=1 && npm run dev`
+
 The [Vue Devtools](https://devtools-next.vuejs.org/) extension is available in development mode.
 To enable it, add the following to `.env.local` and/or `.env.web.local`:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,10 @@ The biggest source of regressions is Electron version changes, especially major 
 The checklist above catches the worst problems these bumps introduce, usually a change in how Chromium interprets some CSS rule.
 This is infrequent.
 
+## Local update testing
+
+For renderer-only testing, start the app with `FAKE_UPDATE_AVAILABLE=1`. This bypasses `electron-updater` and simulates the same update IPC flow that the toast UI listens for.
+
 ## Bump and tag
 
 ```sh

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -98,11 +98,18 @@ const silentLatexIncludeTextBoxes = process.argv.includes(
 const silent = silentPdf || silentLatex || silentHtml;
 
 const disableUpdates = process.argv.includes('--no-update');
+const fakeUpdateMode = process.env.FAKE_UPDATE_AVAILABLE === '1';
 
 let win: BrowserWindow | null = null;
 let readyToExit = false;
 let creatingWindow = false;
 let quitting = false;
+let updateAvailable = false;
+let updateDownloaded = false;
+let updateDownloadInProgress = false;
+let pendingUpdateVersion: string | undefined;
+let didReportUpdateError = false;
+let fakeDownloadProgressTimer: NodeJS.Timeout | null = null;
 
 const minWidth = 800;
 const minHeight = 600;
@@ -155,6 +162,7 @@ let loaded = false;
 let exportAsImageOnConflict: OnConflictChoice | null = null;
 
 let darwinPath: string | null = null;
+let autoUpdaterInitialized = false;
 
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
@@ -209,6 +217,144 @@ async function getExportDefaultPath(
   return sourceFilePath != null
     ? replaceExtension(sourceFilePath, extension)
     : await generateFilePath(`${tempFileName}.${extension}`);
+}
+
+function sendToRenderer(channel: IpcMainChannels, payload?: unknown) {
+  if (win == null || !loaded) {
+    return;
+  }
+
+  win.webContents.send(channel, payload);
+}
+
+function sendPendingUpdateState() {
+  if (updateDownloaded) {
+    sendToRenderer(IpcMainChannels.UpdateDownloaded, {
+      version: pendingUpdateVersion,
+    });
+    return;
+  }
+
+  if (updateDownloadInProgress) {
+    sendToRenderer(IpcMainChannels.UpdateDownloadStarted);
+    return;
+  }
+
+  if (updateAvailable) {
+    sendToRenderer(IpcMainChannels.UpdateAvailable, {
+      version: pendingUpdateVersion,
+    });
+  }
+}
+
+function clearFakeDownloadProgressTimer() {
+  if (fakeDownloadProgressTimer != null) {
+    clearInterval(fakeDownloadProgressTimer);
+    fakeDownloadProgressTimer = null;
+  }
+}
+
+function simulateFakeUpdateDownload() {
+  const progressSteps = [18, 42, 69, 91, 100];
+  const total = 100;
+  let stepIndex = 0;
+
+  clearFakeDownloadProgressTimer();
+
+  fakeDownloadProgressTimer = setInterval(() => {
+    if (win == null || !loaded || !updateDownloadInProgress) {
+      clearFakeDownloadProgressTimer();
+      return;
+    }
+
+    const percent = progressSteps[stepIndex] ?? 100;
+    const transferred = percent;
+
+    sendToRenderer(IpcMainChannels.UpdateDownloadProgress, {
+      percent,
+      transferred,
+      total,
+    });
+
+    stepIndex += 1;
+
+    if (percent >= 100) {
+      clearFakeDownloadProgressTimer();
+      updateDownloaded = true;
+      updateDownloadInProgress = false;
+      sendToRenderer(IpcMainChannels.UpdateDownloaded, {
+        version: pendingUpdateVersion,
+      });
+    }
+  }, 250);
+}
+
+function setupAutoUpdater() {
+  if (autoUpdaterInitialized) {
+    return;
+  }
+
+  autoUpdaterInitialized = true;
+
+  if (fakeUpdateMode) {
+    updateAvailable = true;
+    updateDownloaded = false;
+    updateDownloadInProgress = false;
+    pendingUpdateVersion = undefined;
+    didReportUpdateError = false;
+    return;
+  }
+
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on('update-available', (info) => {
+    updateAvailable = true;
+    updateDownloaded = false;
+    updateDownloadInProgress = false;
+    pendingUpdateVersion = info.version;
+    didReportUpdateError = false;
+
+    sendToRenderer(IpcMainChannels.UpdateAvailable, {
+      version: info.version,
+    });
+  });
+
+  autoUpdater.on('update-downloaded', (info) => {
+    updateDownloaded = true;
+    updateDownloadInProgress = false;
+    pendingUpdateVersion = info.version;
+    didReportUpdateError = false;
+
+    sendToRenderer(IpcMainChannels.UpdateDownloaded, {
+      version: info.version,
+    });
+  });
+
+  autoUpdater.on('download-progress', (info) => {
+    sendToRenderer(IpcMainChannels.UpdateDownloadProgress, {
+      percent: info.percent,
+      transferred: info.transferred,
+      total: info.total,
+    });
+  });
+
+  autoUpdater.on('error', (error) => {
+    const shouldReportError =
+      updateDownloadInProgress || updateAvailable || updateDownloaded;
+
+    updateDownloadInProgress = false;
+
+    if (!shouldReportError || didReportUpdateError) {
+      return;
+    }
+
+    didReportUpdateError = true;
+
+    sendToRenderer(IpcMainChannels.UpdateError, {
+      message: error == null ? 'Unable to update.' : error.message,
+    });
+  });
 }
 
 async function loadStore() {
@@ -1776,7 +1922,10 @@ async function createWindow() {
     });
   }
 
-  win.webContents.once('did-finish-load', () => (loaded = true));
+  win.webContents.once('did-finish-load', () => {
+    loaded = true;
+    sendPendingUpdateState();
+  });
 
   // Prevent the user from accidentally
   // closing the app with unsaved changes
@@ -1791,6 +1940,7 @@ async function createWindow() {
     win = null;
     loaded = false;
     darwinPath = null;
+    clearFakeDownloadProgressTimer();
   });
 
   createMenu();
@@ -1803,8 +1953,8 @@ async function createWindow() {
     }
   } else {
     // Load the index.html when not in development
-    if (!silent && !disableUpdates) {
-      autoUpdater.checkForUpdatesAndNotify();
+    if (!silent && !disableUpdates && !fakeUpdateMode) {
+      autoUpdater.checkForUpdates();
     }
 
     await win.loadFile(indexHtml);
@@ -1871,6 +2021,54 @@ ipcMain.handle(IpcRendererChannels.ExitApplication, async () => {
   } else {
     win?.close();
   }
+});
+
+ipcMain.handle(IpcRendererChannels.DownloadUpdate, async () => {
+  if (updateDownloaded) {
+    sendPendingUpdateState();
+    return;
+  }
+
+  if (!updateAvailable || updateDownloadInProgress) {
+    return;
+  }
+
+  updateDownloadInProgress = true;
+  didReportUpdateError = false;
+  sendToRenderer(IpcMainChannels.UpdateDownloadStarted);
+
+  try {
+    if (fakeUpdateMode) {
+      simulateFakeUpdateDownload();
+      return;
+    }
+
+    await autoUpdater.downloadUpdate();
+  } catch (error) {
+    updateDownloadInProgress = false;
+    didReportUpdateError = true;
+
+    sendToRenderer(IpcMainChannels.UpdateError, {
+      message:
+        error instanceof Error ? error.message : 'Unable to download update.',
+    });
+  }
+});
+
+ipcMain.handle(IpcRendererChannels.RestartToInstallUpdate, async () => {
+  if (!updateDownloaded) {
+    return;
+  }
+
+  if (fakeUpdateMode) {
+    console.info(
+      'FAKE_UPDATE_AVAILABLE=1: restart-and-install requested; skipping quitAndInstall().',
+    );
+    return;
+  }
+
+  readyToExit = true;
+  autoUpdater.quitAndInstall(false, true);
 });
 
 ipcMain.handle(IpcRendererChannels.CancelExit, async () => {
@@ -2087,26 +2285,10 @@ app.on('ready', async () => {
     lng: resolveLanguagePreference(store.language, app.getLocale()),
   });
 
+  setupAutoUpdater();
+
   if (!win) {
     createWindow();
-  }
-
-  if (isMac) {
-    autoUpdater.once('update-available', async (info) => {
-      const result = await dialog.showMessageBox(win!, {
-        type: 'info',
-        title: 'Update Available',
-        message: 'An update is available.',
-        detail: `Version ${info.version} is available.`,
-        buttons: ['Download', 'Not now'],
-        defaultId: 0,
-        cancelId: 1,
-      });
-
-      if (result.response === 0) {
-        shell.openExternal(import.meta.env.VITE_DOWNLOAD_URL);
-      }
-    });
   }
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,13 +13,111 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { toast } from 'vue-sonner';
 
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { EventBus } from '@/eventBus';
+import type { UpdateAvailableArgs, UpdateErrorArgs } from '@/ipc/ipcChannels';
+import { IpcMainChannels, IpcRendererChannels } from '@/ipc/ipcChannels';
 
 const registration = ref<ServiceWorkerRegistration | null>(null);
 const updateExists = ref(false);
+const electronUpdateAvailableToastId = 'electron-update-available';
+const electronUpdateDownloadingToastId = 'electron-update-downloading';
+const electronUpdateDownloadedToastId = 'electron-update-downloaded';
+const electronUpdateErrorToastId = 'electron-update-error';
+
+async function downloadElectronUpdate() {
+  try {
+    await window.ipcRenderer?.invoke(IpcRendererChannels.DownloadUpdate);
+  } catch (error) {
+    toast.dismiss(electronUpdateAvailableToastId);
+    showElectronUpdateErrorToast({
+      message:
+        error instanceof Error ? error.message : 'Unable to download update.',
+    });
+  }
+}
+
+async function restartToInstallElectronUpdate() {
+  try {
+    await window.ipcRenderer?.invoke(
+      IpcRendererChannels.RestartToInstallUpdate,
+    );
+  } catch (error) {
+    toast.dismiss(electronUpdateDownloadedToastId);
+    showElectronUpdateErrorToast({
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Unable to restart to install the update.',
+    });
+  }
+}
+
+function showElectronUpdateAvailableToast(args?: UpdateAvailableArgs) {
+  toast.info('An update is available.', {
+    id: electronUpdateAvailableToastId,
+    duration: Infinity,
+    description: args?.version
+      ? `Version ${args.version} is available.`
+      : undefined,
+    action: {
+      label: 'Download',
+      onClick: () => {
+        void downloadElectronUpdate();
+      },
+    },
+    cancel: {
+      label: 'Later',
+      onClick: () => {
+        toast.dismiss(electronUpdateAvailableToastId);
+      },
+    },
+  });
+}
+
+function showElectronUpdateDownloadingToast() {
+  toast.dismiss(electronUpdateAvailableToastId);
+
+  toast.loading('Downloading update...', {
+    id: electronUpdateDownloadingToastId,
+    duration: Infinity,
+  });
+}
+
+function showElectronUpdateDownloadedToast(args?: UpdateAvailableArgs) {
+  toast.dismiss(electronUpdateDownloadingToastId);
+
+  toast.success('Update downloaded. Restart to install.', {
+    id: electronUpdateDownloadedToastId,
+    duration: Infinity,
+    description: args?.version
+      ? `Version ${args.version} is ready.`
+      : undefined,
+    action: {
+      label: 'Restart now',
+      onClick: () => {
+        void restartToInstallElectronUpdate();
+      },
+    },
+    cancel: {
+      label: 'Later',
+      onClick: () => {
+        toast.dismiss(electronUpdateDownloadedToastId);
+      },
+    },
+  });
+}
+
+function showElectronUpdateErrorToast(args: UpdateErrorArgs) {
+  toast.error('Update failed.', {
+    id: electronUpdateErrorToastId,
+    description: args.message,
+  });
+}
 
 if (navigator.serviceWorker) {
   document.addEventListener('swUpdated', onUpdateAvailable as EventListener, {
@@ -47,6 +145,41 @@ function refreshApp() {
     registration.value.waiting.postMessage({ type: 'SKIP_WAITING' });
   }
 }
+
+const onElectronUpdateAvailable = (args?: UpdateAvailableArgs) =>
+  showElectronUpdateAvailableToast(args);
+const onElectronUpdateDownloadStarted = () =>
+  showElectronUpdateDownloadingToast();
+const onElectronUpdateDownloaded = (args?: UpdateAvailableArgs) =>
+  showElectronUpdateDownloadedToast(args);
+const onElectronUpdateError = (args?: UpdateErrorArgs) => {
+  toast.dismiss(electronUpdateDownloadingToastId);
+  showElectronUpdateErrorToast(args ?? { message: 'Unable to update.' });
+};
+
+onMounted(() => {
+  if (window.ipcRenderer == null) {
+    return;
+  }
+
+  EventBus.$on(IpcMainChannels.UpdateAvailable, onElectronUpdateAvailable);
+  EventBus.$on(
+    IpcMainChannels.UpdateDownloadStarted,
+    onElectronUpdateDownloadStarted,
+  );
+  EventBus.$on(IpcMainChannels.UpdateDownloaded, onElectronUpdateDownloaded);
+  EventBus.$on(IpcMainChannels.UpdateError, onElectronUpdateError);
+});
+
+onBeforeUnmount(() => {
+  EventBus.$off(IpcMainChannels.UpdateAvailable, onElectronUpdateAvailable);
+  EventBus.$off(
+    IpcMainChannels.UpdateDownloadStarted,
+    onElectronUpdateDownloadStarted,
+  );
+  EventBus.$off(IpcMainChannels.UpdateDownloaded, onElectronUpdateDownloaded);
+  EventBus.$off(IpcMainChannels.UpdateError, onElectronUpdateError);
+});
 </script>
 
 <style>

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -2,6 +2,12 @@ import type { PageSize } from '@/models/PageSetup';
 import type { Score } from '@/models/save/v1/Score';
 
 export enum IpcMainChannels {
+  UpdateAvailable = 'UpdateAvailable',
+  UpdateDownloadStarted = 'UpdateDownloadStarted',
+  UpdateDownloadProgress = 'UpdateDownloadProgress',
+  UpdateDownloaded = 'UpdateDownloaded',
+  UpdateError = 'UpdateError',
+
   FileMenuNewScore = 'FileMenuNewScore',
   FileMenuOpenScore = 'FileMenuOpenScore',
   FileMenuPrint = 'FileMenuPrint',
@@ -56,6 +62,9 @@ export enum IpcMainChannels {
 }
 
 export enum IpcRendererChannels {
+  DownloadUpdate = 'DownloadUpdate',
+  RestartToInstallUpdate = 'RestartToInstallUpdate',
+
   SetCanUndo = 'SetCanUndo',
   SetCanRedo = 'SetCanRedo',
 
@@ -105,6 +114,20 @@ export interface FileMenuOpenImageArgs {
   imageHeight: number;
   filePath: string;
   success: boolean;
+}
+
+export interface UpdateAvailableArgs {
+  version?: string;
+}
+
+export interface UpdateDownloadProgressArgs {
+  percent: number;
+  transferred: number;
+  total: number;
+}
+
+export interface UpdateErrorArgs {
+  message: string;
 }
 
 export interface FileMenuImportOcrArgs {


### PR DESCRIPTION
This PR uses the toaster to handle the update workflow for all operating systems. It also intentionally removes the "auto-update on close" feature that happens on MacOS and Windows. Users are now in full control of when they update.