### PR TITLE
Show properties pane by default

### DIFF
--- a/src/models/WorkspacePane.ts
+++ b/src/models/WorkspacePane.ts
@@ -35,7 +35,7 @@ export const workspacePaneDefinitions = [
   {
     allowedEdges: ['left', 'right'],
     defaultSize: rightPaneDefaultSize,
-    defaultVisible: false,
+    defaultVisible: true,
     homeEdge: 'right',
     id: 'properties',
     titleSelector: ($) => $.menu.view.properties,


### PR DESCRIPTION
@basil Any objections? Even on my tiny laptop screen (width is 11.7 in), the properties pane fits fine. My main concern is the discoverability of `Use Default Style` on text boxes, since that is a common thing to change.