### PR TITLE
feat: Use accordions in properties panes

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,7 +6,7 @@ To create a new score, use the file menu: `File -> New`. This will give you a te
 
 ## Workspace panes
 
-The editor uses dockable panes for tools. Use `View -> Neume Selector`, `View -> Common Combinations`, `View -> Properties`, and `View -> Lyrics` to show or hide panes. The Neume Selector and Properties panes are visible by default. The Properties pane shows type-specific settings for the current element. Use `View -> Reset Layout` to restore the default editor layout state, including pane arrangement, pane sections, status bar visibility, and zoom defaults.
+The editor uses dockable panes for tools. Use `View -> Neume Selector`, `View -> Common Combinations`, `View -> Properties`, and `View -> Lyrics` to show or hide panes. The Neume Selector and Properties panes are visible by default. The Properties pane shows type-specific settings for the current element, grouped into collapsible sections. Use `View -> Reset Layout` to restore the default editor layout state, including pane arrangement, pane sections, status bar visibility, and zoom defaults.
 
 ## Updating the title
 

--- a/notes/advanced_typography.md
+++ b/notes/advanced_typography.md
@@ -770,9 +770,11 @@ The same user-facing semantics apply everywhere:
   current default family if the user is still choosing that style.
 - family changes remap the style after the `fontFamily` command, in a separate
   transaction for correct downcast behavior.
-- remove-format clears both `fontFamily` and `fontStyle`; the toolbar clears
-  `fontStyle` before running CKEditor's `removeFormat` command, and the plugin
-  downcast also handles same-batch co-clears as a safety net.
+- the remove-format button in `RichTextToolbar.vue` clears both `fontFamily` and
+  `fontStyle`; the toolbar clears `fontStyle` before running CKEditor's
+  `removeFormat` command, and the plugin downcast also handles same-batch co-clears
+  as a safety net. The properties panel keeps per-field clear actions, but does not
+  run the global remove-format command.
 
 The style control appears beside the family control in both
 `RichTextToolbar.vue` and `PropertiesRichTextStyle.vue`.

--- a/notes/ckeditor_reka.md
+++ b/notes/ckeditor_reka.md
@@ -89,10 +89,10 @@ sub-editors share one owner.
 ### 1.4 The custom UI and where content gets persisted
 
 - **`RichTextToolbar.vue`** -- the floating toolbar (undo/redo, font, size, bold/
-  italic/underline, alignment, lists, indent, neume insertion, and the native
-  link/image/table/find buttons).
+  italic/underline, alignment, remove-format, lists, indent, neume insertion, and
+  the native link/image/table/find buttons).
 - **`PropertiesRichTextStyle.vue`** -- the properties-panel section (font, size,
-  color, style, alignment, script, remove-format, and neume-attribute controls).
+  color, style, alignment, script, and neume-attribute controls).
 - **`TextBoxRich.vue`** -- lays out an element's sub-editors and, on
   `RichTextEditor`'s `blur`, calls `getPendingUpdates()` (which diffs each
   sub-editor's `getData()` against the model) and emits `update`. **Blur is the

--- a/notes/dockview_vue.md
+++ b/notes/dockview_vue.md
@@ -411,8 +411,9 @@ Each `Properties*.vue` follows one shape: it takes `:element` (concrete type) pl
 the shared context it needs (`pageSetup` for min/max bounds, `fonts` for the three
 font-bearing panes, `innerNeume` only for `PropertiesNeume`), reads values directly
 off `element` (the element is treated as read-only input -- there is no local `v-model`
-copy), and emits a single generic `update` carrying a **`Partial<Element>`**. The
-router re-emits that enriched with the element: `@update="emit('update:neume', neumeElement, $event)"`.
+copy), groups its controls inside `PaneAccordion` / `PaneSection`, and
+emits a single generic `update` carrying a **`Partial<Element>`**. The router re-emits
+that enriched with the element: `@update="emit('update:neume', neumeElement, $event)"`.
 The host handler applies it uniformly, routing every edit through the app's undo/redo
 command bus (`commandService`) and then persisting the workspace (`save()`):
 
@@ -441,6 +442,19 @@ conditionally `refreshStaffLyrics()` (re-flows lyric text across the notes);
 `updateTextBox`/`updateRichTextBox` pass a
 `noHistory` flag when the _only_ changed key is the layout-derived `height`, keeping
 pure resizes out of the undo stack.
+
+Pane section state is editor-global environment state, not element state.
+`TheEditor.vue` owns the `openSections` arrays and passes them into
+`DeveloperPane.vue` and `PropertiesPane.vue`; `PropertiesPane.vue` forwards that
+state to the currently mounted `Properties*` child. Each top-level `PaneAccordion`
+is a controlled component that takes `openSections` and emits
+`update:open-sections`, while each `PaneSection` registers its stable section id
+through `paneSectionRegistrationKey`. When the visible section set changes, the
+accordion filters user changes to the currently registered sections but preserves
+open ids for hidden sections, so collapsing `style` on a text box does not discard
+the state of `martyria`, `tempo`, or the developer-only `glue` section when those
+sections are not currently mounted. Reset layout restores
+`DEFAULT_PANE_ACCORDION_STATE`.
 
 ### 3.3 Structural actions and `LyricsPane`
 
@@ -517,6 +531,9 @@ the same object as the selected text box, it's `'score'`, else `'header-footer'`
 - **Panes are stateless over the element.** They read `element` and emit partials;
   they keep no editable copy. The `:key` remount guarantees no stale derived state
   leaks across selections.
+- **Pane sections are stable environment state.** Section ids are semantic
+  (`style`, `positioning`, `tempo`, `display`, etc.), not tied to element ids;
+  adding or renaming one must account for `DEFAULT_PANE_ACCORDION_STATE`.
 - **One update path per element type.** Toolbar and pane both emit `Partial<Element>`
   to the same `updateXxx` -> `UpdatePropertiesCommand`. Adding a control on either
   surface must reuse that handler, never write the element directly.
@@ -594,7 +611,8 @@ pane state is not part of the `Workspace` model or score file. Instead,
 `TheEditor.vue` persists a small editor-global `editorEnvironment` record in
 `localStorage`. That record stores the pieces of layout state the editor owns:
 pane visibility, home edge/floating state for panes that differ from defaults, pane
-accordion sections, status-bar visibility, and zoom defaults.
+accordion sections for the developer and properties panes, status-bar visibility,
+and zoom defaults.
 
 On launch the dock is built programmatically from `workspacePaneDefinitions`
 (`initializeLayout` -> `ensureCenterEditorPanel` + `ensureEdgeGroup` per edge +
@@ -726,11 +744,17 @@ The subsystem spans these files, grouped by concern.
   `paneVisibility` / `layoutResetCounter` / `setPaneVisibility` / `resetLayout` /
   `onPaneVisibilityChange`; the pane IPC handlers and the `SetWorkspacePaneVisibility`
   menu-sync emit; `isEditorShortcutIgnored`.
+- `src/models/EditorEnvironment.ts` -- the editor-global persisted environment
+  shape and default pane accordion section state.
 
 **The inspector:**
 
 - `src/components/properties/InspectorContext.ts` -- the selection discriminated union.
 - `src/components/properties/PropertiesPane.vue` -- the context -> pane router.
+- `src/components/pane/PaneAccordion.vue`,
+  `src/components/pane/PaneSection.vue`,
+  `src/components/pane/PaneSectionRegistration.ts` -- the shared pane accordion
+  and section-state registration contract.
 - `src/components/properties/Properties{Annotation,TextBox,RichTextBox,DropCap,ImageBox,Lyrics,ModeKey,Neume,Martyria,Tempo}.vue`
   -- the per-element structured editors.
 - `src/components/LyricsPane.vue` -- bulk staff-lyrics text editor (selection-independent).

--- a/src/components/DeveloperPane.vue
+++ b/src/components/DeveloperPane.vue
@@ -12,185 +12,164 @@
         Reload Layout Diagnostics
       </Button>
     </div>
-    <ScrollArea class="developer-pane-scroll min-h-0 flex-1">
-      <div class="developer-pane-scroll-content pr-4">
-        <Accordion
-          type="multiple"
-          class="developer-pane-accordion"
-          :model-value="openSections"
-          @update:model-value="emitOpenSections($event)"
+    <PaneAccordion
+      :open-sections="props.openSections"
+      @update:open-sections="emit('update:open-sections', $event)"
+    >
+      <template #legend>Developer diagnostics</template>
+
+      <PaneSection title="Display Switches" value="display">
+        <Field
+          v-for="toggle in utilityDisplayToggles"
+          :key="toggle.key"
+          orientation="horizontal"
         >
-          <AccordionItem value="display">
-            <AccordionTrigger>Display Switches</AccordionTrigger>
-            <AccordionContent>
-              <FieldGroup class="pt-2">
-                <Field
-                  v-for="toggle in utilityDisplayToggles"
-                  :key="toggle.key"
-                  orientation="horizontal"
-                >
-                  <Switch
-                    :id="`developer-pane-${toggle.key}`"
-                    :model-value="props.toggles[toggle.key]"
-                    @update:model-value="
-                      emit('update:toggle', toggle.key, $event === true)
-                    "
-                  />
-                  <FieldLabel :for="`developer-pane-${toggle.key}`">
-                    {{ toggle.label }}
-                  </FieldLabel>
-                </Field>
-                <Separator class="my-3" />
-                <Field
-                  v-for="toggle in displayToggles"
-                  :key="toggle.key"
-                  orientation="horizontal"
-                >
-                  <Switch
-                    :id="`developer-pane-${toggle.key}`"
-                    :disabled="!props.toggles.overlaysEnabled"
-                    :model-value="props.toggles[toggle.key]"
-                    @update:model-value="
-                      emit('update:toggle', toggle.key, $event === true)
-                    "
-                  />
-                  <FieldLabel :for="`developer-pane-${toggle.key}`">
-                    {{ toggle.label }}
-                  </FieldLabel>
-                </Field>
-              </FieldGroup>
-            </AccordionContent>
-          </AccordionItem>
+          <Switch
+            :id="`developer-pane-${toggle.key}`"
+            :model-value="props.toggles[toggle.key]"
+            @update:model-value="
+              emit('update:toggle', toggle.key, $event === true)
+            "
+          />
+          <FieldLabel :for="`developer-pane-${toggle.key}`">
+            {{ toggle.label }}
+          </FieldLabel>
+        </Field>
+        <Separator class="my-3" />
+        <Field
+          v-for="toggle in displayToggles"
+          :key="toggle.key"
+          orientation="horizontal"
+        >
+          <Switch
+            :id="`developer-pane-${toggle.key}`"
+            :disabled="!props.toggles.overlaysEnabled"
+            :model-value="props.toggles[toggle.key]"
+            @update:model-value="
+              emit('update:toggle', toggle.key, $event === true)
+            "
+          />
+          <FieldLabel :for="`developer-pane-${toggle.key}`">
+            {{ toggle.label }}
+          </FieldLabel>
+        </Field>
+      </PaneSection>
 
-          <AccordionItem value="line">
-            <AccordionTrigger>Line Diagnostics</AccordionTrigger>
-            <AccordionContent>
-              <div class="developer-pane-section pt-2">
-                <template v-if="lineDiagnostics != null">
-                  <dl class="developer-pane-grid">
-                    <template
-                      v-for="item in lineDiagnosticRows"
-                      :key="item.label"
-                    >
-                      <dt>{{ item.label }}</dt>
-                      <dd>{{ item.value }}</dd>
-                    </template>
-                  </dl>
-                </template>
-                <p v-else class="developer-pane-empty">
-                  Layout diagnostics are unavailable for the current selection.
-                </p>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
+      <PaneSection
+        body-class="developer-pane-section"
+        title="Line Diagnostics"
+        value="line"
+      >
+        <template v-if="lineDiagnostics != null">
+          <dl class="developer-pane-grid">
+            <template v-for="item in lineDiagnosticRows" :key="item.label">
+              <dt>{{ item.label }}</dt>
+              <dd>{{ item.value }}</dd>
+            </template>
+          </dl>
+        </template>
+        <p v-else class="developer-pane-empty">
+          Layout diagnostics are unavailable for the current selection.
+        </p>
+      </PaneSection>
 
-          <AccordionItem v-if="props.toggles.showGlueWidths" value="glue">
-            <AccordionTrigger>Glue Overlays</AccordionTrigger>
-            <AccordionContent>
-              <div class="developer-pane-section pt-2">
-                <ul class="developer-pane-list">
-                  <li>Top bar = actual justified width.</li>
-                  <li>Bottom bar = preferred width.</li>
-                  <li>Blue = glue that stretched.</li>
-                  <li>Red = glue that shrunk.</li>
-                  <li>Hatched boxes = glue w/ negative width.</li>
-                  <li>Delta = actual minus preferred.</li>
-                </ul>
-                <ul
-                  v-if="lineDiagnostics != null && glueOverlayRows.length > 0"
-                  class="developer-pane-list pt-2"
+      <PaneSection
+        v-if="props.toggles.showGlueWidths"
+        body-class="developer-pane-section"
+        title="Glue Overlays"
+        value="glue"
+      >
+        <ul class="developer-pane-list">
+          <li>Top bar = actual justified width.</li>
+          <li>Bottom bar = preferred width.</li>
+          <li>Blue = glue that stretched.</li>
+          <li>Red = glue that shrunk.</li>
+          <li>Hatched boxes = glue w/ negative width.</li>
+          <li>Delta = actual minus preferred.</li>
+        </ul>
+        <ul
+          v-if="lineDiagnostics != null && glueOverlayRows.length > 0"
+          class="developer-pane-list pt-2"
+        >
+          <li
+            v-for="(row, index) in glueOverlayRows"
+            :key="`glue-overlay-${index}`"
+          >
+            <code>{{ row }}</code>
+          </li>
+        </ul>
+        <p
+          v-else-if="lineDiagnostics != null"
+          class="developer-pane-empty pt-2"
+        >
+          No anchored glue overlays were found for the selected line.
+        </p>
+        <p v-else class="developer-pane-empty pt-2">
+          Select a line-owned element to inspect its glue overlays.
+        </p>
+      </PaneSection>
+
+      <PaneSection
+        body-class="developer-pane-section"
+        title="Element Inspector"
+        value="inspector"
+      >
+        <template v-if="selectedElement != null">
+          <dl class="developer-pane-grid">
+            <template
+              v-for="item in inspectorRows"
+              :key="`${item.label}-${item.value}`"
+            >
+              <dt>{{ item.label }}</dt>
+              <dd
+                :class="{
+                  'developer-pane-grid-multiline': item.value.includes('\n'),
+                }"
+              >
+                {{ item.value }}
+              </dd>
+            </template>
+          </dl>
+
+          <div v-if="generatedItemGroups.length > 0" class="pt-3">
+            <p class="developer-pane-subtitle">Generated Items</p>
+            <div
+              v-for="(group, index) in generatedItemGroups"
+              :key="`${group.ownerElementId}-${index}`"
+              class="developer-pane-group"
+            >
+              <p class="developer-pane-group-title">
+                {{ getGroupLabel(group) }}
+              </p>
+              <ul class="developer-pane-list">
+                <li
+                  v-for="(item, itemIndex) in group.items"
+                  :key="`${group.ownerElementId}-${index}-${itemIndex}`"
                 >
