### PR TITLE
fix: Line spacing for small font sizes in rich text boxes

### DIFF
--- a/src/components/TextBoxRich.vue
+++ b/src/components/TextBoxRich.vue
@@ -114,7 +114,14 @@
 import type { Editor, EditorConfig, FontSizeOption } from 'ckeditor5';
 import { debounce, throttle } from 'throttle-debounce';
 import type { PropType, StyleValue } from 'vue';
-import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  useTemplateRef,
+  watch,
+} from 'vue';
 import type { ComponentExposed } from 'vue-component-type-helpers';
 
 import RichTextEditor from '@/components/RichTextEditor.vue';
@@ -136,6 +143,7 @@ import {
   inferSharedRichTextEditorLanguage,
   RICH_TEXT_LANGUAGE_OPTIONS,
 } from '@/utils/richTextLanguage';
+import { Unit } from '@/utils/Unit';
 import { withZoom } from '@/utils/withZoom';
 
 const emit = defineEmits([
@@ -346,6 +354,59 @@ const contentRight = computed(() => {
       );
 });
 
+function getSelectedFontSize(editor: Editor): string | undefined {
+  const fontSize = editor.model.document.selection.getAttribute('fontSize');
+  return typeof fontSize === 'string' ? fontSize : undefined;
+}
+
+function getFontSizeInPt(value: unknown) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = value.trim().match(/^([\d.]+)(pt|px)$/);
+
+  if (match == null) {
+    return null;
+  }
+
+  const size = Number(match[1]);
+
+  if (!Number.isFinite(size)) {
+    return null;
+  }
+
+  return match[2] === 'pt' ? size : Unit.toPt(size);
+}
+
+function getMinimumFontSizeInEditor(editor: Editor) {
+  const sizes: number[] = [];
+
+  sizes.push(Unit.toPt(props.pageSetup.textBoxDefaultFontSize));
+
+  const selectedFontSize = getSelectedFontSize(editor);
+
+  const selectedFontSizeInPt = getFontSizeInPt(selectedFontSize);
+
+  if (selectedFontSizeInPt != null) {
+    sizes.push(selectedFontSizeInPt);
+  }
+
+  for (const root of editor.model.document.roots) {
+    for (const item of editor.model.createRangeIn(root).getItems()) {
+      const fontSize = item.getAttribute('fontSize');
+
+      const fontSizeInPt = getFontSizeInPt(fontSize);
+
+      if (fontSizeInPt != null) {
+        sizes.push(fontSizeInPt);
+      }
+    }
+  }
+
+  return `${Math.min(...sizes)}pt`;
+}
+
 const containerStyle = computed(() => {
   const defaultFontFamily = props.element.inline
     ? props.pageSetup.lyricsDefaultFontFamily
@@ -359,7 +420,7 @@ const containerStyle = computed(() => {
     ),
     '--ck-content-font-size': props.element.inline
       ? `${props.pageSetup.lyricsDefaultFontSize}px`
-      : `${props.pageSetup.textBoxDefaultFontSize}px`, // no zoom because we will apply zooming on the whole editor
+      : ckContentFontSize.value, // no zoom because we will apply zooming on the whole editor
     '--ck-content-font-color': props.element.inline
       ? props.pageSetup.lyricsDefaultColor
       : props.pageSetup.textBoxDefaultColor,
@@ -452,6 +513,13 @@ watch(
   },
 );
 
+watch(
+  () => props.pageSetup.textBoxDefaultFontSize,
+  () => {
+    refreshCkContentFontSize();
+  },
+);
+
 onBeforeUnmount(() => {
   unmounting.value = true;
   update();
@@ -499,16 +567,63 @@ function phoneHome(height: number) {
   emit('update:height', height);
 }
 
-function onEditorReady(editor: InlineEditor) {
-  applyInitialLanguage(editor);
+const ckContentFontSize = ref(`${props.pageSetup.textBoxDefaultFontSize}px`);
 
-  if (props.recalc) {
-    const height = getHeight();
+function getMinimumFontSizeInActiveEditors() {
+  const activeEditors = getActiveEditorInstances().filter(
+    (editor): editor is InlineEditor => editor != null,
+  );
 
-    if (height != null && Math.abs(props.element.height - height) > 0.001) {
-      debouncedPhoneHome(height);
-    }
+  if (activeEditors.length === 0) {
+    return `${props.pageSetup.textBoxDefaultFontSize}px`;
   }
+
+  const minimumSizes = activeEditors.map((editor) =>
+    parseFloat(getMinimumFontSizeInEditor(editor)),
+  );
+
+  return `${Math.min(...minimumSizes)}pt`;
+}
+
+function refreshCkContentFontSize() {
+  ckContentFontSize.value = getMinimumFontSizeInActiveEditors();
+}
+
+async function initializeCkContentFontSize() {
+  refreshCkContentFontSize();
+  await nextTick();
+}
+
+function emitRecalculatedHeightIfNeeded() {
+  if (!props.recalc) {
+    return;
+  }
+
+  const height = getHeight();
+
+  if (height != null && Math.abs(props.element.height - height) > 0.001) {
+    debouncedPhoneHome(height);
+  }
+}
+
+function observeCkContentFontSize(editor: InlineEditor) {
+  editor.model.document.on('change:data', () => refreshCkContentFontSize());
+
+  editor.model.document.selection.on(
+    'change:attribute',
+    (_evt, attributeName) => {
+      if (attributeName === 'fontSize') {
+        refreshCkContentFontSize();
+      }
+    },
+  );
+}
+
+async function onEditorReady(editor: InlineEditor) {
+  applyInitialLanguage(editor);
+  await initializeCkContentFontSize();
+
+  emitRecalculatedHeightIfNeeded();
 
   if (focusOnReady.value) {
     editor.editing.view.focus();
@@ -516,6 +631,8 @@ function onEditorReady(editor: InlineEditor) {
   }
 
   const element = editor.sourceElement;
+
+  observeCkContentFontSize(editor);
 
   observeResize(
     element!,
@@ -547,8 +664,11 @@ function onEditorReady(editor: InlineEditor) {
   );
 }
 
-function onEditorReadyMultipanelSide(editor: InlineEditor) {
+async function onEditorReadyMultipanelSide(editor: InlineEditor) {
   applyInitialLanguage(editor);
+  await initializeCkContentFontSize();
+  emitRecalculatedHeightIfNeeded();
+  observeCkContentFontSize(editor);
 }
 
 function onEditorReadyInline(editor: InlineEditor) {


### PR DESCRIPTION
## Summary

- Improve rich text box font-size floor detection so editors can shrink below the Page Setup default when saved content uses smaller font sizes.
- Apply that derived minimum before hidden recalc measurements, including multipanel text boxes, so height recalculation uses the real rendered size.
- Keep mounted editors in sync when Page Setup defaults change, and correctly normalize both `pt` and `px` rich-text font-size attributes when computing the minimum.

Closes #2365.