### PR TITLE
feat: Sticky settings

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,7 +6,7 @@ To create a new score, use the file menu: `File -> New`. This will give you a te
 
 ## Workspace panes
 
-The editor uses dockable panes for tools. Use `View -> Neume Selector`, `View -> Common Combinations`, `View -> Properties`, `View -> Selection`, and `View -> Lyrics` to show or hide panes. The Neume Selector is visible by default, the Properties pane shows type-specific settings for the current element, and the Selection pane shows common selection settings. Use `View -> Reset Layout` to restore the default pane arrangement.
+The editor uses dockable panes for tools. Use `View -> Neume Selector`, `View -> Common Combinations`, `View -> Properties`, `View -> Selection`, and `View -> Lyrics` to show or hide panes. The Neume Selector is visible by default, the Properties pane shows type-specific settings for the current element, and the Selection pane shows common selection settings. Use `View -> Reset Layout` to restore the default editor layout state, including pane arrangement, pane sections, status bar visibility, and zoom defaults.
 
 ## Updating the title
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2261,7 +2261,7 @@ function createMenu() {
         {
           label: i18next.t(($) => $.menu.view.resetLayout),
           click() {
-            win?.webContents.send(IpcMainChannels.FileMenuViewResetPaneLayout);
+            win?.webContents.send(IpcMainChannels.FileMenuViewResetLayout);
           },
         },
         ...(isDevelopment

--- a/notes/dockview_vue.md
+++ b/notes/dockview_vue.md
@@ -55,7 +55,7 @@ workspace dark. The wrapper exposes a
 deliberately tiny contract to the host:
 
 - **Props:** `paneVisibility: WorkspacePaneVisibility` (the _desired_ visibility map)
-  and `paneLayoutResetCounter: number` (a monotonically-incrementing reset trigger).
+  and `layoutResetCounter: number` (a monotonically-incrementing reset trigger).
 - **Emit:** `pane-visibility-change(paneId, isVisible)` -- fired whenever Dockview's
   own state changes (a drag, the header buttons, the context menu).
 
@@ -580,22 +580,25 @@ Blink honors a trailing `break-after` on them and emits a blank final page.
 
 ## 5. State ownership: what is persisted, and the menu sync
 
-### 5.1 The layout is not persisted -- it is reconstructed
+### 5.1 The layout is editor-global environment state
 
-There is **no serialization of the dock layout or pane visibility anywhere** -- no
-`api.toJSON()`/`fromJSON()`, no `localStorage` key, no field on the `Workspace`
-model. On every launch the layout is built programmatically from
-`workspacePaneDefinitions` (`initializeLayout` -> `ensureCenterEditorPanel` +
-`ensureEdgeGroup` per edge + `addToolPane` per pane), and `paneVisibility` is seeded
-from `createDefaultPaneVisibility()` -- so only the neume selector is open at start.
-Pane positions, sizes, float state, and the `lastDockedEdgeByPanelId` memory all
-reset. This is a deliberate simplicity: the layout is _editor-session_ state derived
-from one declarative source, not document state to be saved with the score.
+Dockview's full layout JSON is not serialized with `api.toJSON()`/`fromJSON()`, and
+pane state is still not part of the `Workspace` model or score file. Instead,
+`TheEditor.vue` persists a small editor-global `editorEnvironment` record in
+`localStorage`. That record stores the pieces of layout state the editor owns:
+pane visibility, home edge/floating state for panes that differ from defaults, pane
+accordion sections, status-bar visibility, and zoom defaults.
 
-Consistent with this, lyrics-pane visibility is simply `paneVisibility.lyrics` --
-editor-global like every other pane, not a per-workspace field. The serialized
-per-workspace record (`WorkspaceLocalStorage`, the blob written to `localStorage`)
-carries no pane state at all.
+On launch the dock is still built programmatically from `workspacePaneDefinitions`
+(`initializeLayout` -> `ensureCenterEditorPanel` + `ensureEdgeGroup` per edge +
+`addToolPane` per pane). After construction, the saved `editorEnvironment.paneLayout`
+is applied to move/show/hide/float panes. If there is no saved pane layout,
+`paneVisibility` is seeded from `createDefaultPaneVisibility()`.
+
+Consistent with this, lyrics-pane visibility is simply persisted as part of the
+editor environment -- editor-global like every other pane, not a per-workspace field.
+The serialized per-workspace record (`WorkspaceLocalStorage`, the blob written to
+`localStorage`) carries no pane state at all.
 
 ### 5.2 One layout shared across all workspaces
 
@@ -607,18 +610,18 @@ session, not of any document.
 
 ### 5.3 The menu sync (the one cross-process channel)
 
-The only persistence-like wiring is keeping the OS application menu's checkboxes in
+The cross-process state wiring keeps the OS application menu's checkboxes in
 agreement with the renderer. The native **View** menu (built in
 `electron/main/index.ts`) holds one checkbox per pane plus "Reset Layout," and a
 lyrics entry with a `CmdOrCtrl+L` accelerator. The browser build's `FileMenuBar.vue`
 mirrors this menu with `MenubarCheckboxItem`s.
 Three IPC channels carry the state:
 
-| Channel                       | Direction        | Payload                        | Purpose                                        |
-| ----------------------------- | ---------------- | ------------------------------ | ---------------------------------------------- |
-| `FileMenuViewPaneVisibility`  | main -> renderer | `{ paneId, visible? }`         | a menu click; `visible` omitted = toggle       |
-| `FileMenuViewResetPaneLayout` | main -> renderer | --                             | the Reset Layout item                          |
-| `SetWorkspacePaneVisibility`  | renderer -> main | full `WorkspacePaneVisibility` | push authoritative state to re-sync checkboxes |
+| Channel                      | Direction        | Payload                        | Purpose                                        |
+| ---------------------------- | ---------------- | ------------------------------ | ---------------------------------------------- |
+| `FileMenuViewPaneVisibility` | main -> renderer | `{ paneId, visible? }`         | a menu click; `visible` omitted = toggle       |
+| `FileMenuViewResetLayout`    | main -> renderer | --                             | the Reset Layout item                          |
+| `SetWorkspacePaneVisibility` | renderer -> main | full `WorkspacePaneVisibility` | push authoritative state to re-sync checkboxes |
 
 The defining pattern (section 2.8) is that **the menu never trusts its own optimistic
 toggle**: the checkbox handler reverts `menuItem.checked` to the last-known value and
@@ -626,9 +629,10 @@ defers to the renderer, which applies the change and echoes the real state back 
 `SetWorkspacePaneVisibility` -> `syncPaneMenuItems`. The main process keeps a runtime
 shadow `paneMenuVisibility` only so checkboxes survive a menu rebuild (e.g. on
 language change); it is never written to disk and is lost on quit. `Reset Layout`
-sends `FileMenuViewResetPaneLayout` -> `resetLayout()`, which bumps
-`paneLayoutResetCounter`; the dock's watcher restores every pane to its home edge and
-index and re-applies default visibility.
+sends `FileMenuViewResetLayout` -> `resetLayout()`, which clears persisted editor
+layout state, resets zoom defaults, and bumps `layoutResetCounter`; the dock's
+watcher restores every pane to its home edge and index and re-applies default
+visibility.
 
 ---
 
@@ -712,7 +716,7 @@ The subsystem spans these files, grouped by concern.
 
 - `src/components/TheEditor.vue` -- the three zones; the `inspectorContext` computed;
   the `updateXxx` handlers and the `Partial<Element>` -> command pipeline;
-  `paneVisibility` / `paneLayoutResetCounter` / `setPaneVisibility` / `resetLayout` /
+  `paneVisibility` / `layoutResetCounter` / `setPaneVisibility` / `resetLayout` /
   `onPaneVisibilityChange`; the pane IPC handlers and the `SetWorkspacePaneVisibility`
   menu-sync emit; `isEditorShortcutIgnored`.
 
@@ -737,7 +741,7 @@ The subsystem spans these files, grouped by concern.
 - `src/components/FileMenuBar.vue` -- the browser View menu (parallel
   `MenubarCheckboxItem`s + Reset Layout).
 - `src/ipc/ipcChannels.ts` -- `FileMenuViewPaneVisibility`,
-  `FileMenuViewResetPaneLayout`, `SetWorkspacePaneVisibility`, and
+  `FileMenuViewResetLayout`, `SetWorkspacePaneVisibility`, and
   `FileMenuViewPaneVisibilityArgs`.
 - `src/App.vue` -- the print rule hiding stray teleport anchors.
 - `src/i18n/*/menu.json`, `toolbar.json` -- the `menu.view.*` pane titles and the

--- a/src/components/FileMenuBar.vue
+++ b/src/components/FileMenuBar.vue
@@ -344,7 +344,7 @@
             {{ $t(($) => $.menu.view.statusBar, { ns: 'menu' }) }}
           </MenubarCheckboxItem>
           <MenubarSeparator />
-          <MenubarItem @select="onResetPaneLayoutClick">
+          <MenubarItem @select="onResetLayoutClick">
             <PhArrowCounterClockwise />
             {{ $t(($) => $.menu.view.resetLayout, { ns: 'menu' }) }}
           </MenubarItem>
@@ -940,8 +940,8 @@ function onToggleStatusBarClick(visible?: boolean) {
   } as FileMenuViewStatusBarVisibilityArgs);
 }
 
