### PR TITLE
fix: Scale line spacing for small font sizes in rich text boxes

### DIFF
--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -642,6 +642,15 @@ defineExpose({
   line-height: normal;
 }
 
+/*
+ * The * reset above can't reach ::marker (a pseudo-element, not an element
+ * child), so a collapsed <li> would pass line-height: 0 down to its bullet or
+ * number and throw off marker alignment. Restore it explicitly.
+ */
+:deep(.ck-content li:has(span[style*='font-size'])::marker) {
+  line-height: normal;
+}
+
 .ck.ck-editor__editable_inline > *:first-child {
   margin-top: 0;
 }

--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -626,6 +626,22 @@ defineExpose({
   margin: 0;
 }
 
+/*
+ * CKEditor sizes inline spans but leaves the parent <p>/<li> at the editor's
+ * default line-height, so small inline text still reserves a default-size line
+ * box. When a block has explicit font-size spans, collapse the parent line box
+ * and let the sized children supply their own leading, so two 8pt lines stack
+ * like two 8pt lines. The :has() guard avoids collapsing plain text, which is a
+ * bare text node the child rule can't reach.
+ */
+:deep(.ck-content :is(p, li):has(span[style*='font-size'])) {
+  line-height: 0;
+}
+
+:deep(.ck-content :is(p, li):has(span[style*='font-size']) *) {
+  line-height: normal;
+}
+
 .ck.ck-editor__editable_inline > *:first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
Discovered while trying to convert my footers to rich text boxes: CKEditor sizes inline spans but leaves the parent block at the editor's default line-height, so small inline text still reserves a default size line box. As such, my two lines of 8pt text in the footer were each getting a 12pt line height. This PR collapses the parent line box on blocks that contain explicit font-size spans and let the sized children supply their own leading, so two 8pt lines stack like two 8pt lines.