-                  <li
-                    v-for="(row, index) in glueOverlayRows"
-                    :key="`glue-overlay-${index}`"
-                  >
-                    <code>{{ row }}</code>
-                  </li>
-                </ul>
-                <p
-                  v-else-if="lineDiagnostics != null"
-                  class="developer-pane-empty pt-2"
-                >
-                  No anchored glue overlays were found for the selected line.
-                </p>
-                <p v-else class="developer-pane-empty pt-2">
-                  Select a line-owned element to inspect its glue overlays.
-                </p>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-
-          <AccordionItem value="inspector">
-            <AccordionTrigger>Element Inspector</AccordionTrigger>
-            <AccordionContent>
-              <div class="developer-pane-section pt-2">
-                <template v-if="selectedElement != null">
-                  <dl class="developer-pane-grid">
-                    <template
-                      v-for="item in inspectorRows"
-                      :key="`${item.label}-${item.value}`"
-                    >
-                      <dt>{{ item.label }}</dt>
-                      <dd
-                        :class="{
-                          'developer-pane-grid-multiline':
-                            item.value.includes('\n'),
-                        }"
-                      >
-                        {{ item.value }}
-                      </dd>
-                    </template>
-                  </dl>
-
-                  <div v-if="generatedItemGroups.length > 0" class="pt-3">
-                    <p class="developer-pane-subtitle">Generated Items</p>
-                    <div
-                      v-for="(group, index) in generatedItemGroups"
-                      :key="`${group.ownerElementId}-${index}`"
-                      class="developer-pane-group"
-                    >
-                      <p class="developer-pane-group-title">
-                        {{ getGroupLabel(group) }}
-                      </p>
-                      <ul class="developer-pane-list">
-                        <li
-                          v-for="(item, itemIndex) in group.items"
-                          :key="`${group.ownerElementId}-${index}-${itemIndex}`"
-                        >
-                          <code>{{ formatDiagnosticItem(item) }}</code>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                  <p v-else class="developer-pane-empty pt-3">
-                    Generated layout items are unavailable for the current
-                    selection.
-                  </p>
-                </template>
-                <p v-else class="developer-pane-empty">
-                  Select an element to inspect it.
-                </p>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      </div>
-    </ScrollArea>
+                  <code>{{ formatDiagnosticItem(item) }}</code>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <p v-else class="developer-pane-empty pt-3">
+            Generated layout items are unavailable for the current selection.
+          </p>
+        </template>
+        <p v-else class="developer-pane-empty">
+          Select an element to inspect it.
+        </p>
+      </PaneSection>
+    </PaneAccordion>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
 import { Button } from '@/components/ui/button';
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import type { ScoreElement } from '@/models/Element';
@@ -310,13 +289,6 @@ const glueOverlayRows = computed(() => {
   return diagnostics.glueOverlays.map(formatGlueOverlay);
 });
 