-function onResetPaneLayoutClick() {
-  EventBus.$emit(IpcMainChannels.FileMenuViewResetPaneLayout);
+function onResetLayoutClick() {
+  EventBus.$emit(IpcMainChannels.FileMenuViewResetLayout);
 }
 
 function emitViewZoom(args: FileMenuViewZoomArgs) {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -125,6 +125,11 @@ import {
   IpcMainChannels,
   IpcRendererChannels,
 } from '@/ipc/ipcChannels';
+import type { EditorPaneLayout } from '@/models/EditorEnvironment';
+import {
+  DEFAULT_PANE_ACCORDION_STATE,
+  EditorEnvironment,
+} from '@/models/EditorEnvironment';
 import { EditorPreferences } from '@/models/EditorPreferences';
 import type { EmptyElement, ScoreElement } from '@/models/Element';
 import {
@@ -391,9 +396,18 @@ const preferredRichTextBoxFocusTarget = ref<{
 const searchTextQuery = ref('');
 const searchTextPanelIsOpen = ref(false);
 const showFileMenuBar = ref(!isElectron());
-const statusBarIsVisible = ref(true);
-const paneLayoutResetCounter = ref(0);
-const paneVisibility = ref(createDefaultPaneVisibility());
+
+// Hydrate remembered state synchronously (not in onMounted) so saved layout,
+// zoom defaults, and developer-pane preference are available before the dock
+// layout and UI-state refs are first read or rendered.
+const editorEnvironment = ref(loadEditorEnvironment());
+const editorPreferences = ref(loadEditorPreferences());
+
+const statusBarIsVisible = ref(editorEnvironment.value.statusBarIsVisible);
+const layoutResetCounter = ref(0);
+const paneVisibility = ref(
+  createInitialPaneVisibility(editorEnvironment.value, editorPreferences.value),
+);
 const editorPreferencesHydrated = ref(false);
 const isDevelopment = ref(import.meta.env.DEV);
 const isBrowser = ref(!isElectron());
@@ -401,7 +415,10 @@ const isLoading = ref(true);
 const printMode = ref(false);
 const canUndo = ref(false);
 const canRedo = ref(false);
-const developerPaneOpenSections = ref(['display', 'line', 'inspector']);
+const developerPaneOpenSections = computed({
+  get: () => accordionStateFor('developer'),
+  set: (value: string[]) => setAccordionState('developer', value),
+});
 const workspaces = ref<Workspace[]>([]);
 const selectedWorkspaceValue = ref(new Workspace());
 const pendingLyricsAssignmentTimers = new Map<string, number>();
@@ -468,7 +485,6 @@ const audioOptions = reactive<PlaybackOptions>({
     [Accidental.Sharp_8_Left]: 8,
   },
 });
-const editorPreferences = ref(new EditorPreferences());
 const byzHtmlExporter = new ByzHtmlExporter();
 const exportInProgress = ref(false);
 
@@ -1572,6 +1588,11 @@ watch(
   { immediate: true },
 );
 
+watch(statusBarIsVisible, (visible) => {
+  editorEnvironment.value.statusBarIsVisible = visible;
+  saveEditorEnvironment();
+});
+
 watch(
   () =>
     ({
@@ -1610,14 +1631,6 @@ onMounted(() => {
     // Deserialize as -Infinity
     audioOptions.volumeIson = audioOptions.volumeIson ?? -Infinity;
     audioOptions.volumeMelody = audioOptions.volumeMelody ?? -Infinity;
-  }
-
-  const savedEditorPreferences = localStorage.getItem('editorPreferences');
-
-  if (savedEditorPreferences != null) {
-    editorPreferences.value = EditorPreferences.createFrom(
-      JSON.parse(savedEditorPreferences),
-    );
   }
 
   syncDeveloperPanelsFromPreferencesOnStartup();
@@ -1685,8 +1698,8 @@ onMounted(() => {
     onFileMenuViewStatusBarVisibility,
   );
   EventBus.$on(
-    IpcMainChannels.FileMenuViewResetPaneLayout,
-    onFileMenuViewResetPaneLayout,
+    IpcMainChannels.FileMenuViewResetLayout,
+    onFileMenuViewResetLayout,
   );
   EventBus.$on(IpcMainChannels.FileMenuViewZoom, onFileMenuViewZoom);
   EventBus.$on(IpcMainChannels.FileMenuPreferences, onFileMenuPreferences);
@@ -1739,6 +1752,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('keyup', onKeyup);
   window.removeEventListener('resize', throttled.onEditorViewportResize);
   clearZoomWheelDeltaReset();
+  saveEditorEnvironment();
 
   EventBus.$off(IpcMainChannels.CloseWorkspaces, onCloseWorkspaces);
   EventBus.$off(IpcMainChannels.CloseApplication, onCloseApplication);
@@ -1791,8 +1805,8 @@ onBeforeUnmount(() => {
     onFileMenuViewStatusBarVisibility,
   );
   EventBus.$off(
-    IpcMainChannels.FileMenuViewResetPaneLayout,
-    onFileMenuViewResetPaneLayout,
+    IpcMainChannels.FileMenuViewResetLayout,
+    onFileMenuViewResetLayout,
   );
   EventBus.$off(IpcMainChannels.FileMenuViewZoom, onFileMenuViewZoom);
   EventBus.$off(IpcMainChannels.FileMenuPreferences, onFileMenuPreferences);
@@ -2944,7 +2958,10 @@ function syncDeveloperPanelsMenuState() {
 }
 
 function syncDeveloperPanelsFromPreferencesOnStartup() {
-  setPaneVisibility('developer', editorPreferences.value.showDeveloperPanels);
+  if (editorEnvironment.value.paneLayout?.developer == null) {
+    setPaneVisibility('developer', editorPreferences.value.showDeveloperPanels);
+  }
+
   syncDeveloperPanelsMenuState();
 }
 
@@ -3009,10 +3026,25 @@ function showPropertiesPaneForRichTextNeume() {
 
 function resetLayout() {
   const defaultVisibility = createDefaultPaneVisibility();
+  const defaultEnvironment = new EditorEnvironment();
 
+  pendingZoomFitDefaultUpdate = null;
+  editorEnvironment.value.defaultZoom = defaultEnvironment.defaultZoom;
+  editorEnvironment.value.defaultZoomFitMode =
+    defaultEnvironment.defaultZoomFitMode;
+  editorEnvironment.value.statusBarIsVisible =
+    defaultEnvironment.statusBarIsVisible;
+  editorEnvironment.value.paneLayout = defaultEnvironment.paneLayout;
+  editorEnvironment.value.paneAccordionState = {
+    ...defaultEnvironment.paneAccordionState,
+  };
+  zoom.value = defaultEnvironment.defaultZoom;
+  zoomFitMode.value = defaultEnvironment.defaultZoomFitMode;
+  statusBarIsVisible.value = defaultEnvironment.statusBarIsVisible;
   Object.assign(paneVisibility.value, defaultVisibility);
   paneVisibility.value.developer = editorPreferences.value.showDeveloperPanels;
-  paneLayoutResetCounter.value += 1;
+  layoutResetCounter.value += 1;
+  saveEditorEnvironment();
 }
 
 function onPaneVisibilityChange(paneId: WorkspacePaneId, isVisible: boolean) {
@@ -3028,6 +3060,11 @@ function onPaneVisibilityChange(paneId: WorkspacePaneId, isVisible: boolean) {
 
   setPaneVisibility(paneId, isVisible);
   refocusSelectedRichTextEditorAfterShowingPane(paneId, isVisible);
+}
+
+function onPaneLayoutChange(layout: EditorPaneLayout) {
+  editorEnvironment.value.paneLayout = layout;
+  saveEditorEnvironmentDebounced();
 }
 
 function updateEditorPreferences(form: EditorPreferences) {
@@ -3061,6 +3098,84 @@ function saveEditorPreferences() {
     'editorPreferences',
     JSON.stringify(editorPreferences.value),
   );
+}
+
+function loadEditorPreferences() {
+  try {
+    const savedEditorPreferences = localStorage.getItem('editorPreferences');
+
+    if (savedEditorPreferences != null) {
+      return EditorPreferences.createFrom(JSON.parse(savedEditorPreferences));
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  return new EditorPreferences();
+}
+
+function loadEditorEnvironment() {
+  try {
+    const savedEditorEnvironment = localStorage.getItem('editorEnvironment');
+
+    if (savedEditorEnvironment != null) {
+      return EditorEnvironment.createFrom(JSON.parse(savedEditorEnvironment));
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  return new EditorEnvironment();
+}
+
+function createInitialPaneVisibility(
+  environment: EditorEnvironment,
+  preferences: EditorPreferences,
+) {
+  const visibility = createDefaultPaneVisibility();
+  const savedLayout = environment.paneLayout;
+
+  if (savedLayout != null) {
+    (Object.keys(visibility) as WorkspacePaneId[]).forEach((paneId) => {
+      const paneState = savedLayout[paneId];
+
+      if (paneState != null) {
+        visibility[paneId] = paneState.visible;
+      }
+    });
+  }
+
+  if (!preferences.showDeveloperPanels) {
+    visibility.developer = false;
+  } else if (savedLayout?.developer == null) {
+    visibility.developer = true;
+  }
+
+  return visibility;
+}
+
+function saveEditorEnvironment() {
+  localStorage.setItem(
+    'editorEnvironment',
+    JSON.stringify(editorEnvironment.value),
+  );
+}
+
+// Pane-layout and fit-mode zoom changes can fire rapidly (drag, resize); coalesce
+// their writes.
+const saveEditorEnvironmentDebounced = debounce(500, saveEditorEnvironment);
+
+function accordionStateFor(paneId: WorkspacePaneId): string[] {
+  return (
+    editorEnvironment.value.paneAccordionState[paneId] ??
+    DEFAULT_PANE_ACCORDION_STATE[paneId] ??
+    []
+  );
+}
+
+function setAccordionState(paneId: WorkspacePaneId, value: string[]) {
+  editorEnvironment.value.paneAccordionState[paneId] = value;
+  saveEditorEnvironment();
 }
 
 function isLastElement(element: ScoreElement) {
@@ -5674,6 +5789,7 @@ async function onCloseApplication() {
     }
   }
 
+  saveEditorEnvironment();
   await ipcService.exitApplication();
 }
 
@@ -7390,6 +7506,36 @@ function updateEntryMode(mode: EntryMode) {
   entryMode.value = mode;
 }
 
+// Remember the current zoom settings so newly opened documents inherit the last
+// user-selected zoom command rather than whichever tab or page setup recalculated
+// zoom-fit most recently.
+function rememberZoomDefault() {
+  if (
+    editorEnvironment.value.defaultZoom === zoom.value &&
+    editorEnvironment.value.defaultZoomFitMode === zoomFitMode.value
+  ) {
+    return;
+  }
+
+  editorEnvironment.value.defaultZoom = zoom.value;
+  editorEnvironment.value.defaultZoomFitMode = zoomFitMode.value;
+  saveEditorEnvironmentDebounced();
+}
+
+function rememberZoomFitModeDefault(mode: ZoomFitMode) {
+  if (editorEnvironment.value.defaultZoomFitMode === mode) {
+    return;
+  }
+
+  editorEnvironment.value.defaultZoomFitMode = mode;
+  saveEditorEnvironmentDebounced();
+}
+
+let pendingZoomFitDefaultUpdate: {
+  mode: ZoomFitMode;
+  workspaceId: string;
+} | null = null;
+
 function updateZoom(newZoom: number) {
   if (newZoom < MIN_ZOOM || newZoom > MAX_ZOOM) {
     toast.error(
@@ -7403,8 +7549,10 @@ function updateZoom(newZoom: number) {
       },
     );
   } else {
+    pendingZoomFitDefaultUpdate = null;
     zoom.value = newZoom;
     zoomFitMode.value = null;
+    rememberZoomDefault();
   }
 }
 
@@ -7426,6 +7574,12 @@ function zoomToNearestStep(direction: 1 | -1) {
 }
 
 function updateZoomFitMode(mode: ZoomFitMode) {
+  pendingZoomFitDefaultUpdate = {
+    mode,
+    workspaceId: selectedWorkspace.value.id,
+  };
+  rememberZoomFitModeDefault(mode);
+
   if (zoomFitMode.value === mode) {
     performZoomToFit();
     return;
@@ -7474,6 +7628,14 @@ function performZoomToFit() {
   const newZoom = clamp(fitZoom, MIN_ZOOM, MAX_ZOOM);
   zoom.value = newZoom;
   alignZoomFitScroll(mode, newZoom);
+
+  if (
+    pendingZoomFitDefaultUpdate?.workspaceId === selectedWorkspace.value.id &&
+    pendingZoomFitDefaultUpdate.mode === mode
+  ) {
+    pendingZoomFitDefaultUpdate = null;
+    rememberZoomDefault();
+  }
 }
 
 function getCurrentPhysicalPageNumber() {
@@ -8701,7 +8863,7 @@ function onFileMenuViewStatusBarVisibility({
   }
 }
 
-function onFileMenuViewResetPaneLayout() {
+function onFileMenuViewResetLayout() {
   if (!dialogOpen.value) {
     resetLayout();
   }
@@ -8906,6 +9068,10 @@ function openScore(args: FileMenuOpenScoreArgs) {
 }
 
 function addWorkspace(workspace: Workspace) {
+  // Newly opened documents inherit the last-used zoom settings.
+  workspace.zoom = editorEnvironment.value.defaultZoom;
+  workspace.zoomFitMode = editorEnvironment.value.defaultZoomFitMode;
+
   workspaces.value.push(workspace);
 
   const tab = {
@@ -9264,8 +9430,10 @@ function renderTabLabel(tab: Tab) {
       <WorkspaceDockLayout
         :developer-pane-enabled="showDeveloperPanels"
         :pane-visibility="paneVisibility"
-        :pane-layout-reset-counter="paneLayoutResetCounter"
+        :pane-layout="editorEnvironment.paneLayout"
+        :layout-reset-counter="layoutResetCounter"
         @pane-visibility-change="onPaneVisibilityChange"
+        @layout-change="onPaneLayoutChange"
       >
         <template #neume-selector>
           <NeumeSelector

--- a/src/components/WorkspaceDockLayout.vue
+++ b/src/components/WorkspaceDockLayout.vue
@@ -45,6 +45,7 @@ import {
 } from 'vue';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
+import type { EditorPaneLayout } from '@/models/EditorEnvironment';
 import type {
   MenuSelector,
   WorkspacePaneId,
@@ -86,7 +87,8 @@ interface PaneContentParams {
 
 const props = defineProps<{
   developerPaneEnabled: boolean;
-  paneLayoutResetCounter: number;
+  layoutResetCounter: number;
+  paneLayout: EditorPaneLayout | null;
   paneVisibility: WorkspacePaneVisibility;
 }>();
 const emit = defineEmits<{
@@ -95,6 +97,7 @@ const emit = defineEmits<{
     paneId: WorkspacePaneId,
     isVisible: boolean,
   ): void;
+  (event: 'layout-change', layout: EditorPaneLayout): void;
 }>();
 
 type DockDropEvent =
@@ -523,6 +526,31 @@ function requireDockviewPanel(api: DockviewApi, panelId: string) {
   return panel;
 }
 
+function paneHasDockviewPanel(definition: PaneDefinition) {
+  return definition.paneId !== 'developer' || props.developerPaneEnabled;
+}
+
+// All non-developer panes are permanent Dockview panels after initialization.
+// The developer pane is the only pane whose panel may be absent at runtime.
+function activePaneDefinitions() {
+  return paneRegistry.panes.filter(paneHasDockviewPanel);
+}
+
+function getPaneLayoutEdge(
+  definition: PaneDefinition,
+  layout: EditorPaneLayout | null = props.paneLayout,
+) {
+  const edge = layout?.[definition.paneId]?.edge;
+
+  return edge != null && definition.allowedEdges.includes(edge)
+    ? edge
+    : definition.homeEdge;
+}
+
+function shouldRestorePaneAsFloating(state: EditorPaneLayout[WorkspacePaneId]) {
+  return state?.floating === true && state.visible;
+}
+
 function resolvePane(panelId: string): ResolvedPane | null {
   const api = dockviewApi.value;
   const definition = findPaneDefinition(panelId);
@@ -768,13 +796,12 @@ function addToolPane(
   centerPanel.api.setActive();
 }
 
-function syncDeveloperPanePresence(enabled: boolean, api: DockviewApi) {
-  const developerPane = paneRegistry.byId.get('workspace-developer');
-
-  if (developerPane == null) {
-    return;
-  }
-
+function syncDeveloperPanePresence(
+  enabled: boolean,
+  api: DockviewApi,
+  restoreSavedLayout = false,
+) {
+  const developerPane = requirePaneDefinition('workspace-developer');
   const existingPanel = api.getPanel(developerPane.id);
 
   if (!enabled) {
@@ -789,12 +816,18 @@ function syncDeveloperPanePresence(enabled: boolean, api: DockviewApi) {
     return;
   }
 
-  addToolPane(
-    developerPane,
-    api,
-    ensureCenterEditorPanel(api),
-    developerPane.homeEdge,
-  );
+  const targetEdge = restoreSavedLayout
+    ? getPaneLayoutEdge(developerPane)
+    : developerPane.homeEdge;
+
+  addToolPane(developerPane, api, ensureCenterEditorPanel(api), targetEdge);
+
+  if (
+    restoreSavedLayout &&
+    shouldRestorePaneAsFloating(props.paneLayout?.developer)
+  ) {
+    floatPane(requireDockviewPanel(api, developerPane.id), api);
+  }
 }
 
 function activateSiblingPane(group: DockviewGroupPanel, panelId: string) {
@@ -896,18 +929,13 @@ function showPane(panelId: string, emitChange = true) {
   emitPaneVisibilityChange(definition.paneId, true, emitChange);
 }
 
-function computePaneVisibility(): WorkspacePaneVisibility {
+function computePaneVisibility(api: DockviewApi): WorkspacePaneVisibility {
   const visibility = createAllHiddenPaneVisibility();
-  const api = dockviewApi.value;
 
-  if (api == null) {
-    return visibility;
-  }
+  activePaneDefinitions().forEach((definition) => {
+    const panel = requireDockviewPanel(api, definition.id);
 
-  paneRegistry.panes.forEach((definition) => {
-    const panel = api.getPanel(definition.id);
-
-    if (panel == null || !isPanelVisible(panel.id, panel.group)) {
+    if (!isPanelVisible(panel.id, panel.group)) {
       return;
     }
 
@@ -919,8 +947,8 @@ function computePaneVisibility(): WorkspacePaneVisibility {
 
 let lastEmittedPaneVisibility: WorkspacePaneVisibility | null = null;
 
-function emitPaneVisibilityState() {
-  const visibility = computePaneVisibility();
+function emitPaneVisibilityState(api: DockviewApi) {
+  const visibility = computePaneVisibility(api);
   const previousVisibility = lastEmittedPaneVisibility;
   lastEmittedPaneVisibility = visibility;
 
@@ -936,14 +964,53 @@ function emitPaneVisibilityState() {
   });
 }
 
-function scheduleVisibilityStateEmit() {
+function captureLayoutState(api: DockviewApi): EditorPaneLayout {
+  const layout: EditorPaneLayout = { ...props.paneLayout };
+
+  activePaneDefinitions().forEach((definition) => {
+    const panel = requireDockviewPanel(api, definition.id);
+    const visible = isPanelVisible(panel.id, panel.group);
+
+    layout[definition.paneId] = {
+      visible,
+      edge:
+        getGroupEdge(panel.group) ??
+        lastDockedEdgeByPanelId.get(panel.id) ??
+        definition.homeEdge,
+      floating: visible && panel.api.location.type === 'floating',
+    };
+  });
+
+  return layout;
+}
+
+let lastEmittedPaneLayoutJson: string | null = null;
+
+function emitLayoutState(api: DockviewApi) {
+  const layout = captureLayoutState(api);
+  const layoutJson = JSON.stringify(layout);
+
+  if (lastEmittedPaneLayoutJson === layoutJson) {
+    return;
+  }
+
+  lastEmittedPaneLayoutJson = layoutJson;
+  emit('layout-change', layout);
+}
+
+function markLayoutStateCurrent(api: DockviewApi) {
+  lastEmittedPaneLayoutJson = JSON.stringify(captureLayoutState(api));
+}
+
+function scheduleVisibilityStateEmit(api: DockviewApi) {
   if (paneStateAnimationFrame !== 0) {
     return;
   }
 
   paneStateAnimationFrame = requestAnimationFrame(() => {
     paneStateAnimationFrame = 0;
-    emitPaneVisibilityState();
+    emitPaneVisibilityState(api);
+    emitLayoutState(api);
   });
 }
 
@@ -969,49 +1036,46 @@ function disposeGroupStateListeners(groupId: string) {
   paneStateGroupDisposables.delete(groupId);
 }
 
-function watchGroupState(group: DockviewGroupPanel) {
+function watchGroupState(group: DockviewGroupPanel, api: DockviewApi) {
   if (paneStateGroupDisposables.has(group.id)) {
     return;
   }
 
   paneStateGroupDisposables.set(group.id, [
-    group.api.onDidActivePanelChange(() => scheduleVisibilityStateEmit()),
-    group.api.onDidCollapsedChange(() => scheduleVisibilityStateEmit()),
-    group.api.onDidLocationChange(() => scheduleVisibilityStateEmit()),
+    group.api.onDidActivePanelChange(() => scheduleVisibilityStateEmit(api)),
+    group.api.onDidCollapsedChange(() => scheduleVisibilityStateEmit(api)),
+    group.api.onDidLocationChange(() => scheduleVisibilityStateEmit(api)),
   ]);
 }
 
 function installStateListeners(api: DockviewApi) {
   disposeStateListeners();
 
-  api.groups.forEach((group) => watchGroupState(group));
+  api.groups.forEach((group) => watchGroupState(group, api));
   paneStateApiDisposables.push(
     api.onDidAddGroup((group) => {
-      watchGroupState(group);
-      scheduleVisibilityStateEmit();
+      watchGroupState(group, api);
+      scheduleVisibilityStateEmit(api);
     }),
     api.onDidRemoveGroup((group) => {
       disposeGroupStateListeners(group.id);
-      scheduleVisibilityStateEmit();
+      scheduleVisibilityStateEmit(api);
     }),
     api.onDidMovePanel((event) => {
       rememberPanelCurrentOrPreviousDockedEdge(event.panel, event.from);
-      scheduleVisibilityStateEmit();
+      scheduleVisibilityStateEmit(api);
     }),
-    api.onDidActivePanelChange(() => scheduleVisibilityStateEmit()),
+    api.onDidActivePanelChange(() => scheduleVisibilityStateEmit(api)),
   );
 }
 
-function applyPaneVisibility(visibility: WorkspacePaneVisibility) {
-  const api = dockviewApi.value;
+function applyPaneVisibility(
+  visibility: WorkspacePaneVisibility,
+  api: DockviewApi,
+) {
+  syncDeveloperPanePresence(props.developerPaneEnabled, api, true);
 
-  if (api == null) {
-    return;
-  }
-
-  syncDeveloperPanePresence(props.developerPaneEnabled, api);
-
-  const visibleAtStart = computePaneVisibility();
+  const visibleAtStart = computePaneVisibility(api);
   const panesToShow = paneRegistry.panes.filter(
     (pane) => visibility[pane.paneId] && !visibleAtStart[pane.paneId],
   );
@@ -1029,6 +1093,46 @@ function applyPaneVisibility(visibility: WorkspacePaneVisibility) {
   });
 }
 
+function applyLayoutState(layout: EditorPaneLayout, api: DockviewApi) {
+  syncDeveloperPanePresence(props.developerPaneEnabled, api);
+
+  activePaneDefinitions().forEach((definition) => {
+    const panel = requireDockviewPanel(api, definition.id);
+    const targetEdge = getPaneLayoutEdge(definition, layout);
+    const targetGroup = ensureEdgeGroup(targetEdge, api);
+
+    if (panel.group !== targetGroup) {
+      panel.api.moveTo({ group: targetGroup, skipSetActive: true });
+    }
+
+    rememberPaneDockedEdge(panel.id, targetEdge);
+  });
+
+  const visibility = createAllHiddenPaneVisibility();
+
+  activePaneDefinitions().forEach((definition) => {
+    const state = layout[definition.paneId];
+    visibility[definition.paneId] =
+      state?.visible ?? props.paneVisibility[definition.paneId];
+  });
+
+  applyPaneVisibility(visibility, api);
+
+  activePaneDefinitions().forEach((definition) => {
+    const panel = requireDockviewPanel(api, definition.id);
+    const state = layout[definition.paneId];
+
+    if (
+      shouldRestorePaneAsFloating(state) &&
+      panel.api.location.type !== 'floating'
+    ) {
+      floatPane(panel, api);
+    }
+  });
+
+  ensureCenterEditorPanel(api).api.setActive();
+}
+
 function resetLayout() {
   const api = dockviewApi.value;
 
@@ -1038,13 +1142,8 @@ function resetLayout() {
 
   syncDeveloperPanePresence(props.developerPaneEnabled, api);
 
-  paneRegistry.panes.forEach((paneDefinition) => {
-    const panel = api.getPanel(paneDefinition.id);
-
-    if (panel == null) {
-      return;
-    }
-
+  activePaneDefinitions().forEach((paneDefinition) => {
+    const panel = requireDockviewPanel(api, paneDefinition.id);
     const homeGroup = ensureEdgeGroup(paneDefinition.homeEdge, api);
     const homeIndex = paneRegistry.homeIndexById.get(paneDefinition.id);
 
@@ -1068,8 +1167,10 @@ function resetLayout() {
     rememberPaneDockedEdge(panel.id, paneDefinition.homeEdge);
   });
 
-  applyPaneVisibility(props.paneVisibility);
+  applyPaneVisibility(props.paneVisibility, api);
   ensureCenterEditorPanel(api).api.setActive();
+  emitPaneVisibilityState(api);
+  markLayoutStateCurrent(api);
 }
 
 function dockPaneToLastDockedEdge(panelId: string) {
@@ -1201,9 +1302,16 @@ function onDockviewReady(event: DockviewReadyEvent) {
   );
 
   initializeLayout(event.api);
-  applyPaneVisibility(props.paneVisibility);
+
+  if (props.paneLayout != null) {
+    applyLayoutState(props.paneLayout, event.api);
+  } else {
+    applyPaneVisibility(props.paneVisibility, event.api);
+  }
+
+  markLayoutStateCurrent(event.api);
   installStateListeners(event.api);
-  emitPaneVisibilityState();
+  emitPaneVisibilityState(event.api);
 }
 
 function onDockviewWillShowOverlay(
@@ -1749,12 +1857,20 @@ onBeforeUnmount(() => {
 
 watch(
   () => props.paneVisibility,
-  (paneVisibility) => applyPaneVisibility(paneVisibility),
+  (paneVisibility) => {
+    const api = dockviewApi.value;
+
+    if (api == null) {
+      return;
+    }
+
+    applyPaneVisibility(paneVisibility, api);
+  },
   { deep: true, flush: 'post' },
 );
 
 watch(
-  () => props.paneLayoutResetCounter,
+  () => props.layoutResetCounter,
   () => resetLayout(),
   { flush: 'post' },
 );

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -45,7 +45,7 @@ export enum IpcMainChannels {
 
   FileMenuViewPaneVisibility = 'FileMenuViewPaneVisibility',
   FileMenuViewStatusBarVisibility = 'FileMenuViewStatusBarVisibility',
-  FileMenuViewResetPaneLayout = 'FileMenuViewResetPaneLayout',
+  FileMenuViewResetLayout = 'FileMenuViewResetLayout',
   FileMenuViewZoom = 'FileMenuViewZoom',
 
   FileMenuPreferences = 'FileMenuPreferences',

--- a/src/models/EditorEnvironment.ts
+++ b/src/models/EditorEnvironment.ts
@@ -1,0 +1,126 @@
+import type { ZoomFitMode } from '@/models/Workspace';
+import type { PaneEdge, WorkspacePaneId } from '@/models/WorkspacePane';
+import { workspacePaneDefinitions } from '@/models/WorkspacePane';
+
+export const DEFAULT_PANE_ACCORDION_STATE: Partial<
+  Record<WorkspacePaneId, string[]>
+> = {
+  developer: ['display', 'line', 'inspector'],
+};
+
+export type EditorPaneLayout = {
+  [PaneId in WorkspacePaneId]?: {
+    visible: boolean;
+    edge: PaneEdge;
+    floating: boolean;
+  };
+};
+
+export type PaneAccordionState = Partial<Record<WorkspacePaneId, string[]>>;
+
+export type PersistedEditorEnvironment = Partial<{
+  defaultZoom: number;
+  defaultZoomFitMode: ZoomFitMode;
+  statusBarIsVisible: false;
+  paneLayout: EditorPaneLayout;
+  paneAccordionState: PaneAccordionState;
+}>;
+
+export class EditorEnvironment {
+  defaultZoom = 1;
+  defaultZoomFitMode: ZoomFitMode | null = null;
+  statusBarIsVisible = true;
+  paneLayout: EditorPaneLayout | null = null;
+  paneAccordionState: PaneAccordionState = {};
+
+  static createFrom(data: PersistedEditorEnvironment) {
+    return Object.assign(new EditorEnvironment(), data);
+  }
+
+  toJSON(): PersistedEditorEnvironment {
+    return {
+      ...persistZoom(this.defaultZoom, this.defaultZoomFitMode),
+      ...(this.statusBarIsVisible ? {} : { statusBarIsVisible: false }),
+      ...persistPaneLayout(this.paneLayout),
+      ...persistPaneAccordionState(this.paneAccordionState),
+    };
+  }
+}
+
+function persistZoom(
+  defaultZoom: number,
+  defaultZoomFitMode: ZoomFitMode | null,
+): PersistedEditorEnvironment {
+  return {
+    ...(defaultZoom === 1 ? {} : { defaultZoom }),
+    ...(defaultZoomFitMode == null ? {} : { defaultZoomFitMode }),
+  };
+}
+
+function persistPaneLayout(
+  paneLayout: EditorPaneLayout | null,
+): PersistedEditorEnvironment {
+  if (paneLayout == null) {
+    return {};
+  }
+
+  const persistedLayout: EditorPaneLayout = {};
+
+  workspacePaneDefinitions.forEach((definition) => {
+    const paneState = paneLayout[definition.id];
+
+    if (
+      paneState != null &&
+      shouldPersistPaneLayoutState(definition, paneState)
+    ) {
+      persistedLayout[definition.id] = paneState;
+    }
+  });
+
+  return Object.keys(persistedLayout).length === 0
+    ? {}
+    : { paneLayout: persistedLayout };
+}
+
+function shouldPersistPaneLayoutState(
+  definition: (typeof workspacePaneDefinitions)[number],
+  state: NonNullable<EditorPaneLayout[WorkspacePaneId]>,
+) {
+  if (definition.id === 'developer') {
+    return true;
+  }
+
+  return (
+    state.visible !== definition.defaultVisible ||
+    state.edge !== definition.homeEdge ||
+    state.floating
+  );
+}
+
+function persistPaneAccordionState(
+  paneAccordionState: PaneAccordionState,
+): PersistedEditorEnvironment {
+  const persistedState: PaneAccordionState = {};
+
+  workspacePaneDefinitions.forEach((definition) => {
+    const openSections = paneAccordionState[definition.id];
+
+    if (
+      openSections != null &&
+      !arraysAreEqual(
+        openSections,
+        DEFAULT_PANE_ACCORDION_STATE[definition.id] ?? [],
+      )
+    ) {
+      persistedState[definition.id] = openSections;
+    }
+  });
+
+  return Object.keys(persistedState).length === 0
+    ? {}
+    : { paneAccordionState: persistedState };
+}
+
+function arraysAreEqual(a: readonly string[], b: readonly string[]) {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}


### PR DESCRIPTION
- Add an `EditorEnvironment` localStorage model for editor-wide UI state, including zoom defaults, status bar visibility, pane layout, and pane accordion sections.
- Hydrate editor preferences and environment before initial render so new workspaces inherit saved zoom defaults and Dockview restores saved pane visibility, edges, and floating state.
- Expand Reset Layout to clear persisted editor layout state, status bar visibility, pane section state, and zoom defaults, with the reset IPC channel renamed to `FileMenuViewResetLayout`.
- Update the user guide and Dockview notes to document the persisted editor environment behavior.

Fixes #2373