### PR TITLE
fix: update later button

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2053,6 +2053,7 @@ ipcMain.handle(IpcRendererChannels.DownloadUpdate, async () => {
   sendToRenderer(IpcMainChannels.UpdateDownloadStarted);
 
   try {
+    autoUpdater.autoInstallOnAppQuit = true;
     await autoUpdater.downloadUpdate();
   } catch (error) {
     updateDownloadInProgress = false;
@@ -2079,21 +2080,6 @@ ipcMain.handle(IpcRendererChannels.RestartToInstallUpdate, async () => {
 
   readyToExit = true;
   autoUpdater.quitAndInstall(false, true);
-});
-
-ipcMain.handle(IpcRendererChannels.InstallUpdateOnExit, async () => {
-  if (!updateDownloaded) {
-    return;
-  }
-
-  if (fakeUpdateMode) {
-    console.info(
-      'FAKE_UPDATE_AVAILABLE=1: install-on-exit requested; skipping autoInstallOnAppQuit.',
-    );
-    return;
-  }
-
-  autoUpdater.autoInstallOnAppQuit = true;
 });
 
 ipcMain.handle(IpcRendererChannels.CancelExit, async () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,19 +55,6 @@ async function restartToInstallElectronUpdate() {
   }
 }
 
-async function installElectronUpdateOnExit() {
-  try {
-    await window.ipcRenderer?.invoke(IpcRendererChannels.InstallUpdateOnExit);
-  } catch (error) {
-    showElectronUpdateErrorToast({
-      message:
-        error instanceof Error
-          ? error.message
-          : 'Unable to schedule the update for app exit.',
-    });
-  }
-}
-
 function showElectronUpdateAvailableToast(args?: UpdateAvailableArgs) {
   toast.info('An update is available.', {
     id: electronUpdateAvailableToastId,
@@ -111,9 +98,6 @@ function showElectronUpdateDownloadedToast(args?: UpdateAvailableArgs) {
     },
     cancel: {
       label: 'Later',
-      onClick: () => {
-        void installElectronUpdateOnExit();
-      },
     },
   });
 }

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -64,7 +64,6 @@ export enum IpcMainChannels {
 export enum IpcRendererChannels {
   DownloadUpdate = 'DownloadUpdate',
   RestartToInstallUpdate = 'RestartToInstallUpdate',
-  InstallUpdateOnExit = 'InstallUpdateOnExit',
 
   SetCanUndo = 'SetCanUndo',
   SetCanRedo = 'SetCanRedo',


### PR DESCRIPTION
- Updated the auto-update flow so that if a user selects “Later” after an update has been downloaded, the update will be installed automatically the next time the application exits normally.
- Ensures autoInstallOnAppQuit is configured before the download completes so the underlying quit handler is registered correctly by electron-updater.
- Preserves the “Restart Now” option for immediate installation via quitAndInstall().