-function emitOpenSections(value: string | string[] | undefined) {
-  emit(
-    'update:open-sections',
-    value == null ? [] : Array.isArray(value) ? value : [value],
-  );
-}
-
 function formatDiagnosticItem(item: LayoutDiagnosticItem) {
   if (item.type === 'box') {
     const label = item.label;
@@ -391,17 +363,6 @@ function getGlueOwnerLabel(glue: GlueOverlayDiagnostics) {
 </script>
 
 <style scoped>
-.developer-pane-accordion {
-  display: flex;
-  min-height: 0;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.developer-pane-scroll-content {
-  min-width: 0;
-}
-
 .developer-pane-section {
   font-size: 0.75rem;
 }

--- a/src/components/RichTextToolbar.vue
+++ b/src/components/RichTextToolbar.vue
@@ -112,6 +112,21 @@
           </ToolbarToggleItem>
         </AppTooltip>
       </ToolbarToggleGroup>
+      <AppTooltip
+        :tooltip="
+          $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
+        "
+      >
+        <ToolbarButton
+          variant="secondary"
+          class="chrome-button"
+          :disabled="!isCommandEnabled('removeFormat')"
+          @mousedown.prevent
+          @click="onRemoveFormat"
+        >
+          <PhEraser class="size-4" />
+        </ToolbarButton>
+      </AppTooltip>
       <ToolbarSeparator />
       <ToolbarToggleGroup
         type="single"
@@ -315,6 +330,7 @@
 import {
   PhArrowClockwise,
   PhArrowCounterClockwise,
+  PhEraser,
   PhTextAlignCenter,
   PhTextAlignJustify,
   PhTextAlignLeft,
@@ -382,6 +398,7 @@ const EXTRA_COMMAND_NAMES = [
   'indent',
   'undo',
   'redo',
+  'removeFormat',
   INSERT_NEUME_COMMAND,
 ];
 
@@ -430,6 +447,7 @@ const {
   onFontSizeChanged,
   onStyleValuesChanged,
   onAlignmentChanged,
+  onRemoveFormat,
 } = useRichTextStyleCommands(props, EXTRA_COMMAND_NAMES);
 
 const scopedEditor = useActiveEditorForOwner(() => props.element);

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -418,6 +418,10 @@ const developerPaneOpenSections = computed({
   get: () => accordionStateFor('developer'),
   set: (value: string[]) => setAccordionState('developer', value),
 });
+const propertiesPaneOpenSections = computed({
+  get: () => accordionStateFor('properties'),
+  set: (value: string[]) => setAccordionState('properties', value),
+});
 const workspaces = ref<Workspace[]>([]);
 const selectedWorkspaceValue = ref(new Workspace());
 const pendingLyricsAssignmentTimers = new Map<string, number>();
@@ -9278,6 +9282,7 @@ function renderTabLabel(tab: Tab) {
             :context="inspectorContext"
             :fonts="fonts"
             :inner-neume="toolbarInnerNeume"
+            :open-sections="propertiesPaneOpenSections"
             :page-setup="score.pageSetup"
             @update:annotation="updateAnnotation"
             @update:text-box="updateTextBox"
@@ -9288,6 +9293,7 @@ function renderTabLabel(tab: Tab) {
             @update:mode-key="updateModeKey"
             @update:neume="updateNoteAndSave"
             @update:martyria="updateMartyria"
+            @update:open-sections="propertiesPaneOpenSections = $event"
             @update:tempo="updateTempo"
           />
         </template>

--- a/src/components/pane/PaneAccordion.vue
+++ b/src/components/pane/PaneAccordion.vue
@@ -1,0 +1,68 @@
+<template>
+  <FieldSet :class="cn('min-h-0 flex-1 overflow-auto', props.class)">
+    <FieldLegend class="sr-only">
+      <slot name="legend" />
+    </FieldLegend>
+    <Accordion
+      type="multiple"
+      :class="cn('pane-accordion', props.accordionClass)"
+      :model-value="props.openSections"
+      @update:model-value="onOpenSectionsChanged($event as string[])"
+    >
+      <slot />
+    </Accordion>
+  </FieldSet>
+</template>
+
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { provide } from 'vue';
+
+import { Accordion } from '@/components/ui/accordion';
+import { FieldLegend, FieldSet } from '@/components/ui/field';
+import { cn } from '@/lib/utils';
+
+import { paneSectionRegistrationKey } from './PaneSectionRegistration';
+
+const props = defineProps<{
+  accordionClass?: HTMLAttributes['class'];
+  class?: HTMLAttributes['class'];
+  openSections: string[];
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:open-sections', value: string[]): void;
+}>();
+
+const registeredSections = new Set<string>();
+
+provide(paneSectionRegistrationKey, {
+  registerSection(value: string) {
+    registeredSections.add(value);
+  },
+  unregisterSection(value: string) {
+    registeredSections.delete(value);
+  },
+});
+
+function onOpenSectionsChanged(value: string[]) {
+  const nextVisibleSections = value.filter((section) =>
+    registeredSections.has(section),
+  );
+  const hiddenOpenSections = props.openSections.filter(
+    (section) => !registeredSections.has(section),
+  );
+
+  emit('update:open-sections', [...hiddenOpenSections, ...nextVisibleSections]);
+}
+</script>
+
+<style scoped>
+.pane-accordion {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+</style>

--- a/src/components/pane/PaneSection.vue
+++ b/src/components/pane/PaneSection.vue
@@ -1,0 +1,36 @@
+<template>
+  <AccordionItem :value="value">
+    <AccordionTrigger>{{ title }}</AccordionTrigger>
+    <AccordionContent>
+      <FieldGroup :class="cn('pt-2', props.bodyClass)">
+        <slot />
+      </FieldGroup>
+    </AccordionContent>
+  </AccordionItem>
+</template>
+
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { inject, onBeforeUnmount, onMounted } from 'vue';
+
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { FieldGroup } from '@/components/ui/field';
+import { cn } from '@/lib/utils';
+
+import { paneSectionRegistrationKey } from './PaneSectionRegistration';
+
+const props = defineProps<{
+  bodyClass?: HTMLAttributes['class'];
+  title: string;
+  value: string;
+}>();
+
+const sectionRegistration = inject(paneSectionRegistrationKey)!;
+
+onMounted(() => sectionRegistration.registerSection(props.value));
+onBeforeUnmount(() => sectionRegistration.unregisterSection(props.value));
+</script>

--- a/src/components/pane/PaneSectionRegistration.ts
+++ b/src/components/pane/PaneSectionRegistration.ts
@@ -1,0 +1,9 @@
+import type { InjectionKey } from 'vue';
+
+export type PaneSectionRegistration = {
+  registerSection: (value: string) => void;
+  unregisterSection: (value: string) => void;
+};
+
+export const paneSectionRegistrationKey: InjectionKey<PaneSectionRegistration> =
+  Symbol('paneSectionRegistration');

--- a/src/components/properties/PropertiesAnnotation.vue
+++ b/src/components/properties/PropertiesAnnotation.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.insert.annotation, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <FieldLabel for="properties-annotation-left">{{
           $t(($) => $.dialog.common.left, { ns: 'dialog' })
@@ -35,34 +42,27 @@
           "
         />
       </Field>
+    </PaneSection>
 
-      <FieldSeparator />
-
-      <PropertiesRichTextStyle
-        id-prefix="properties-annotation"
-        :element="element"
-        :fonts="fonts"
-        :page-setup="pageSetup"
-        :default-font-color="pageSetup.textBoxDefaultColor"
-        :default-font-size="pageSetup.lyricsDefaultFontSize"
-        :default-font-family="pageSetup.textBoxDefaultFontFamily"
-      />
-    </FieldGroup>
-  </FieldSet>
+    <PropertiesRichTextStyle
+      id-prefix="properties-annotation"
+      :element="element"
+      :fonts="fonts"
+      :page-setup="pageSetup"
+      :default-font-color="pageSetup.textBoxDefaultColor"
+      :default-font-size="pageSetup.lyricsDefaultFontSize"
+      :default-font-family="pageSetup.textBoxDefaultFontFamily"
+    />
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
 
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSeparator,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import type { AnnotationElement } from '@/models/Element';
 import type { PageSetup } from '@/models/PageSetup';
 import { fraction2FormatOptions } from '@/utils/numberFormatOptions';
@@ -78,11 +78,15 @@ defineProps({
     type: Array as PropType<string[]>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-defineEmits(['update']);
+defineEmits(['update', 'update:open-sections']);
 </script>

--- a/src/components/properties/PropertiesDropCap.vue
+++ b/src/components/properties/PropertiesDropCap.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.insert.dropCap, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="style"
+      :title="$t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-drop-cap-use-default-style"
@@ -52,6 +59,33 @@
         </Field>
 
         <Field orientation="horizontal">
+          <FieldLabel>{{
+            $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
+          }}</FieldLabel>
+          <ToggleGroup
+            type="multiple"
+            variant="outline"
+            :model-value="styleValues"
+            @update:model-value="onStyleValuesChanged"
+          >
+            <ToggleGroupItem
+              value="bold"
+              aria-label="Toggle bold"
+              :disabled="!isFontStyleAxisToggleEnabled('bold')"
+            >
+              <PhTextB />
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="italic"
+              aria-label="Toggle italic"
+              :disabled="!isFontStyleAxisToggleEnabled('italic')"
+            >
+              <PhTextItalic />
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </Field>
+
+        <Field orientation="horizontal">
           <FieldLabel for="properties-drop-cap-font-size">{{
             $t(($) => $.toolbar.initialMartyria.size, { ns: 'toolbar' })
           }}</FieldLabel>
@@ -61,6 +95,24 @@
             :model-value="element.fontSize"
             @update:model-value="
               $emit('update', { fontSize: $event } as Partial<DropCapElement>)
+            "
+          />
+        </Field>
+
+        <Field orientation="horizontal">
+          <FieldLabel for="properties-drop-cap-line-span">{{
+            $t(($) => $.toolbar.dropCap.lineSpan, { ns: 'toolbar' })
+          }}</FieldLabel>
+          <InputUnit
+            id="properties-drop-cap-line-span"
+            unit="unitless"
+            :min="1"
+            :max="10"
+            :step="1"
+            :model-value="element.lineSpan"
+            :format-options="fraction0FormatOptions"
+            @update:model-value="
+              $emit('update', { lineSpan: $event } as Partial<DropCapElement>)
             "
           />
         </Field>
@@ -97,33 +149,6 @@
         </Field>
 
         <Field orientation="horizontal">
-          <FieldLabel>{{
-            $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
-          }}</FieldLabel>
-          <ToggleGroup
-            type="multiple"
-            variant="outline"
-            :model-value="styleValues"
-            @update:model-value="onStyleValuesChanged"
-          >
-            <ToggleGroupItem
-              value="bold"
-              aria-label="Toggle bold"
-              :disabled="!isFontStyleAxisToggleEnabled('bold')"
-            >
-              <PhTextB />
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="italic"
-              aria-label="Toggle italic"
-              :disabled="!isFontStyleAxisToggleEnabled('italic')"
-            >
-              <PhTextItalic />
-            </ToggleGroupItem>
-          </ToggleGroup>
-        </Field>
-
-        <Field orientation="horizontal">
           <FieldLabel for="properties-drop-cap-outline">{{
             $t(($) => $.toolbar.common.outline, { ns: 'toolbar' })
           }}</FieldLabel>
@@ -137,26 +162,13 @@
             "
           />
         </Field>
-
-        <Field orientation="horizontal">
-          <FieldLabel for="properties-drop-cap-line-span">{{
-            $t(($) => $.toolbar.dropCap.lineSpan, { ns: 'toolbar' })
-          }}</FieldLabel>
-          <InputUnit
-            id="properties-drop-cap-line-span"
-            unit="unitless"
-            :min="1"
-            :max="10"
-            :step="1"
-            :model-value="element.lineSpan"
-            :format-options="fraction0FormatOptions"
-            @update:model-value="
-              $emit('update', { lineSpan: $event } as Partial<DropCapElement>)
-            "
-          />
-        </Field>
       </template>
+    </PaneSection>
 
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <FieldLabel for="properties-drop-cap-width">{{
           $t(($) => $.toolbar.common.width, { ns: 'toolbar' })
@@ -176,8 +188,8 @@
           "
         />
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -191,13 +203,9 @@ import FontStyleSelect from '@/components/FontStyleSelect.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
 import InputStrokeWidth from '@/components/InputStrokeWidth.vue';
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Switch } from '@/components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useFontStyleControls } from '@/composables/useFontStyleControls';
@@ -220,13 +228,17 @@ const props = defineProps({
     type: Array as PropType<string[]>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 
 const {
   fontStyleOptions,

--- a/src/components/properties/PropertiesImageBox.vue
+++ b/src/components/properties/PropertiesImageBox.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.insert.image, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="size"
+      :title="$t(($) => $.dialog.pageSetup.size, { ns: 'dialog' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-image-box-inline"
@@ -67,8 +74,14 @@
           @update:model-value="onChangeHeight($event)"
         />
       </Field>
+    </PaneSection>
 
-      <Field v-if="!element.inline" orientation="horizontal">
+    <PaneSection
+      v-if="!element.inline"
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
+      <Field orientation="horizontal">
         <FieldLabel>{{
           $t(($) => $.toolbar.common.alignment, { ns: 'toolbar' })
         }}</FieldLabel>
@@ -103,8 +116,8 @@
           </AppTooltip>
         </ToggleGroup>
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -117,13 +130,9 @@ import type { PropType } from 'vue';
 
 import AppTooltip from '@/components/AppTooltip.vue';
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Switch } from '@/components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import type { ImageBoxElement } from '@/models/Element';
@@ -136,13 +145,17 @@ const props = defineProps({
     type: Object as PropType<ImageBoxElement>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 
 function onAlignmentChanged(value: unknown) {
   if (isTextBoxAlignment(value)) {

--- a/src/components/properties/PropertiesLyrics.vue
+++ b/src/components/properties/PropertiesLyrics.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.view.lyrics, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="style"
+      :title="$t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-lyrics-use-default-style"
@@ -52,35 +59,6 @@
         </Field>
 
         <Field orientation="horizontal">
-          <FieldLabel for="properties-lyrics-font-size">{{
-            $t(($) => $.dialog.pageSetup.size, { ns: 'dialog' })
-          }}</FieldLabel>
-          <InputFontSize
-            id="properties-lyrics-font-size"
-            :model-value="element.lyricsFontSize"
-            @update:model-value="
-              $emit('update', {
-                lyricsFontSize: $event,
-              } as Partial<NoteElement>)
-            "
-          />
-        </Field>
-
-        <Field orientation="horizontal">
-          <FieldLabel>{{
-            $t(($) => $.dialog.pageSetup.color, { ns: 'dialog' })
-          }}</FieldLabel>
-          <ColorPicker
-            :model-value="element.lyricsColor"
-            @update:model-value="
-              $emit('update', {
-                lyricsColor: $event,
-              } as Partial<NoteElement>)
-            "
-          />
-        </Field>
-
-        <Field orientation="horizontal">
           <FieldLabel>{{
             $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
           }}</FieldLabel>
@@ -111,6 +89,35 @@
         </Field>
 
         <Field orientation="horizontal">
+          <FieldLabel for="properties-lyrics-font-size">{{
+            $t(($) => $.dialog.pageSetup.size, { ns: 'dialog' })
+          }}</FieldLabel>
+          <InputFontSize
+            id="properties-lyrics-font-size"
+            :model-value="element.lyricsFontSize"
+            @update:model-value="
+              $emit('update', {
+                lyricsFontSize: $event,
+              } as Partial<NoteElement>)
+            "
+          />
+        </Field>
+
+        <Field orientation="horizontal">
+          <FieldLabel>{{
+            $t(($) => $.dialog.pageSetup.color, { ns: 'dialog' })
+          }}</FieldLabel>
+          <ColorPicker
+            :model-value="element.lyricsColor"
+            @update:model-value="
+              $emit('update', {
+                lyricsColor: $event,
+              } as Partial<NoteElement>)
+            "
+          />
+        </Field>
+
+        <Field orientation="horizontal">
           <FieldLabel>{{
             $t(($) => $.toolbar.common.outline, { ns: 'toolbar' })
           }}</FieldLabel>
@@ -124,8 +131,8 @@
           />
         </Field>
       </template>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -138,13 +145,9 @@ import FontCombobox from '@/components/FontCombobox.vue';
 import FontStyleSelect from '@/components/FontStyleSelect.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
 import InputStrokeWidth from '@/components/InputStrokeWidth.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Switch } from '@/components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useFontStyleControls } from '@/composables/useFontStyleControls';
@@ -160,9 +163,13 @@ const props = defineProps({
     type: Array as PropType<string[]>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 
 const {
   fontStyleOptions,

--- a/src/components/properties/PropertiesMartyria.vue
+++ b/src/components/properties/PropertiesMartyria.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.toolbar.main.martyria, { ns: 'toolbar' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="martyria"
+      :title="$t(($) => $.toolbar.main.martyria, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-martyria-auto"
@@ -78,66 +85,6 @@
           </Select>
         </Field>
       </template>
-
-      <Field orientation="horizontal">
-        <FieldLabel for="properties-martyria-bpm">{{
-          $t(($) => $.toolbar.common.bpm, { ns: 'toolbar' })
-        }}</FieldLabel>
-        <InputBpm
-          id="properties-martyria-bpm"
-          :disabled="
-            element.tempo == null &&
-            element.tempoLeft == null &&
-            element.tempoRight == null
-          "
-          :model-value="element.bpm"
-          @update:model-value="
-            $emit('update', {
-              bpm: $event,
-            } as Partial<MartyriaElement>)
-          "
-        />
-      </Field>
-
-      <Field orientation="horizontal">
-        <FieldLabel for="properties-martyria-vertical-offset">{{
-          $t(($) => $.toolbar.common.verticalOffset, { ns: 'toolbar' })
-        }}</FieldLabel>
-        <InputUnit
-          id="properties-martyria-vertical-offset"
-          unit="pt"
-          :min="-spaceAfterMax"
-          :max="spaceAfterMax"
-          :step="0.5"
-          :format-options="fraction2FormatOptions"
-          :model-value="element.verticalOffset"
-          @update:model-value="
-            $emit('update', {
-              verticalOffset: $event,
-            } as Partial<MartyriaElement>)
-          "
-        />
-      </Field>
-
-      <Field orientation="horizontal">
-        <FieldLabel for="properties-martyria-space-after">{{
-          $t(($) => $.toolbar.common.spaceAfter, { ns: 'toolbar' })
-        }}</FieldLabel>
-        <InputUnit
-          id="properties-martyria-space-after"
-          unit="pt"
-          :min="-spaceAfterMax"
-          :max="spaceAfterMax"
-          :step="0.5"
-          :format-options="fraction2FormatOptions"
-          :model-value="element.spaceAfter"
-          @update:model-value="
-            $emit('update', {
-              spaceAfter: $event,
-            } as Partial<MartyriaElement>)
-          "
-        />
-      </Field>
 
       <Field v-if="showChromaticFthoraNote">
         <FieldLabel for="properties-martyria-fthora-note">{{
@@ -223,8 +170,78 @@
           </SelectContent>
         </Select>
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+
+    <PaneSection
+      value="tempo"
+      :title="$t(($) => $.toolbar.common.tempoSign, { ns: 'toolbar' })"
+    >
+      <Field orientation="horizontal">
+        <FieldLabel for="properties-martyria-bpm">{{
+          $t(($) => $.toolbar.common.bpm, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputBpm
+          id="properties-martyria-bpm"
+          :disabled="
+            element.tempo == null &&
+            element.tempoLeft == null &&
+            element.tempoRight == null
+          "
+          :model-value="element.bpm"
+          @update:model-value="
+            $emit('update', {
+              bpm: $event,
+            } as Partial<MartyriaElement>)
+          "
+        />
+      </Field>
+    </PaneSection>
+
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
+      <Field orientation="horizontal">
+        <FieldLabel for="properties-martyria-vertical-offset">{{
+          $t(($) => $.toolbar.common.verticalOffset, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputUnit
+          id="properties-martyria-vertical-offset"
+          unit="pt"
+          :min="-spaceAfterMax"
+          :max="spaceAfterMax"
+          :step="0.5"
+          :format-options="fraction2FormatOptions"
+          :model-value="element.verticalOffset"
+          @update:model-value="
+            $emit('update', {
+              verticalOffset: $event,
+            } as Partial<MartyriaElement>)
+          "
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel for="properties-martyria-space-after">{{
+          $t(($) => $.toolbar.common.spaceAfter, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputUnit
+          id="properties-martyria-space-after"
+          unit="pt"
+          :min="-spaceAfterMax"
+          :max="spaceAfterMax"
+          :step="0.5"
+          :format-options="fraction2FormatOptions"
+          :model-value="element.spaceAfter"
+          @update:model-value="
+            $emit('update', {
+              spaceAfter: $event,
+            } as Partial<MartyriaElement>)
+          "
+        />
+      </Field>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -234,13 +251,9 @@ import { computed } from 'vue';
 
 import InputBpm from '@/components/InputBpm.vue';
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import {
   Select,
   SelectContent,
@@ -318,13 +331,17 @@ const props = defineProps({
     type: Object as PropType<MartyriaElement>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 const SELECT_NONE_VALUE = '__none__';
 
 const spaceAfterMax = computed(() =>

--- a/src/components/properties/PropertiesModeKey.vue
+++ b/src/components/properties/PropertiesModeKey.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.insert.initialMartyria, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="style"
+      :title="$t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-mode-key-use-default-style"
@@ -82,7 +89,12 @@
           />
         </Field>
       </template>
+    </PaneSection>
 
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <FieldLabel>{{
           $t(($) => $.toolbar.common.alignment, { ns: 'toolbar' })
@@ -169,6 +181,26 @@
           "
         />
       </Field>
+    </PaneSection>
+
+    <PaneSection
+      value="initial-martyria"
+      :title="$t(($) => $.menu.insert.initialMartyria, { ns: 'menu' })"
+    >
+      <Field orientation="horizontal">
+        <Switch
+          id="properties-mode-key-show-ambitus"
+          :model-value="element.showAmbitus"
+          @update:model-value="
+            $emit('update', {
+              showAmbitus: $event === true,
+            } as Partial<ModeKeyElement>)
+          "
+        />
+        <FieldLabel for="properties-mode-key-show-ambitus">{{
+          $t(($) => $.toolbar.initialMartyria.showAmbitus, { ns: 'toolbar' })
+        }}</FieldLabel>
+      </Field>
 
       <Field orientation="horizontal">
         <Switch
@@ -182,21 +214,6 @@
         />
         <FieldLabel for="properties-mode-key-ignore-attractions">{{
           $t(($) => $.toolbar.common.ignoreAttractions, { ns: 'toolbar' })
-        }}</FieldLabel>
-      </Field>
-
-      <Field orientation="horizontal">
-        <Switch
-          id="properties-mode-key-show-ambitus"
-          :model-value="element.showAmbitus"
-          @update:model-value="
-            $emit('update', {
-              showAmbitus: $event === true,
-            } as Partial<ModeKeyElement>)
-          "
-        />
-        <FieldLabel for="properties-mode-key-show-ambitus">{{
-          $t(($) => $.toolbar.initialMartyria.showAmbitus, { ns: 'toolbar' })
         }}</FieldLabel>
       </Field>
 
@@ -219,8 +236,8 @@
           })
         }}</FieldLabel>
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -238,13 +255,9 @@ import InputBpm from '@/components/InputBpm.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
 import InputStrokeWidth from '@/components/InputStrokeWidth.vue';
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Switch } from '@/components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import type { ModeKeyElement } from '@/models/Element';
@@ -261,13 +274,17 @@ const props = defineProps({
     type: Object as PropType<ModeKeyElement>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 
 const heightAdjustmentMin = computed(
   () => -Math.round(Unit.fromPt(props.element.height)),

--- a/src/components/properties/PropertiesNeume.vue
+++ b/src/components/properties/PropertiesNeume.vue
@@ -1,38 +1,39 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.toolbar.common.neume, { ns: 'toolbar' })
-    }}</FieldLegend>
-    <FieldGroup>
-      <Field orientation="horizontal">
-        <FieldLabel for="properties-neume-space-after">{{
-          $t(($) => $.toolbar.common.spaceAfter, { ns: 'toolbar' })
-        }}</FieldLabel>
-        <InputUnit
-          id="properties-neume-space-after"
-          unit="pt"
-          :min="-spaceAfterMax"
-          :max="spaceAfterMax"
-          :step="0.5"
-          :format-options="fraction2FormatOptions"
-          :model-value="element.spaceAfter"
-          @update:model-value="$emit('update', { spaceAfter: $event })"
-        />
-      </Field>
+    }}</template>
 
-      <Field orientation="horizontal">
-        <Switch
-          id="properties-neume-ignore-attractions"
-          :model-value="element.ignoreAttractions"
-          @update:model-value="
-            $emit('update', {
-              ignoreAttractions: $event === true,
-            } as Partial<NoteElement>)
-          "
-        />
-        <FieldLabel for="properties-neume-ignore-attractions">{{
-          $t(($) => $.toolbar.common.ignoreAttractions, { ns: 'toolbar' })
+    <PaneSection
+      value="neume"
+      :title="$t(($) => $.toolbar.common.neume, { ns: 'toolbar' })"
+    >
+      <Field v-if="showChromaticFthoraNote">
+        <FieldLabel for="properties-neume-fthora-note">{{
+          $t(($) => $.toolbar.common.fthoraNote, { ns: 'toolbar' })
         }}</FieldLabel>
+        <Select
+          :model-value="chromaticFthoraNote"
+          @update:model-value="updateChromaticFthoraNote"
+        >
+          <SelectTrigger id="properties-neume-fthora-note" class="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem
+                v-for="note in notes"
+                :key="note.value"
+                :value="note.value"
+              >
+                {{ $t(note.label, { ns: 'model' }) }}
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
       </Field>
 
       <Field>
@@ -81,32 +82,43 @@
         </Select>
       </Field>
 
-      <Field v-if="showChromaticFthoraNote">
-        <FieldLabel for="properties-neume-fthora-note">{{
-          $t(($) => $.toolbar.common.fthoraNote, { ns: 'toolbar' })
+      <Field orientation="horizontal">
+        <Switch
+          id="properties-neume-ignore-attractions"
+          :model-value="element.ignoreAttractions"
+          @update:model-value="
+            $emit('update', {
+              ignoreAttractions: $event === true,
+            } as Partial<NoteElement>)
+          "
+        />
+        <FieldLabel for="properties-neume-ignore-attractions">{{
+          $t(($) => $.toolbar.common.ignoreAttractions, { ns: 'toolbar' })
         }}</FieldLabel>
-        <Select
-          :model-value="chromaticFthoraNote"
-          @update:model-value="updateChromaticFthoraNote"
-        >
-          <SelectTrigger id="properties-neume-fthora-note" class="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              <SelectItem
-                v-for="note in notes"
-                :key="note.value"
-                :value="note.value"
-              >
-                {{ $t(note.label, { ns: 'model' }) }}
-              </SelectItem>
-            </SelectGroup>
-          </SelectContent>
-        </Select>
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
+      <Field orientation="horizontal">
+        <FieldLabel for="properties-neume-space-after">{{
+          $t(($) => $.toolbar.common.spaceAfter, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputUnit
+          id="properties-neume-space-after"
+          unit="pt"
+          :min="-spaceAfterMax"
+          :max="spaceAfterMax"
+          :step="0.5"
+          :format-options="fraction2FormatOptions"
+          :model-value="element.spaceAfter"
+          @update:model-value="$emit('update', { spaceAfter: $event })"
+        />
+      </Field>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -115,13 +127,9 @@ import type { PropType } from 'vue';
 import { computed } from 'vue';
 
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import {
   Select,
   SelectContent,
@@ -174,13 +182,17 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 
 const notes = computed((): ChromaticFthoraNoteOption[] => {
   if (

--- a/src/components/properties/PropertiesPane.vue
+++ b/src/components/properties/PropertiesPane.vue
@@ -17,7 +17,9 @@
       v-else-if="tempoElement != null"
       :key="`tempo-${tempoElement.id}`"
       :element="tempoElement"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:tempo', tempoElement, $event)"
     />
 
@@ -26,7 +28,9 @@
       :key="`annotation-${annotationElement.id}`"
       :element="annotationElement"
       :fonts="fonts"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:annotation', annotationElement, $event)"
     />
 
@@ -35,8 +39,10 @@
       :key="`text-box-${textBoxElement.id}`"
       :element="textBoxElement"
       :fonts="fonts"
+      :open-sections="openSections"
       :page-setup="pageSetup"
       :source="textBoxSource"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:text-box', textBoxElement, $event)"
     />
 
@@ -45,8 +51,10 @@
       :key="`rich-text-box-${richTextBoxElement.id}`"
       :element="richTextBoxElement"
       :fonts="fonts"
+      :open-sections="openSections"
       :page-setup="pageSetup"
       :source="richTextBoxSource"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:rich-text-box', richTextBoxElement, $event)"
     />
 
@@ -55,7 +63,9 @@
       :key="`drop-cap-${dropCapElement.id}`"
       :element="dropCapElement"
       :fonts="fonts"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:drop-cap', dropCapElement, $event)"
     />
 
@@ -63,7 +73,9 @@
       v-else-if="imageBoxElement != null"
       :key="`image-box-${imageBoxElement.id}`"
       :element="imageBoxElement"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:image-box', imageBoxElement, $event)"
     />
 
@@ -72,6 +84,8 @@
       :key="`lyrics-${lyricsElement.id}`"
       :element="lyricsElement"
       :fonts="fonts"
+      :open-sections="openSections"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:lyrics', lyricsElement, $event)"
     />
 
@@ -79,7 +93,9 @@
       v-else-if="modeKeyElement != null"
       :key="`mode-key-${modeKeyElement.id}`"
       :element="modeKeyElement"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:mode-key', modeKeyElement, $event)"
     />
 
@@ -88,7 +104,9 @@
       :key="`neume-${neumeElement.id}`"
       :element="neumeElement"
       :inner-neume="innerNeume"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:neume', neumeElement, $event)"
     />
 
@@ -96,7 +114,9 @@
       v-else-if="martyriaElement != null"
       :key="`martyria-${martyriaElement.id}`"
       :element="martyriaElement"
+      :open-sections="openSections"
       :page-setup="pageSetup"
+      @update:open-sections="emit('update:open-sections', $event)"
       @update="emit('update:martyria', martyriaElement, $event)"
     />
   </div>
@@ -143,9 +163,14 @@ const props = defineProps({
     type: Object as PropType<PageSetup>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
 });
 
 const emit = defineEmits([
+  'update:open-sections',
   'update:annotation',
   'update:drop-cap',
   'update:image-box',

--- a/src/components/properties/PropertiesRichTextBox.vue
+++ b/src/components/properties/PropertiesRichTextBox.vue
@@ -1,33 +1,38 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.insert.richTextBox, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
-      <PropertiesRichTextStyle
-        id-prefix="properties-rich-text-box"
-        :element="element"
-        :fonts="fonts"
-        :page-setup="pageSetup"
-        :default-font-color="
-          element.inline
-            ? pageSetup.lyricsDefaultColor
-            : pageSetup.textBoxDefaultColor
-        "
-        :default-font-size="
-          element.inline
-            ? pageSetup.lyricsDefaultFontSize
-            : pageSetup.textBoxDefaultFontSize
-        "
-        :default-font-family="
-          element.inline
-            ? pageSetup.lyricsDefaultFontFamily
-            : pageSetup.textBoxDefaultFontFamily
-        "
-      />
+    }}</template>
 
-      <FieldSeparator />
+    <PropertiesRichTextStyle
+      id-prefix="properties-rich-text-box"
+      :element="element"
+      :fonts="fonts"
+      :page-setup="pageSetup"
+      :default-font-color="
+        element.inline
+          ? pageSetup.lyricsDefaultColor
+          : pageSetup.textBoxDefaultColor
+      "
+      :default-font-size="
+        element.inline
+          ? pageSetup.lyricsDefaultFontSize
+          : pageSetup.textBoxDefaultFontSize
+      "
+      :default-font-family="
+        element.inline
+          ? pageSetup.lyricsDefaultFontFamily
+          : pageSetup.textBoxDefaultFontFamily
+      "
+    />
 
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-rich-text-box-inline"
@@ -39,7 +44,7 @@
         </FieldLabel>
       </Field>
 
-      <FieldGroup v-if="element.inline">
+      <template v-if="element.inline">
         <Field orientation="horizontal">
           <FieldLabel for="properties-rich-text-box-width">{{
             $t(($) => $.toolbar.common.width, { ns: 'toolbar' })
@@ -106,7 +111,7 @@
             $t(($) => $.toolbar.textbox.centerOnPage, { ns: 'toolbar' })
           }}</FieldLabel>
         </Field>
-      </FieldGroup>
+      </template>
 
       <Field orientation="horizontal">
         <FieldLabel for="properties-rich-text-box-margin-top">{{
@@ -141,9 +146,12 @@
           @update:model-value="updateNumberProperty('marginBottom', $event)"
         />
       </Field>
+    </PaneSection>
 
-      <FieldSeparator />
-
+    <PaneSection
+      value="mode-change"
+      :title="$t(($) => $.toolbar.textbox.modeChange, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-rich-text-box-mode-change"
@@ -155,14 +163,11 @@
         }}</FieldLabel>
       </Field>
 
-      <FieldGroup v-if="element.modeChange">
+      <template v-if="element.modeChange">
         <Field>
-          <FieldLabel
-            for="properties-rich-text-box-mode-change-physical-note"
-            >{{
-              $t(($) => $.toolbar.martyria.note, { ns: 'toolbar' })
-            }}</FieldLabel
-          >
+          <FieldLabel for="properties-rich-text-box-mode-change-physical-note">
+            {{ $t(($) => $.toolbar.martyria.note, { ns: 'toolbar' }) }}
+          </FieldLabel>
           <Select
             :model-value="element.modeChangePhysicalNote"
             @update:model-value="onModeChangePhysicalNoteChanged"
@@ -288,80 +293,74 @@
             })
           }}</FieldLabel>
         </Field>
-      </FieldGroup>
+      </template>
+    </PaneSection>
 
-      <template v-if="source === 'score'">
-        <FieldSeparator />
-
-        <FieldSet>
-          <FieldLegend variant="label">{{
-            $t(($) => $.toolbar.textbox.runningMarker, { ns: 'toolbar' })
-          }}</FieldLegend>
-          <FieldGroup>
-            <Field>
-              <FieldLabel for="properties-rich-text-box-running-marker-role">{{
-                $t(($) => $.toolbar.textbox.runningMarkerRole, {
-                  ns: 'toolbar',
-                })
-              }}</FieldLabel>
-              <Select
-                :model-value="
-                  element.runningMarkerRole ?? RUNNING_MARKER_NONE_VALUE
-                "
-                @update:model-value="onRunningMarkerRoleChanged"
-              >
-                <SelectTrigger
-                  id="properties-rich-text-box-running-marker-role"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <RichTextSelectContent>
-                  <SelectGroup>
-                    <SelectItem :value="RUNNING_MARKER_NONE_VALUE">
-                      {{ $t(($) => $.toolbar.common.none, { ns: 'toolbar' }) }}
-                    </SelectItem>
-                    <SelectItem value="chapter">
-                      {{
-                        $t(($) => $.toolbar.textbox.runningMarkerChapter, {
-                          ns: 'toolbar',
-                        })
-                      }}
-                    </SelectItem>
-                    <SelectItem value="section">
-                      {{
-                        $t(($) => $.toolbar.textbox.runningMarkerSection, {
-                          ns: 'toolbar',
-                        })
-                      }}
-                    </SelectItem>
-                  </SelectGroup>
-                </RichTextSelectContent>
-              </Select>
-            </Field>
-
-            <Field>
-              <FieldLabel for="properties-rich-text-box-running-marker-text">{{
-                $t(($) => $.toolbar.textbox.runningMarkerText, {
-                  ns: 'toolbar',
-                })
-              }}</FieldLabel>
-              <Input
-                id="properties-rich-text-box-running-marker-text"
-                :model-value="element.runningMarkerText ?? ''"
-                :placeholder="
-                  $t(($) => $.toolbar.textbox.runningMarkerTextPlaceholder, {
+    <PaneSection
+      v-if="source === 'score'"
+      value="running-marker"
+      :title="$t(($) => $.toolbar.textbox.runningMarker, { ns: 'toolbar' })"
+    >
+      <Field>
+        <FieldLabel for="properties-rich-text-box-running-marker-role">{{
+          $t(($) => $.toolbar.textbox.runningMarkerRole, {
+            ns: 'toolbar',
+          })
+        }}</FieldLabel>
+        <Select
+          :model-value="element.runningMarkerRole ?? RUNNING_MARKER_NONE_VALUE"
+          @update:model-value="onRunningMarkerRoleChanged"
+        >
+          <SelectTrigger id="properties-rich-text-box-running-marker-role">
+            <SelectValue />
+          </SelectTrigger>
+          <RichTextSelectContent>
+            <SelectGroup>
+              <SelectItem :value="RUNNING_MARKER_NONE_VALUE">
+                {{ $t(($) => $.toolbar.common.none, { ns: 'toolbar' }) }}
+              </SelectItem>
+              <SelectItem value="chapter">
+                {{
+                  $t(($) => $.toolbar.textbox.runningMarkerChapter, {
                     ns: 'toolbar',
                   })
-                "
-                @update:model-value="onRunningMarkerTextChanged"
-              />
-            </Field>
-          </FieldGroup>
-        </FieldSet>
-      </template>
+                }}
+              </SelectItem>
+              <SelectItem value="section">
+                {{
+                  $t(($) => $.toolbar.textbox.runningMarkerSection, {
+                    ns: 'toolbar',
+                  })
+                }}
+              </SelectItem>
+            </SelectGroup>
+          </RichTextSelectContent>
+        </Select>
+      </Field>
 
-      <FieldSeparator />
+      <Field>
+        <FieldLabel for="properties-rich-text-box-running-marker-text">{{
+          $t(($) => $.toolbar.textbox.runningMarkerText, {
+            ns: 'toolbar',
+          })
+        }}</FieldLabel>
+        <Input
+          id="properties-rich-text-box-running-marker-text"
+          :model-value="element.runningMarkerText ?? ''"
+          :placeholder="
+            $t(($) => $.toolbar.textbox.runningMarkerTextPlaceholder, {
+              ns: 'toolbar',
+            })
+          "
+          @update:model-value="onRunningMarkerTextChanged"
+        />
+      </Field>
+    </PaneSection>
 
+    <PaneSection
+      value="scrollable"
+      :title="$t(($) => $.toolbar.textbox.scrollable, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-rich-text-box-scrollable"
@@ -372,8 +371,8 @@
           $t(($) => $.toolbar.textbox.scrollable, { ns: 'toolbar' })
         }}</FieldLabel>
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -383,15 +382,10 @@ import { computed } from 'vue';
 
 import InputBpm from '@/components/InputBpm.vue';
 import InputUnit from '@/components/InputUnit.vue';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
 import RichTextSelectContent from '@/components/RichTextSelectContent.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSeparator,
-  FieldSet,
-} from '@/components/ui/field';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -443,6 +437,10 @@ const props = defineProps({
     type: Array as PropType<string[]>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
@@ -454,6 +452,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits<{
+  'update:open-sections': [value: string[]];
   update: [value: Partial<RichTextBoxElement>];
 }>();
 
@@ -520,7 +519,7 @@ function onModeChangeVirtualNoteChanged(value: AcceptableValue) {
 function onRunningMarkerRoleChanged(value: AcceptableValue) {
   updateElement({
     runningMarkerRole:
-      value === RUNNING_MARKER_NONE_VALUE || value == null
+      value === RUNNING_MARKER_NONE_VALUE
         ? null
         : (value as RichTextBoxElement['runningMarkerRole']),
   });

--- a/src/components/properties/PropertiesRichTextStyle.vue
+++ b/src/components/properties/PropertiesRichTextStyle.vue
@@ -1,783 +1,783 @@
 <template>
   <div ref="panelRoot" class="contents">
-    <Field>
-      <div class="flex min-h-6 items-center justify-between gap-2">
-        <FieldLabel :for="`${idPrefix}-font`">{{
-          $t(($) => $.dialog.pageSetup.font, { ns: 'dialog' })
-        }}</FieldLabel>
-        <!--
+    <PaneSection
+      value="style"
+      :title="$t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })"
+    >
+      <Field>
+        <div class="flex min-h-6 items-center justify-between gap-2">
+          <FieldLabel :for="`${idPrefix}-font`">{{
+            $t(($) => $.dialog.pageSetup.font, { ns: 'dialog' })
+          }}</FieldLabel>
+          <!--
           Keep the action mounted so controls do not shift when formatting is
           removed; disable it when there is no explicit value to clear. The
           wrapper still receives pointer events for disabled buttons so clicking
           an inactive clear action does not blur the active editor.
         -->
-        <AppTooltip
-          :tooltip="
-            $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
-          "
-        >
-          <span class="inline-flex" @mousedown.prevent>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              class="text-muted-foreground"
-              :aria-label="
-                $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
-              "
-              :disabled="
-                !isCommandEnabled('fontFamily') ||
-                fontFamilyValue === RICH_TEXT_DEFAULT_FONT_FAMILY
-              "
-              @click="onFontFamilyChanged(RICH_TEXT_DEFAULT_FONT_FAMILY)"
-            >
-              <PhEraser />
-            </Button>
-          </span>
-        </AppTooltip>
-      </div>
-      <FontCombobox
-        :id="`${idPrefix}-font`"
-        class="w-full max-w-full"
-        :model-value="fontFamilyValue"
-        :options="fontFamilyOptions"
-        :selected-label-class="
-          fontFamilyValue === RICH_TEXT_DEFAULT_FONT_FAMILY
-            ? 'text-muted-foreground'
-            : undefined
-        "
-        :disabled="!isCommandEnabled('fontFamily')"
-        rich-text-portal
-        @update:model-value="onFontFamilyChanged"
-        @update:open="
-          $event
-            ? beginSelectionGuard(element)
-            : endSelectionGuard(element, { refocus: true })
-        "
-      />
-    </Field>
-
-    <Field>
-      <FieldLabel :for="`${idPrefix}-font-style`">{{
-        $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
-      }}</FieldLabel>
-      <FontStyleSelect
-        :id="`${idPrefix}-font-style`"
-        class="w-full max-w-full"
-        :model-value="fontStyleValue"
-        :options="fontStyleOptions"
-        :disabled="fontStyleDisabled"
-        rich-text-portal
-        @update:model-value="onFontStyleChanged"
-        @update:open="
-          $event
-            ? beginSelectionGuard(element)
-            : endSelectionGuard(element, { refocus: true })
-        "
-      />
-    </Field>
-
-    <Field>
-      <FieldLabel :for="`${idPrefix}-language`">
-        {{ $t(($) => $.dialog.preferences.language, { ns: 'dialog' }) }}
-      </FieldLabel>
-      <Select
-        :model-value="languageSelectValue"
-        :disabled="!isCommandEnabled('textPartLanguage')"
-        @update:model-value="onLanguageChanged"
-        @update:open="
-          $event
-            ? beginSelectionGuard(element)
-            : endSelectionGuard(element, { refocus: true })
-        "
-      >
-        <SelectTrigger :id="`${idPrefix}-language`" class="w-full">
-          <SelectValue
-            :placeholder="
-              $t(($) => $.dialog.preferences.languageSystemDefault, {
-                ns: 'dialog',
-              })
+          <AppTooltip
+            :tooltip="
+              $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
             "
-          />
-        </SelectTrigger>
-        <RichTextSelectContent>
-          <SelectGroup>
-            <SelectItem :value="RICH_TEXT_NO_LANGUAGE_VALUE">
-              {{
-                $t(($) => $.dialog.preferences.languageSystemDefault, {
-                  ns: 'dialog',
-                })
-              }}
-            </SelectItem>
-            <SelectItem
-              v-for="language in languageOptions"
-              :key="language.value"
-              :value="language.value"
-              :text-value="language.title"
-            >
-              {{ language.title }}
-            </SelectItem>
-          </SelectGroup>
-        </RichTextSelectContent>
-      </Select>
-    </Field>
-
-    <Field orientation="horizontal">
-      <FieldLabel :for="`${idPrefix}-font-size`">{{
-        $t(($) => $.toolbar.initialMartyria.size, { ns: 'toolbar' })
-      }}</FieldLabel>
-      <div class="flex shrink-0 items-center gap-1">
-        <InputFontSize
-          :id="`${idPrefix}-font-size`"
-          class="w-36"
-          :model-value="fontSizeValue"
-          :disabled="!isCommandEnabled('fontSize')"
-          nullable
-          :placeholder="fontSizePlaceholder"
-          :default-value="defaultFontSize"
-          @update:model-value="onFontSizeChanged"
-          @focus-within="beginSelectionGuard(element)"
-          @blur-within="endSelectionGuard(element, { refocus: false })"
-        />
-        <AppTooltip
-          :tooltip="
-            $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
+          >
+            <span class="inline-flex" @mousedown.prevent>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                class="text-muted-foreground"
+                :aria-label="
+                  $t(($) => $.toolbar.richTextBox.removeFormat, {
+                    ns: 'toolbar',
+                  })
+                "
+                :disabled="
+                  !isCommandEnabled('fontFamily') ||
+                  fontFamilyValue === RICH_TEXT_DEFAULT_FONT_FAMILY
+                "
+                @click="onFontFamilyChanged(RICH_TEXT_DEFAULT_FONT_FAMILY)"
+              >
+                <PhEraser />
+              </Button>
+            </span>
+          </AppTooltip>
+        </div>
+        <FontCombobox
+          :id="`${idPrefix}-font`"
+          class="w-full max-w-full"
+          :model-value="fontFamilyValue"
+          :options="fontFamilyOptions"
+          :selected-label-class="
+            fontFamilyValue === RICH_TEXT_DEFAULT_FONT_FAMILY
+              ? 'text-muted-foreground'
+              : undefined
           "
-        >
-          <span class="inline-flex" @mousedown.prevent>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              class="text-muted-foreground"
-              :aria-label="
-                $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
-              "
-              :disabled="!isCommandEnabled('fontSize') || fontSizeValue == null"
-              @click="onFontSizeChanged(null)"
-            >
-              <PhEraser />
-            </Button>
-          </span>
-        </AppTooltip>
-      </div>
-    </Field>
-
-    <Field orientation="horizontal">
-      <FieldLabel :for="`${idPrefix}-font-color`">{{
-        $t(($) => $.dialog.pageSetup.color, { ns: 'dialog' })
-      }}</FieldLabel>
-      <div class="flex shrink-0 items-center gap-1">
-        <ColorPicker
-          :id="`${idPrefix}-font-color`"
-          :model-value="fontColorValue"
-          :disabled="!isCommandEnabled('fontColor')"
+          :disabled="!isCommandEnabled('fontFamily')"
           rich-text-portal
-          @update:model-value="onFontColorChanged"
+          @update:model-value="onFontFamilyChanged"
           @update:open="
             $event
               ? beginSelectionGuard(element)
               : endSelectionGuard(element, { refocus: true })
           "
         />
-        <AppTooltip
-          :tooltip="
-            $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
+      </Field>
+
+      <Field>
+        <FieldLabel :for="`${idPrefix}-font-style`">{{
+          $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
+        }}</FieldLabel>
+        <FontStyleSelect
+          :id="`${idPrefix}-font-style`"
+          class="w-full max-w-full"
+          :model-value="fontStyleValue"
+          :options="fontStyleOptions"
+          :disabled="fontStyleDisabled"
+          rich-text-portal
+          @update:model-value="onFontStyleChanged"
+          @update:open="
+            $event
+              ? beginSelectionGuard(element)
+              : endSelectionGuard(element, { refocus: true })
+          "
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel>{{
+          $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
+        }}</FieldLabel>
+        <div class="flex flex-wrap gap-1">
+          <ToggleGroup
+            type="multiple"
+            variant="outline"
+            :model-value="styleValues"
+            @update:model-value="onStyleValuesChanged"
+          >
+            <ToggleGroupItem
+              value="bold"
+              :aria-label="$t(($) => $.dialog.pageSetup.bold, { ns: 'dialog' })"
+              :disabled="!isStyleToggleEnabled('bold')"
+              @mousedown.prevent
+            >
+              <PhTextB />
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="italic"
+              :aria-label="
+                $t(($) => $.dialog.pageSetup.italic, { ns: 'dialog' })
+              "
+              :disabled="!isStyleToggleEnabled('italic')"
+              @mousedown.prevent
+            >
+              <PhTextItalic />
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="underline"
+              :aria-label="
+                $t(($) => $.toolbar.richTextBox.underline, { ns: 'toolbar' })
+              "
+              :disabled="!isStyleToggleEnabled('underline')"
+              @mousedown.prevent
+            >
+              <PhTextUnderline />
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="`${idPrefix}-font-size`">{{
+          $t(($) => $.toolbar.initialMartyria.size, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <div class="flex shrink-0 items-center gap-1">
+          <InputFontSize
+            :id="`${idPrefix}-font-size`"
+            class="w-36"
+            :model-value="fontSizeValue"
+            :disabled="!isCommandEnabled('fontSize')"
+            nullable
+            :placeholder="fontSizePlaceholder"
+            :default-value="defaultFontSize"
+            @update:model-value="onFontSizeChanged"
+            @focus-within="beginSelectionGuard(element)"
+            @blur-within="endSelectionGuard(element, { refocus: false })"
+          />
+          <AppTooltip
+            :tooltip="
+              $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
+            "
+          >
+            <span class="inline-flex" @mousedown.prevent>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                class="text-muted-foreground"
+                :aria-label="
+                  $t(($) => $.toolbar.richTextBox.removeFormat, {
+                    ns: 'toolbar',
+                  })
+                "
+                :disabled="
+                  !isCommandEnabled('fontSize') || fontSizeValue == null
+                "
+                @click="onFontSizeChanged(null)"
+              >
+                <PhEraser />
+              </Button>
+            </span>
+          </AppTooltip>
+        </div>
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="`${idPrefix}-font-color`">{{
+          $t(($) => $.dialog.pageSetup.color, { ns: 'dialog' })
+        }}</FieldLabel>
+        <div class="flex shrink-0 items-center gap-1">
+          <ColorPicker
+            :id="`${idPrefix}-font-color`"
+            :model-value="fontColorValue"
+            :disabled="!isCommandEnabled('fontColor')"
+            rich-text-portal
+            @update:model-value="onFontColorChanged"
+            @update:open="
+              $event
+                ? beginSelectionGuard(element)
+                : endSelectionGuard(element, { refocus: true })
+            "
+          />
+          <AppTooltip
+            :tooltip="
+              $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
+            "
+          >
+            <span class="inline-flex" @mousedown.prevent>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                class="text-muted-foreground"
+                :aria-label="
+                  $t(($) => $.toolbar.richTextBox.removeFormat, {
+                    ns: 'toolbar',
+                  })
+                "
+                :disabled="
+                  !isCommandEnabled('fontColor') || !fontColorHasExplicitValue
+                "
+                @click="onFontColorChanged(null)"
+              >
+                <PhEraser />
+              </Button>
+            </span>
+          </AppTooltip>
+        </div>
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel>{{
+          $t(($) => $.toolbar.common.alignment, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          :model-value="alignmentValue"
+          @update:model-value="onAlignmentChanged"
+        >
+          <AppTooltip
+            :tooltip="$t(($) => $.toolbar.common.alignLeft, { ns: 'toolbar' })"
+          >
+            <ToggleGroupItem
+              value="left"
+              :disabled="!isCommandEnabled('alignment')"
+              @mousedown.prevent
+            >
+              <PhTextAlignLeft />
+            </ToggleGroupItem>
+          </AppTooltip>
+          <AppTooltip
+            :tooltip="
+              $t(($) => $.toolbar.common.alignCenter, { ns: 'toolbar' })
+            "
+          >
+            <ToggleGroupItem
+              value="center"
+              :disabled="!isCommandEnabled('alignment')"
+              @mousedown.prevent
+            >
+              <PhTextAlignCenter />
+            </ToggleGroupItem>
+          </AppTooltip>
+          <AppTooltip
+            :tooltip="$t(($) => $.toolbar.common.alignRight, { ns: 'toolbar' })"
+          >
+            <ToggleGroupItem
+              value="right"
+              :disabled="!isCommandEnabled('alignment')"
+              @mousedown.prevent
+            >
+              <PhTextAlignRight />
+            </ToggleGroupItem>
+          </AppTooltip>
+          <AppTooltip
+            :tooltip="
+              $t(($) => $.toolbar.common.alignJustify, { ns: 'toolbar' })
+            "
+          >
+            <ToggleGroupItem
+              value="justify"
+              :disabled="!isCommandEnabled('alignment')"
+              @mousedown.prevent
+            >
+              <PhTextAlignJustify />
+            </ToggleGroupItem>
+          </AppTooltip>
+        </ToggleGroup>
+      </Field>
+
+      <Field>
+        <FieldLabel :for="`${idPrefix}-language`">
+          {{ $t(($) => $.dialog.preferences.language, { ns: 'dialog' }) }}
+        </FieldLabel>
+        <Select
+          :model-value="languageSelectValue"
+          :disabled="!isCommandEnabled('textPartLanguage')"
+          @update:model-value="onLanguageChanged"
+          @update:open="
+            $event
+              ? beginSelectionGuard(element)
+              : endSelectionGuard(element, { refocus: true })
           "
         >
-          <span class="inline-flex" @mousedown.prevent>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              class="text-muted-foreground"
-              :aria-label="
-                $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' })
+          <SelectTrigger :id="`${idPrefix}-language`" class="w-full">
+            <SelectValue
+              :placeholder="
+                $t(($) => $.dialog.preferences.languageSystemDefault, {
+                  ns: 'dialog',
+                })
               "
-              :disabled="
-                !isCommandEnabled('fontColor') || !fontColorHasExplicitValue
-              "
-              @click="onFontColorChanged(null)"
-            >
-              <PhEraser />
-            </Button>
-          </span>
-        </AppTooltip>
-      </div>
-    </Field>
+            />
+          </SelectTrigger>
+          <RichTextSelectContent>
+            <SelectGroup>
+              <SelectItem :value="RICH_TEXT_NO_LANGUAGE_VALUE">
+                {{
+                  $t(($) => $.dialog.preferences.languageSystemDefault, {
+                    ns: 'dialog',
+                  })
+                }}
+              </SelectItem>
+              <SelectItem
+                v-for="language in languageOptions"
+                :key="language.value"
+                :value="language.value"
+                :text-value="language.title"
+              >
+                {{ language.title }}
+              </SelectItem>
+            </SelectGroup>
+          </RichTextSelectContent>
+        </Select>
+      </Field>
 
-    <Field orientation="horizontal">
-      <FieldLabel>{{
-        $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
-      }}</FieldLabel>
-      <div class="flex flex-wrap gap-1">
+      <Field orientation="horizontal">
+        <FieldLabel>{{
+          $t(($) => $.toolbar.richTextBox.position, { ns: 'toolbar' })
+        }}</FieldLabel>
         <ToggleGroup
-          type="multiple"
+          type="single"
           variant="outline"
-          :model-value="styleValues"
-          @update:model-value="onStyleValuesChanged"
+          :model-value="positionValue"
+          @update:model-value="onPositionValueChanged"
         >
           <ToggleGroupItem
-            value="bold"
-            :aria-label="$t(($) => $.dialog.pageSetup.bold, { ns: 'dialog' })"
-            :disabled="!isStyleToggleEnabled('bold')"
-            @mousedown.prevent
-          >
-            <PhTextB />
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            value="italic"
-            :aria-label="$t(($) => $.dialog.pageSetup.italic, { ns: 'dialog' })"
-            :disabled="!isStyleToggleEnabled('italic')"
-            @mousedown.prevent
-          >
-            <PhTextItalic />
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            value="underline"
+            value="subscript"
             :aria-label="
-              $t(($) => $.toolbar.richTextBox.underline, { ns: 'toolbar' })
+              $t(($) => $.toolbar.richTextBox.subscript, { ns: 'toolbar' })
             "
-            :disabled="!isStyleToggleEnabled('underline')"
+            :disabled="!isCommandEnabled('subscript')"
             @mousedown.prevent
           >
-            <PhTextUnderline />
+            <PhTextSubscript />
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="superscript"
+            :aria-label="
+              $t(($) => $.toolbar.richTextBox.superscript, { ns: 'toolbar' })
+            "
+            :disabled="!isCommandEnabled('superscript')"
+            @mousedown.prevent
+          >
+            <PhTextSuperscript />
           </ToggleGroupItem>
         </ToggleGroup>
-      </div>
-    </Field>
+      </Field>
 
-    <Field orientation="horizontal">
-      <FieldLabel>{{
-        $t(($) => $.toolbar.common.alignment, { ns: 'toolbar' })
-      }}</FieldLabel>
-      <ToggleGroup
-        type="single"
-        variant="outline"
-        :model-value="alignmentValue"
-        @update:model-value="onAlignmentChanged"
-      >
-        <AppTooltip
-          :tooltip="$t(($) => $.toolbar.common.alignLeft, { ns: 'toolbar' })"
+      <Field orientation="horizontal">
+        <FieldLabel>{{
+          $t(($) => $.toolbar.richTextBox.case, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          :model-value="capsValue"
+          @update:model-value="onCapsChanged"
         >
-          <ToggleGroupItem
-            value="left"
-            :disabled="!isCommandEnabled('alignment')"
-            @mousedown.prevent
+          <AppTooltip
+            v-for="option in capsOptions"
+            :key="option.value"
+            :tooltip="option.label"
           >
-            <PhTextAlignLeft />
-          </ToggleGroupItem>
-        </AppTooltip>
-        <AppTooltip
-          :tooltip="$t(($) => $.toolbar.common.alignCenter, { ns: 'toolbar' })"
-        >
-          <ToggleGroupItem
-            value="center"
-            :disabled="!isCommandEnabled('alignment')"
-            @mousedown.prevent
-          >
-            <PhTextAlignCenter />
-          </ToggleGroupItem>
-        </AppTooltip>
-        <AppTooltip
-          :tooltip="$t(($) => $.toolbar.common.alignRight, { ns: 'toolbar' })"
-        >
-          <ToggleGroupItem
-            value="right"
-            :disabled="!isCommandEnabled('alignment')"
-            @mousedown.prevent
-          >
-            <PhTextAlignRight />
-          </ToggleGroupItem>
-        </AppTooltip>
-        <AppTooltip
-          :tooltip="$t(($) => $.toolbar.common.alignJustify, { ns: 'toolbar' })"
-        >
-          <ToggleGroupItem
-            value="justify"
-            :disabled="!isCommandEnabled('alignment')"
-            @mousedown.prevent
-          >
-            <PhTextAlignJustify />
-          </ToggleGroupItem>
-        </AppTooltip>
-      </ToggleGroup>
-    </Field>
-
-    <Field orientation="horizontal">
-      <FieldLabel>{{
-        $t(($) => $.toolbar.richTextBox.position, { ns: 'toolbar' })
-      }}</FieldLabel>
-      <ToggleGroup
-        type="single"
-        variant="outline"
-        :model-value="positionValue"
-        @update:model-value="onPositionValueChanged"
-      >
-        <ToggleGroupItem
-          value="subscript"
-          :aria-label="
-            $t(($) => $.toolbar.richTextBox.subscript, { ns: 'toolbar' })
-          "
-          :disabled="!isCommandEnabled('subscript')"
-          @mousedown.prevent
-        >
-          <PhTextSubscript />
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          value="superscript"
-          :aria-label="
-            $t(($) => $.toolbar.richTextBox.superscript, { ns: 'toolbar' })
-          "
-          :disabled="!isCommandEnabled('superscript')"
-          @mousedown.prevent
-        >
-          <PhTextSuperscript />
-        </ToggleGroupItem>
-      </ToggleGroup>
-    </Field>
-
-    <Field orientation="horizontal">
-      <FieldLabel>{{
-        $t(($) => $.toolbar.richTextBox.numbers, { ns: 'toolbar' })
-      }}</FieldLabel>
-      <ToggleGroup
-        type="single"
-        variant="outline"
-        :model-value="numericValue"
-        @update:model-value="onNumericChanged"
-      >
-        <AppTooltip
-          v-for="option in numericOptions"
-          :key="option.value"
-          :tooltip="option.label"
-        >
-          <ToggleGroupItem
-            :value="option.value"
-            :aria-label="option.label"
-            :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
-            :style="numericOptionStyle(option.value)"
-            @mousedown.prevent
-          >
-            19
-          </ToggleGroupItem>
-        </AppTooltip>
-      </ToggleGroup>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-fractions`"
-        :model-value="numericVariant.fractions !== null"
-        :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
-        @mousedown.prevent
-        @update:model-value="onFractionsChanged($event)"
-      />
-      <FieldLabel :for="`${idPrefix}-fractions`" @mousedown.prevent>
-        {{ $t(($) => $.toolbar.richTextBox.fractions, { ns: 'toolbar' }) }}
-      </FieldLabel>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-slashed-zero`"
-        :model-value="numericVariant.slashedZero"
-        :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
-        @mousedown.prevent
-        @update:model-value="onNumericFlagChanged('slashedZero', $event)"
-      />
-      <FieldLabel :for="`${idPrefix}-slashed-zero`" @mousedown.prevent>
-        {{ $t(($) => $.toolbar.richTextBox.slashedZero, { ns: 'toolbar' }) }}
-      </FieldLabel>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-ordinals`"
-        :model-value="numericVariant.ordinal"
-        :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
-        @mousedown.prevent
-        @update:model-value="onNumericFlagChanged('ordinal', $event)"
-      />
-      <FieldLabel :for="`${idPrefix}-ordinals`" @mousedown.prevent>
-        {{ $t(($) => $.toolbar.richTextBox.ordinals, { ns: 'toolbar' }) }}
-      </FieldLabel>
-    </Field>
-
-    <Field orientation="horizontal">
-      <FieldLabel>{{
-        $t(($) => $.toolbar.richTextBox.case, { ns: 'toolbar' })
-      }}</FieldLabel>
-      <ToggleGroup
-        type="single"
-        variant="outline"
-        :model-value="capsValue"
-        @update:model-value="onCapsChanged"
-      >
-        <AppTooltip
-          v-for="option in capsOptions"
-          :key="option.value"
-          :tooltip="option.label"
-        >
-          <ToggleGroupItem
-            :value="option.value"
-            :aria-label="option.label"
-            :disabled="!isCommandEnabled(FONT_VARIANT_CAPS)"
-            :style="caseOptionStyle(option.value)"
-            @mousedown.prevent
-          >
-            Aa
-          </ToggleGroupItem>
-        </AppTooltip>
-      </ToggleGroup>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-common-ligatures`"
-        :model-value="ligatureVariant.common"
-        :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
-        @mousedown.prevent
-        @update:model-value="onLigatureFlagChanged('common', $event)"
-      />
-      <FieldLabel :for="`${idPrefix}-common-ligatures`" @mousedown.prevent>
-        {{
-          $t(($) => $.toolbar.richTextBox.commonLigatures, { ns: 'toolbar' })
-        }}
-      </FieldLabel>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-discretionary-ligatures`"
-        :model-value="ligatureVariant.discretionary"
-        :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
-        @mousedown.prevent
-        @update:model-value="onLigatureFlagChanged('discretionary', $event)"
-      />
-      <FieldLabel
-        :for="`${idPrefix}-discretionary-ligatures`"
-        @mousedown.prevent
-      >
-        {{
-          $t(($) => $.toolbar.richTextBox.discretionaryLigatures, {
-            ns: 'toolbar',
-          })
-        }}
-      </FieldLabel>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-historical-ligatures`"
-        :model-value="ligatureVariant.historical"
-        :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
-        @mousedown.prevent
-        @update:model-value="onLigatureFlagChanged('historical', $event)"
-      />
-      <FieldLabel :for="`${idPrefix}-historical-ligatures`" @mousedown.prevent>
-        {{
-          $t(($) => $.toolbar.richTextBox.historicalLigatures, {
-            ns: 'toolbar',
-          })
-        }}
-      </FieldLabel>
-    </Field>
-
-    <Field orientation="horizontal">
-      <Switch
-        :id="`${idPrefix}-contextual-alternates`"
-        :model-value="ligatureVariant.contextual"
-        :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
-        @mousedown.prevent
-        @update:model-value="onLigatureFlagChanged('contextual', $event)"
-      />
-      <FieldLabel :for="`${idPrefix}-contextual-alternates`" @mousedown.prevent>
-        {{
-          $t(($) => $.toolbar.richTextBox.contextualAlternates, {
-            ns: 'toolbar',
-          })
-        }}
-      </FieldLabel>
-    </Field>
-
-    <Button
-      type="button"
-      variant="secondary"
-      :disabled="!isCommandEnabled('removeFormat')"
-      @mousedown.prevent
-      @click="onRemoveFormat"
-    >
-      <PhEraser data-icon="inline-start" />
-      {{ $t(($) => $.toolbar.richTextBox.removeFormat, { ns: 'toolbar' }) }}
-    </Button>
-
-    <template v-if="isNeumeSelected">
-      <FieldSeparator />
-
-      <FieldSet>
-        <FieldLegend variant="label">{{
-          $t(($) => $.toolbar.richTextBox.neumeAttributes, { ns: 'toolbar' })
-        }}</FieldLegend>
-        <FieldGroup>
-          <template v-if="neumeType === 'martyria'">
-            <Field>
-              <FieldLabel
-                :for="neumeFieldId('martyria-note')"
-                @mousedown.prevent
-              >
-                {{
-                  $t(($) => $.toolbar.richTextBox.martyriaNote, {
-                    ns: 'toolbar',
-                  })
-                }}
-              </FieldLabel>
-              <Select
-                :model-value="neumeMartyriaNote"
-                @update:model-value="onNeumeMartyriaNoteChanged"
-              >
-                <SelectTrigger
-                  :id="neumeFieldId('martyria-note')"
-                  class="w-full"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <RichTextSelectContent>
-                  <SelectGroup>
-                    <SelectItem
-                      v-for="note in martyriaNotes"
-                      :key="note.key"
-                      :value="note.key"
-                    >
-                      {{ $t(note.displayName, { ns: 'model' }) }}
-                    </SelectItem>
-                  </SelectGroup>
-                </RichTextSelectContent>
-              </Select>
-            </Field>
-
-            <Field>
-              <FieldLabel
-                :for="neumeFieldId('martyria-root-sign')"
-                @mousedown.prevent
-              >
-                {{
-                  $t(($) => $.toolbar.richTextBox.martyriaSign, {
-                    ns: 'toolbar',
-                  })
-                }}
-              </FieldLabel>
-              <Select
-                :model-value="neumeMartyriaRootSign"
-                @update:model-value="onNeumeMartyriaRootSignChanged"
-              >
-                <SelectTrigger
-                  :id="neumeFieldId('martyria-root-sign')"
-                  class="w-full"
-                >
-                  <SelectValue>
-                    <span
-                      v-if="selectedMartyriaRootSign"
-                      class="root-sign-option"
-                    >
-                      <span class="root-sign-glyph" :style="neumeGlyphStyle">{{
-                        selectedMartyriaRootSign.glyph
-                      }}</span>
-                      <span class="root-sign-name">{{
-                        $t(selectedMartyriaRootSign.name, { ns: 'model' })
-                      }}</span>
-                    </span>
-                  </SelectValue>
-                </SelectTrigger>
-                <RichTextSelectContent>
-                  <SelectGroup>
-                    <SelectItem
-                      v-for="rootSign in martyriaRootSigns"
-                      :key="rootSign.key"
-                      :value="rootSign.key"
-                      :text-value="$t(rootSign.name, { ns: 'model' })"
-                    >
-                      <span class="root-sign-option">
-                        <span
-                          class="root-sign-glyph"
-                          :style="neumeGlyphStyle"
-                          >{{ rootSign.glyph }}</span
-                        >
-                        <span class="root-sign-name">{{
-                          $t(rootSign.name, { ns: 'model' })
-                        }}</span>
-                      </span>
-                    </SelectItem>
-                  </SelectGroup>
-                </RichTextSelectContent>
-              </Select>
-            </Field>
-          </template>
-
-          <Field orientation="horizontal">
-            <Switch
-              :id="neumeFieldId('align-right')"
-              :model-value="neumeAlignRight"
+            <ToggleGroupItem
+              :value="option.value"
+              :aria-label="option.label"
+              :disabled="!isCommandEnabled(FONT_VARIANT_CAPS)"
+              :style="caseOptionStyle(option.value)"
               @mousedown.prevent
-              @update:model-value="onNeumeAlignRightChanged"
-            />
-            <FieldLabel :for="neumeFieldId('align-right')" @mousedown.prevent>
-              {{ $t(($) => $.toolbar.common.alignRight, { ns: 'toolbar' }) }}
-            </FieldLabel>
-          </Field>
+            >
+              Aa
+            </ToggleGroupItem>
+          </AppTooltip>
+        </ToggleGroup>
+      </Field>
 
-          <Field orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('top')">{{
-              $t(($) => $.dialog.common.top, { ns: 'dialog' })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('top')"
-              class="w-28"
-              unit="unitless"
-              :model-value="neumeTop"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="updateNeumeNumberAttribute('top', $event)"
-            />
-          </Field>
+      <Field orientation="horizontal">
+        <FieldLabel>{{
+          $t(($) => $.toolbar.richTextBox.numbers, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          :model-value="numericValue"
+          @update:model-value="onNumericChanged"
+        >
+          <AppTooltip
+            v-for="option in numericOptions"
+            :key="option.value"
+            :tooltip="option.label"
+          >
+            <ToggleGroupItem
+              :value="option.value"
+              :aria-label="option.label"
+              :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
+              :style="numericOptionStyle(option.value)"
+              @mousedown.prevent
+            >
+              19
+            </ToggleGroupItem>
+          </AppTooltip>
+        </ToggleGroup>
+      </Field>
 
-          <Field v-if="neumeAlignRight" orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('right')">{{
-              $t(($) => $.dialog.common.right, { ns: 'dialog' })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('right')"
-              class="w-28"
-              unit="unitless"
-              :model-value="neumeRight"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="updateNeumeNumberAttribute('right', $event)"
-            />
-          </Field>
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-fractions`"
+          :model-value="numericVariant.fractions !== null"
+          :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
+          @mousedown.prevent
+          @update:model-value="onFractionsChanged($event)"
+        />
+        <FieldLabel :for="`${idPrefix}-fractions`" @mousedown.prevent>
+          {{ $t(($) => $.toolbar.richTextBox.fractions, { ns: 'toolbar' }) }}
+        </FieldLabel>
+      </Field>
 
-          <Field v-else orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('left')">{{
-              $t(($) => $.dialog.common.left, { ns: 'dialog' })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('left')"
-              class="w-28"
-              unit="unitless"
-              :model-value="neumeLeft"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="updateNeumeNumberAttribute('left', $event)"
-            />
-          </Field>
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-slashed-zero`"
+          :model-value="numericVariant.slashedZero"
+          :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
+          @mousedown.prevent
+          @update:model-value="onNumericFlagChanged('slashedZero', $event)"
+        />
+        <FieldLabel :for="`${idPrefix}-slashed-zero`" @mousedown.prevent>
+          {{ $t(($) => $.toolbar.richTextBox.slashedZero, { ns: 'toolbar' }) }}
+        </FieldLabel>
+      </Field>
 
-          <Field orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('kerning-left')">{{
-              $t(($) => $.toolbar.richTextBox.kerningLeft, { ns: 'toolbar' })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('kerning-left')"
-              class="w-28"
-              unit="unitless"
-              :model-value="neumeKerningLeft"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="
-                updateNeumeNumberAttribute('kerningLeft', $event)
-              "
-            />
-          </Field>
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-ordinals`"
+          :model-value="numericVariant.ordinal"
+          :disabled="!isCommandEnabled(FONT_VARIANT_NUMERIC)"
+          @mousedown.prevent
+          @update:model-value="onNumericFlagChanged('ordinal', $event)"
+        />
+        <FieldLabel :for="`${idPrefix}-ordinals`" @mousedown.prevent>
+          {{ $t(($) => $.toolbar.richTextBox.ordinals, { ns: 'toolbar' }) }}
+        </FieldLabel>
+      </Field>
 
-          <Field orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('kerning-right')">{{
-              $t(($) => $.toolbar.richTextBox.kerningRight, { ns: 'toolbar' })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('kerning-right')"
-              class="w-28"
-              unit="unitless"
-              :model-value="neumeKerningRight"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="
-                updateNeumeNumberAttribute('kerningRight', $event)
-              "
-            />
-          </Field>
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-common-ligatures`"
+          :model-value="ligatureVariant.common"
+          :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
+          @mousedown.prevent
+          @update:model-value="onLigatureFlagChanged('common', $event)"
+        />
+        <FieldLabel :for="`${idPrefix}-common-ligatures`" @mousedown.prevent>
+          {{
+            $t(($) => $.toolbar.richTextBox.commonLigatures, { ns: 'toolbar' })
+          }}
+        </FieldLabel>
+      </Field>
 
-          <Field orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('width')">{{
-              $t(($) => $.toolbar.common.width, { ns: 'toolbar' })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('width')"
-              class="w-28"
-              unit="unitless"
-              :nullable="true"
-              :min="0"
-              :model-value="neumeWidth"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              placeholder="auto"
-              @update:model-value="updateNeumeAttributes({ width: $event })"
-            />
-          </Field>
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-discretionary-ligatures`"
+          :model-value="ligatureVariant.discretionary"
+          :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
+          @mousedown.prevent
+          @update:model-value="onLigatureFlagChanged('discretionary', $event)"
+        />
+        <FieldLabel
+          :for="`${idPrefix}-discretionary-ligatures`"
+          @mousedown.prevent
+        >
+          {{
+            $t(($) => $.toolbar.richTextBox.discretionaryLigatures, {
+              ns: 'toolbar',
+            })
+          }}
+        </FieldLabel>
+      </Field>
 
-          <Field orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('font-size')">{{
-              $t(($) => $.toolbar.richTextBox.neumeFontSize, {
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-historical-ligatures`"
+          :model-value="ligatureVariant.historical"
+          :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
+          @mousedown.prevent
+          @update:model-value="onLigatureFlagChanged('historical', $event)"
+        />
+        <FieldLabel
+          :for="`${idPrefix}-historical-ligatures`"
+          @mousedown.prevent
+        >
+          {{
+            $t(($) => $.toolbar.richTextBox.historicalLigatures, {
+              ns: 'toolbar',
+            })
+          }}
+        </FieldLabel>
+      </Field>
+
+      <Field orientation="horizontal">
+        <Switch
+          :id="`${idPrefix}-contextual-alternates`"
+          :model-value="ligatureVariant.contextual"
+          :disabled="!isCommandEnabled(FONT_VARIANT_LIGATURES)"
+          @mousedown.prevent
+          @update:model-value="onLigatureFlagChanged('contextual', $event)"
+        />
+        <FieldLabel
+          :for="`${idPrefix}-contextual-alternates`"
+          @mousedown.prevent
+        >
+          {{
+            $t(($) => $.toolbar.richTextBox.contextualAlternates, {
+              ns: 'toolbar',
+            })
+          }}
+        </FieldLabel>
+      </Field>
+    </PaneSection>
+
+    <PaneSection
+      v-if="isNeumeSelected"
+      value="neume-attributes"
+      :title="
+        $t(($) => $.toolbar.richTextBox.neumeAttributes, { ns: 'toolbar' })
+      "
+    >
+      <template v-if="neumeType === 'martyria'">
+        <Field>
+          <FieldLabel :for="neumeFieldId('martyria-note')" @mousedown.prevent>
+            {{
+              $t(($) => $.toolbar.richTextBox.martyriaNote, {
                 ns: 'toolbar',
               })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('font-size')"
-              class="w-28"
-              unit="unitless"
-              :min="0"
-              :model-value="neumeFontSize"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="
-                updateNeumeNumberAttribute('neumeFontSize', $event, 1)
-              "
-            />
-          </Field>
+            }}
+          </FieldLabel>
+          <Select
+            :model-value="neumeMartyriaNote"
+            @update:model-value="onNeumeMartyriaNoteChanged"
+          >
+            <SelectTrigger :id="neumeFieldId('martyria-note')" class="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <RichTextSelectContent>
+              <SelectGroup>
+                <SelectItem
+                  v-for="note in martyriaNotes"
+                  :key="note.key"
+                  :value="note.key"
+                >
+                  {{ $t(note.displayName, { ns: 'model' }) }}
+                </SelectItem>
+              </SelectGroup>
+            </RichTextSelectContent>
+          </Select>
+        </Field>
 
-          <Field v-if="neumeType === 'plagal'" orientation="horizontal">
-            <FieldLabel :for="neumeFieldId('line-height')">{{
-              $t(($) => $.dialog.pageSetup.lineHeight, {
-                ns: 'dialog',
+        <Field>
+          <FieldLabel
+            :for="neumeFieldId('martyria-root-sign')"
+            @mousedown.prevent
+          >
+            {{
+              $t(($) => $.toolbar.richTextBox.martyriaSign, {
+                ns: 'toolbar',
               })
-            }}</FieldLabel>
-            <InputUnit
-              :id="neumeFieldId('line-height')"
-              class="w-28"
-              unit="unitless"
-              :min="0"
-              :model-value="neumeLineHeight"
-              :step="0.05"
-              :format-options="fraction3FormatOptions"
-              @update:model-value="
-                updateNeumeNumberAttribute('neumeLineHeight', $event, 1)
-              "
-            />
-          </Field>
+            }}
+          </FieldLabel>
+          <Select
+            :model-value="neumeMartyriaRootSign"
+            @update:model-value="onNeumeMartyriaRootSignChanged"
+          >
+            <SelectTrigger
+              :id="neumeFieldId('martyria-root-sign')"
+              class="w-full"
+            >
+              <SelectValue>
+                <span v-if="selectedMartyriaRootSign" class="root-sign-option">
+                  <span class="root-sign-glyph" :style="neumeGlyphStyle">{{
+                    selectedMartyriaRootSign.glyph
+                  }}</span>
+                  <span class="root-sign-name">{{
+                    $t(selectedMartyriaRootSign.name, { ns: 'model' })
+                  }}</span>
+                </span>
+              </SelectValue>
+            </SelectTrigger>
+            <RichTextSelectContent>
+              <SelectGroup>
+                <SelectItem
+                  v-for="rootSign in martyriaRootSigns"
+                  :key="rootSign.key"
+                  :value="rootSign.key"
+                  :text-value="$t(rootSign.name, { ns: 'model' })"
+                >
+                  <span class="root-sign-option">
+                    <span class="root-sign-glyph" :style="neumeGlyphStyle">{{
+                      rootSign.glyph
+                    }}</span>
+                    <span class="root-sign-name">{{
+                      $t(rootSign.name, { ns: 'model' })
+                    }}</span>
+                  </span>
+                </SelectItem>
+              </SelectGroup>
+            </RichTextSelectContent>
+          </Select>
+        </Field>
+      </template>
 
-          <Field orientation="horizontal">
-            <FieldLabel @mousedown.prevent>{{
-              $t(($) => $.dialog.pageSetup.color, { ns: 'dialog' })
-            }}</FieldLabel>
-            <ColorPicker
-              :model-value="neumeColor"
-              :default-colors="neumeDefaultColors"
-              history-key="richTextNeumeColorPicker_presetColors"
-              rich-text-portal
-              @update:model-value="updateNeumeAttributes({ color: $event })"
-            />
-          </Field>
-        </FieldGroup>
-      </FieldSet>
-    </template>
+      <Field orientation="horizontal">
+        <Switch
+          :id="neumeFieldId('align-right')"
+          :model-value="neumeAlignRight"
+          @mousedown.prevent
+          @update:model-value="onNeumeAlignRightChanged"
+        />
+        <FieldLabel :for="neumeFieldId('align-right')" @mousedown.prevent>
+          {{ $t(($) => $.toolbar.common.alignRight, { ns: 'toolbar' }) }}
+        </FieldLabel>
+      </Field>
+
+      <Field v-if="neumeAlignRight" orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('right')">{{
+          $t(($) => $.dialog.common.right, { ns: 'dialog' })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('right')"
+          class="w-28"
+          unit="unitless"
+          :model-value="neumeRight"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="updateNeumeNumberAttribute('right', $event)"
+        />
+      </Field>
+
+      <Field v-else orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('left')">{{
+          $t(($) => $.dialog.common.left, { ns: 'dialog' })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('left')"
+          class="w-28"
+          unit="unitless"
+          :model-value="neumeLeft"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="updateNeumeNumberAttribute('left', $event)"
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('top')">{{
+          $t(($) => $.dialog.common.top, { ns: 'dialog' })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('top')"
+          class="w-28"
+          unit="unitless"
+          :model-value="neumeTop"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="updateNeumeNumberAttribute('top', $event)"
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('width')">{{
+          $t(($) => $.toolbar.common.width, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('width')"
+          class="w-28"
+          unit="unitless"
+          :nullable="true"
+          :min="0"
+          :model-value="neumeWidth"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          placeholder="auto"
+          @update:model-value="updateNeumeAttributes({ width: $event })"
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('font-size')">{{
+          $t(($) => $.toolbar.richTextBox.neumeFontSize, {
+            ns: 'toolbar',
+          })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('font-size')"
+          class="w-28"
+          unit="unitless"
+          :min="0"
+          :model-value="neumeFontSize"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="
+            updateNeumeNumberAttribute('neumeFontSize', $event, 1)
+          "
+        />
+      </Field>
+
+      <Field v-if="neumeType === 'plagal'" orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('line-height')">{{
+          $t(($) => $.dialog.pageSetup.lineHeight, {
+            ns: 'dialog',
+          })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('line-height')"
+          class="w-28"
+          unit="unitless"
+          :min="0"
+          :model-value="neumeLineHeight"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="
+            updateNeumeNumberAttribute('neumeLineHeight', $event, 1)
+          "
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('kerning-left')">{{
+          $t(($) => $.toolbar.richTextBox.kerningLeft, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('kerning-left')"
+          class="w-28"
+          unit="unitless"
+          :model-value="neumeKerningLeft"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="
+            updateNeumeNumberAttribute('kerningLeft', $event)
+          "
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel :for="neumeFieldId('kerning-right')">{{
+          $t(($) => $.toolbar.richTextBox.kerningRight, { ns: 'toolbar' })
+        }}</FieldLabel>
+        <InputUnit
+          :id="neumeFieldId('kerning-right')"
+          class="w-28"
+          unit="unitless"
+          :model-value="neumeKerningRight"
+          :step="0.05"
+          :format-options="fraction3FormatOptions"
+          @update:model-value="
+            updateNeumeNumberAttribute('kerningRight', $event)
+          "
+        />
+      </Field>
+
+      <Field orientation="horizontal">
+        <FieldLabel @mousedown.prevent>{{
+          $t(($) => $.dialog.pageSetup.color, { ns: 'dialog' })
+        }}</FieldLabel>
+        <ColorPicker
+          :model-value="neumeColor"
+          :default-colors="neumeDefaultColors"
+          history-key="richTextNeumeColorPicker_presetColors"
+          rich-text-portal
+          @update:model-value="updateNeumeAttributes({ color: $event })"
+        />
+      </Field>
+    </PaneSection>
   </div>
 </template>
 
@@ -821,16 +821,10 @@ import FontCombobox from '@/components/FontCombobox.vue';
 import FontStyleSelect from '@/components/FontStyleSelect.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
 import InputUnit from '@/components/InputUnit.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
 import RichTextSelectContent from '@/components/RichTextSelectContent.vue';
 import { Button } from '@/components/ui/button';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSeparator,
-  FieldSet,
-} from '@/components/ui/field';
+import { Field, FieldLabel } from '@/components/ui/field';
 import {
   Select,
   SelectGroup,
@@ -900,11 +894,9 @@ const {
   onFontColorChanged,
   onStyleValuesChanged,
   onAlignmentChanged,
-  onRemoveFormat,
 } = useRichTextStyleCommands(props, [
   'subscript',
   'superscript',
-  'removeFormat',
   'textPartLanguage',
   FONT_VARIANT_NUMERIC,
   FONT_VARIANT_LIGATURES,

--- a/src/components/properties/PropertiesTempo.vue
+++ b/src/components/properties/PropertiesTempo.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.toolbar.common.tempoSign, { ns: 'toolbar' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="tempo"
+      :title="$t(($) => $.toolbar.common.tempoSign, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <FieldLabel for="properties-tempo-bpm">{{
           $t(($) => $.toolbar.common.bpm, { ns: 'toolbar' })
@@ -16,7 +23,12 @@
           "
         />
       </Field>
+    </PaneSection>
 
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
       <Field orientation="horizontal">
         <FieldLabel for="properties-tempo-space-after">{{
           $t(($) => $.toolbar.common.spaceAfter, { ns: 'toolbar' })
@@ -34,8 +46,8 @@
           "
         />
       </Field>
-    </FieldGroup>
-  </FieldSet>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -44,13 +56,9 @@ import { computed } from 'vue';
 
 import InputBpm from '@/components/InputBpm.vue';
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import type { TempoElement } from '@/models/Element';
 import type { PageSetup } from '@/models/PageSetup';
 import { fraction2FormatOptions } from '@/utils/numberFormatOptions';
@@ -61,13 +69,17 @@ const props = defineProps({
     type: Object as PropType<TempoElement>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
   },
 });
 
-defineEmits(['update']);
+defineEmits(['update', 'update:open-sections']);
 
 const spaceAfterMax = computed(() =>
   Math.round(Unit.toPt(props.pageSetup.pageWidth)),

--- a/src/components/properties/PropertiesTextBox.vue
+++ b/src/components/properties/PropertiesTextBox.vue
@@ -1,9 +1,16 @@
 <template>
-  <FieldSet class="min-h-0 flex-1 overflow-auto">
-    <FieldLegend class="sr-only">{{
+  <PaneAccordion
+    :open-sections="openSections"
+    @update:open-sections="$emit('update:open-sections', $event)"
+  >
+    <template #legend>{{
       $t(($) => $.menu.insert.textBox, { ns: 'menu' })
-    }}</FieldLegend>
-    <FieldGroup>
+    }}</template>
+
+    <PaneSection
+      value="style"
+      :title="$t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })"
+    >
       <Field orientation="horizontal">
         <Switch
           id="properties-text-box-use-default-style"
@@ -52,6 +59,36 @@
         </Field>
 
         <Field orientation="horizontal">
+          <FieldLabel>{{
+            $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
+          }}</FieldLabel>
+          <ToggleGroup
+            type="multiple"
+            variant="outline"
+            :model-value="styleValues"
+            @update:model-value="onStyleValuesChanged"
+          >
+            <ToggleGroupItem
+              value="bold"
+              aria-label="Toggle bold"
+              :disabled="!isFontStyleAxisToggleEnabled('bold')"
+            >
+              <PhTextB />
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="italic"
+              aria-label="Toggle italic"
+              :disabled="!isFontStyleAxisToggleEnabled('italic')"
+            >
+              <PhTextItalic />
+            </ToggleGroupItem>
+            <ToggleGroupItem value="underline" aria-label="Toggle underline">
+              <PhTextUnderline />
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </Field>
+
+        <Field orientation="horizontal">
           <FieldLabel for="properties-text-box-font-size">{{
             $t(($) => $.toolbar.initialMartyria.size, { ns: 'toolbar' })
           }}</FieldLabel>
@@ -93,36 +130,6 @@
               $emit('update', { color: $event } as Partial<TextBoxElement>)
             "
           />
-        </Field>
-
-        <Field orientation="horizontal">
-          <FieldLabel>{{
-            $t(($) => $.dialog.pageSetup.style, { ns: 'dialog' })
-          }}</FieldLabel>
-          <ToggleGroup
-            type="multiple"
-            variant="outline"
-            :model-value="styleValues"
-            @update:model-value="onStyleValuesChanged"
-          >
-            <ToggleGroupItem
-              value="bold"
-              aria-label="Toggle bold"
-              :disabled="!isFontStyleAxisToggleEnabled('bold')"
-            >
-              <PhTextB />
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="italic"
-              aria-label="Toggle italic"
-              :disabled="!isFontStyleAxisToggleEnabled('italic')"
-            >
-              <PhTextItalic />
-            </ToggleGroupItem>
-            <ToggleGroupItem value="underline" aria-label="Toggle underline">
-              <PhTextUnderline />
-            </ToggleGroupItem>
-          </ToggleGroup>
         </Field>
 
         <Field orientation="horizontal">
@@ -192,23 +199,28 @@
           </AppTooltip>
         </ToggleGroup>
       </Field>
+    </PaneSection>
+
+    <PaneSection
+      value="positioning"
+      :title="$t(($) => $.toolbar.neume.positioning, { ns: 'toolbar' })"
+    >
+      <Field v-if="!element.inline" orientation="horizontal">
+        <Switch
+          id="properties-text-box-multipanel"
+          :model-value="element.multipanel"
+          @update:model-value="
+            $emit('update', {
+              multipanel: $event === true,
+            } as Partial<TextBoxElement>)
+          "
+        />
+        <FieldLabel for="properties-text-box-multipanel">{{
+          $t(($) => $.toolbar.textbox.multipanel, { ns: 'toolbar' })
+        }}</FieldLabel>
+      </Field>
 
       <template v-if="!element.inline">
-        <Field orientation="horizontal">
-          <Switch
-            id="properties-text-box-multipanel"
-            :model-value="element.multipanel"
-            @update:model-value="
-              $emit('update', {
-                multipanel: $event === true,
-              } as Partial<TextBoxElement>)
-            "
-          />
-          <FieldLabel for="properties-text-box-multipanel">{{
-            $t(($) => $.toolbar.textbox.multipanel, { ns: 'toolbar' })
-          }}</FieldLabel>
-        </Field>
-
         <Field v-if="!element.multipanel" orientation="horizontal">
           <FieldLabel for="properties-text-box-height">{{
             $t(($) => $.toolbar.common.height, { ns: 'toolbar' })
@@ -308,76 +320,69 @@
           "
         />
       </Field>
+    </PaneSection>
 
-      <template v-if="source === 'score'">
-        <FieldSeparator />
-
-        <FieldSet>
-          <FieldLegend variant="label">{{
-            $t(($) => $.toolbar.textbox.runningMarker, { ns: 'toolbar' })
-          }}</FieldLegend>
-          <FieldGroup>
-            <Field>
-              <FieldLabel for="properties-text-box-running-marker-role">{{
-                $t(($) => $.toolbar.textbox.runningMarkerRole, {
-                  ns: 'toolbar',
-                })
-              }}</FieldLabel>
-              <Select
-                :model-value="
-                  element.runningMarkerRole ?? RUNNING_MARKER_NONE_VALUE
-                "
-                @update:model-value="onRunningMarkerRoleChanged"
-              >
-                <SelectTrigger id="properties-text-box-running-marker-role">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectItem :value="RUNNING_MARKER_NONE_VALUE">
-                      {{ $t(($) => $.toolbar.common.none, { ns: 'toolbar' }) }}
-                    </SelectItem>
-                    <SelectItem value="chapter">
-                      {{
-                        $t(($) => $.toolbar.textbox.runningMarkerChapter, {
-                          ns: 'toolbar',
-                        })
-                      }}
-                    </SelectItem>
-                    <SelectItem value="section">
-                      {{
-                        $t(($) => $.toolbar.textbox.runningMarkerSection, {
-                          ns: 'toolbar',
-                        })
-                      }}
-                    </SelectItem>
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-
-            <Field>
-              <FieldLabel for="properties-text-box-running-marker-text">{{
-                $t(($) => $.toolbar.textbox.runningMarkerText, {
-                  ns: 'toolbar',
-                })
-              }}</FieldLabel>
-              <Input
-                id="properties-text-box-running-marker-text"
-                :model-value="element.runningMarkerText ?? ''"
-                :placeholder="
-                  $t(($) => $.toolbar.textbox.runningMarkerTextPlaceholder, {
+    <PaneSection
+      v-if="source === 'score'"
+      value="running-marker"
+      :title="$t(($) => $.toolbar.textbox.runningMarker, { ns: 'toolbar' })"
+    >
+      <Field>
+        <FieldLabel for="properties-text-box-running-marker-role">{{
+          $t(($) => $.toolbar.textbox.runningMarkerRole, {
+            ns: 'toolbar',
+          })
+        }}</FieldLabel>
+        <Select
+          :model-value="element.runningMarkerRole ?? RUNNING_MARKER_NONE_VALUE"
+          @update:model-value="onRunningMarkerRoleChanged"
+        >
+          <SelectTrigger id="properties-text-box-running-marker-role">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem :value="RUNNING_MARKER_NONE_VALUE">
+                {{ $t(($) => $.toolbar.common.none, { ns: 'toolbar' }) }}
+              </SelectItem>
+              <SelectItem value="chapter">
+                {{
+                  $t(($) => $.toolbar.textbox.runningMarkerChapter, {
                     ns: 'toolbar',
                   })
-                "
-                @update:model-value="onRunningMarkerTextChanged"
-              />
-            </Field>
-          </FieldGroup>
-        </FieldSet>
-      </template>
-    </FieldGroup>
-  </FieldSet>
+                }}
+              </SelectItem>
+              <SelectItem value="section">
+                {{
+                  $t(($) => $.toolbar.textbox.runningMarkerSection, {
+                    ns: 'toolbar',
+                  })
+                }}
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Field>
+        <FieldLabel for="properties-text-box-running-marker-text">{{
+          $t(($) => $.toolbar.textbox.runningMarkerText, {
+            ns: 'toolbar',
+          })
+        }}</FieldLabel>
+        <Input
+          id="properties-text-box-running-marker-text"
+          :model-value="element.runningMarkerText ?? ''"
+          :placeholder="
+            $t(($) => $.toolbar.textbox.runningMarkerTextPlaceholder, {
+              ns: 'toolbar',
+            })
+          "
+          @update:model-value="onRunningMarkerTextChanged"
+        />
+      </Field>
+    </PaneSection>
+  </PaneAccordion>
 </template>
 
 <script setup lang="ts">
@@ -400,14 +405,9 @@ import FontStyleSelect from '@/components/FontStyleSelect.vue';
 import InputFontSize from '@/components/InputFontSize.vue';
 import InputStrokeWidth from '@/components/InputStrokeWidth.vue';
 import InputUnit from '@/components/InputUnit.vue';
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSeparator,
-  FieldSet,
-} from '@/components/ui/field';
+import PaneAccordion from '@/components/pane/PaneAccordion.vue';
+import PaneSection from '@/components/pane/PaneSection.vue';
+import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -439,6 +439,10 @@ const props = defineProps({
     type: Array as PropType<string[]>,
     required: true,
   },
+  openSections: {
+    type: Array as PropType<string[]>,
+    required: true,
+  },
   pageSetup: {
     type: Object as PropType<PageSetup>,
     required: true,
@@ -449,7 +453,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['update']);
+const emit = defineEmits(['update', 'update:open-sections']);
 
 const {
   fontStyleOptions,
@@ -507,7 +511,7 @@ function onAlignmentChanged(value: unknown) {
 function onRunningMarkerRoleChanged(value: AcceptableValue) {
   emit('update', {
     runningMarkerRole:
-      value === RUNNING_MARKER_NONE_VALUE || value == null
+      value === RUNNING_MARKER_NONE_VALUE
         ? null
         : (value as TextBoxElement['runningMarkerRole']),
   } as Partial<TextBoxElement>);

--- a/src/models/EditorEnvironment.ts
+++ b/src/models/EditorEnvironment.ts
@@ -6,6 +6,19 @@ export const DEFAULT_PANE_ACCORDION_STATE: Partial<
   Record<WorkspacePaneId, string[]>
 > = {
   developer: ['display', 'line', 'inspector'],
+  properties: [
+    'style',
+    'size',
+    'positioning',
+    'neume',
+    'tempo',
+    'martyria',
+    'initial-martyria',
+    'mode-change',
+    'running-marker',
+    'scrollable',
+    'neume-attributes',
+  ],
 };
 
 export type EditorPaneLayout = {
@@ -107,7 +120,7 @@ function persistPaneAccordionState(
 
     if (
       openSections != null &&
-      !arraysAreEqual(
+      !arraysHaveSameValues(
         openSections,
         DEFAULT_PANE_ACCORDION_STATE[definition.id] ?? [],
       )
@@ -121,6 +134,12 @@ function persistPaneAccordionState(
     : { paneAccordionState: persistedState };
 }
 
-function arraysAreEqual(a: readonly string[], b: readonly string[]) {
-  return a.length === b.length && a.every((value, index) => value === b[index]);
+function arraysHaveSameValues(a: readonly string[], b: readonly string[]) {
+  const values = new Set(a);
+  const otherValues = new Set(b);
+
+  return (
+    values.size === otherValues.size &&
+    [...values].every((value) => otherValues.has(value))
+  );
 }


### PR DESCRIPTION
The properties panes were getting unwieldy with all the new recently added features. I liked the use of accordions in the developer pane, so I generalized that to a standard abstraction used throughout all the properties panes:

- Introduce shared `PaneAccordion` / `PaneSection` components with section registration so pane open-state can be controlled while preserving hidden section state across element changes.
- Convert the developer pane and per-element properties panes to grouped collapsible sections, including style, size, positioning, tempo, martyria, mode-change, running-marker, scrollable, and rich-text neume-attribute sections.
- Persist default properties-pane accordion state through the editor environment, compare persisted section sets order-independently, and document the new pane section behavior.
- Move the global rich-text remove-format action to the floating rich-text toolbar while keeping per-field clear actions in the properties rich-text style panel.