### PR TITLE
fix: right pane hides new tab button

### DIFF
--- a/notes/dockview_vue.md
+++ b/notes/dockview_vue.md
@@ -633,6 +633,12 @@ re-renders for the selected workspace), but the dock structure -- edges, panes, 
 floating windows -- is untouched. Panel arrangement is a property of the editor
 session, not of any document.
 
+The center panel also hosts the workspace tab strip. Because Dockview can change the
+center width when edge panes open, close, resize, or restore without a window resize,
+`TheEditor.vue` observes the tab-strip host and schedules `Vue3TabsChrome.doLayout()`
+after those geometry changes settle. That keeps the tab widths in sync with the live
+center pane without storing any extra layout state.
+
 ### 5.3 The menu sync (the one cross-process channel)
 
 The cross-process state wiring keeps the OS application menu's checkboxes in

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -266,6 +266,7 @@ import { withZoom } from '@/utils/withZoom';
 
 interface Vue3TabsChromeComponent {
   addTab: (...newTabs: Array<Tab>) => void;
+  doLayout: () => void;
   removeTab: (tabKey: string | number) => void;
 }
 
@@ -356,6 +357,9 @@ const navigableElements = [
 
 const keydownThrottleIntervalMs = 100;
 const tabsRef = useTemplateRef<Vue3TabsChromeComponent>('tabsRef');
+const workspaceTabStripRef = useTemplateRef<HTMLElement>(
+  'workspaceTabStripRef',
+);
 const searchTextRef =
   useTemplateRef<InstanceType<typeof SearchText>>('searchTextRef');
 const pageBackgroundRef = useTemplateRef<HTMLElement>('pageBackgroundRef');
@@ -374,6 +378,31 @@ const {
 } = useEditorServices();
 const { t } = useTranslation();
 const { observe: observePageBackgroundResize } = useResizeObserver();
+const { observe: observeWorkspaceTabStripResize } = useResizeObserver();
+
+let workspaceTabLayoutFrameId: number | null = null;
+let workspaceTabLayoutPending = false;
+
+function scheduleWorkspaceTabLayout() {
+  // Dockview can change the center width without a window resize, so defer the
+  // tab relayout until the pane geometry has settled.
+  if (workspaceTabLayoutPending) {
+    return;
+  }
+
+  workspaceTabLayoutPending = true;
+  void nextTick(() => {
+    if (!workspaceTabLayoutPending) {
+      return;
+    }
+
+    workspaceTabLayoutFrameId = window.requestAnimationFrame(() => {
+      workspaceTabLayoutFrameId = null;
+      workspaceTabLayoutPending = false;
+      tabsRef.value?.doLayout();
+    });
+  });
+}
 
 const dynamicTemplateRefs = new Map<string, unknown[]>();
 const dynamicTemplateRefSetters = new Map<string, (value: unknown) => void>();
@@ -1669,6 +1698,13 @@ onMounted(() => {
     });
   }
 
+  if (workspaceTabStripRef.value != null) {
+    observeWorkspaceTabStripResize(workspaceTabStripRef.value, () => {
+      scheduleWorkspaceTabLayout();
+    });
+    scheduleWorkspaceTabLayout();
+  }
+
   EventBus.$on(IpcMainChannels.CloseWorkspaces, onCloseWorkspaces);
   EventBus.$on(IpcMainChannels.CloseApplication, onCloseApplication);
   EventBus.$on(IpcRendererChannels.SetCanUndo, onSetCanUndo);
@@ -1774,6 +1810,12 @@ onMounted(() => {
 onBeforeUnmount(() => {
   // Remove the debugging variable from window
   (window as any)._editor = undefined;
+
+  if (workspaceTabLayoutFrameId != null) {
+    window.cancelAnimationFrame(workspaceTabLayoutFrameId);
+    workspaceTabLayoutFrameId = null;
+  }
+  workspaceTabLayoutPending = false;
 
   window.removeEventListener('keydown', onKeydown);
   window.removeEventListener('keyup', onKeyup);
@@ -9498,71 +9540,79 @@ function renderTabLabel(tab: Tab) {
 
         <template #center>
           <div class="page-container chrome-paper-canvas">
-            <ContextMenu>
-              <ContextMenuTrigger
-                as="div"
-                @contextmenu.capture="resetContextMenuWorkspace"
-                @contextmenu="onWorkspaceTabContextMenu"
-              >
-                <!-- @vue-ignore -->
-                <Vue3TabsChrome
-                  ref="tabsRef"
-                  v-model="selectedWorkspaceId"
-                  class="workspace-tab-container"
-                  :tabs="tabs"
-                  :gap="0"
-                  :on-close="onTabClosed"
-                  :render-label="renderTabLabel"
-                  @contextmenu="selectContextMenuWorkspace"
+            <div ref="workspaceTabStripRef" class="workspace-tab-strip-host">
+              <ContextMenu>
+                <ContextMenuTrigger
+                  as="div"
+                  @contextmenu.capture="resetContextMenuWorkspace"
+                  @contextmenu="onWorkspaceTabContextMenu"
                 >
-                  <template #after>
-                    <button
-                      class="workspace-tab-new-button"
-                      type="button"
-                      @click="onFileMenuNewScore"
-                    >
-                      +
-                    </button>
-                  </template>
-                </Vue3TabsChrome>
-              </ContextMenuTrigger>
-              <ContextMenuContent class="chrome-menu">
-                <ContextMenuItem
-                  @select="
-                    closeContextMenuWorkspaces(CloseWorkspacesDisposition.SELF)
-                  "
-                >
-                  <PhX />
-                  {{ $t(($) => $.menu.tab.close, { ns: 'menu' }) }}
-                </ContextMenuItem>
-                <ContextMenuItem
-                  @select="
-                    closeContextMenuWorkspaces(
-                      CloseWorkspacesDisposition.OTHERS,
-                    )
-                  "
-                >
-                  <PhXCircle />
-                  {{ $t(($) => $.menu.tab.closeOthers, { ns: 'menu' }) }}
-                </ContextMenuItem>
-                <ContextMenuItem
-                  @select="
-                    closeContextMenuWorkspaces(CloseWorkspacesDisposition.LEFT)
-                  "
-                >
-                  <PhArrowLineLeft />
-                  {{ $t(($) => $.menu.tab.closeToTheLeft, { ns: 'menu' }) }}
-                </ContextMenuItem>
-                <ContextMenuItem
-                  @select="
-                    closeContextMenuWorkspaces(CloseWorkspacesDisposition.RIGHT)
-                  "
-                >
-                  <PhArrowLineRight />
-                  {{ $t(($) => $.menu.tab.closeToTheRight, { ns: 'menu' }) }}
-                </ContextMenuItem>
-              </ContextMenuContent>
-            </ContextMenu>
+                  <!-- @vue-ignore -->
+                  <Vue3TabsChrome
+                    ref="tabsRef"
+                    v-model="selectedWorkspaceId"
+                    class="workspace-tab-container"
+                    :tabs="tabs"
+                    :gap="0"
+                    :on-close="onTabClosed"
+                    :render-label="renderTabLabel"
+                    @contextmenu="selectContextMenuWorkspace"
+                  >
+                    <template #after>
+                      <button
+                        class="workspace-tab-new-button"
+                        type="button"
+                        @click="onFileMenuNewScore"
+                      >
+                        +
+                      </button>
+                    </template>
+                  </Vue3TabsChrome>
+                </ContextMenuTrigger>
+                <ContextMenuContent class="chrome-menu">
+                  <ContextMenuItem
+                    @select="
+                      closeContextMenuWorkspaces(
+                        CloseWorkspacesDisposition.SELF,
+                      )
+                    "
+                  >
+                    <PhX />
+                    {{ $t(($) => $.menu.tab.close, { ns: 'menu' }) }}
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    @select="
+                      closeContextMenuWorkspaces(
+                        CloseWorkspacesDisposition.OTHERS,
+                      )
+                    "
+                  >
+                    <PhXCircle />
+                    {{ $t(($) => $.menu.tab.closeOthers, { ns: 'menu' }) }}
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    @select="
+                      closeContextMenuWorkspaces(
+                        CloseWorkspacesDisposition.LEFT,
+                      )
+                    "
+                  >
+                    <PhArrowLineLeft />
+                    {{ $t(($) => $.menu.tab.closeToTheLeft, { ns: 'menu' }) }}
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    @select="
+                      closeContextMenuWorkspaces(
+                        CloseWorkspacesDisposition.RIGHT,
+                      )
+                    "
+                  >
+                    <PhArrowLineRight />
+                    {{ $t(($) => $.menu.tab.closeToTheRight, { ns: 'menu' }) }}
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
+            </div>
             <SearchText
               v-if="searchTextPanelIsOpen"
               ref="searchTextRef"
@@ -11250,7 +11300,6 @@ function renderTabLabel(tab: Tab) {
 }
 
 :deep(.vue3-tabs-chrome .tabs-after) {
-  position: relative;
   z-index: 1;
   display: inline-flex !important;
   right: auto !important;
@@ -11259,7 +11308,18 @@ function renderTabLabel(tab: Tab) {
   overflow: visible;
 }
 
+.workspace-tab-strip-host {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
 .workspace-tab-container {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   background-color: var(--chrome-tab-strip);
 }
 


### PR DESCRIPTION
#2427 

## Summary

This PR fixes the workspace tab strip so the new-tab button stays visible when Dockview changes the center pane width, especially when the right pane is shown, hidden, resized, or restored.

## Motivation

The tab strip was only reacting to broader layout changes and could fall out of sync with Dockview’s live center-pane geometry. When that happened, the tabs would not relayout to the new available width, which could push or hide the new-tab button even though the editor pane itself had resized correctly.

## Major Changes

- Added explicit tab-strip relayout handling in `TheEditor.vue` by observing the workspace tab host and calling `Vue3TabsChrome.doLayout()` after Dockview-driven geometry changes settle.
- Wrapped the relayout in `nextTick` plus `requestAnimationFrame` so the tab component measures after Vue and Dockview have finished applying the new pane size.
- Tightened the tab strip host/container sizing and overflow rules so the workspace tabs stay bounded to the center pane width.
- Documented the Dockview-specific layout behavior in `notes/dockview_vue.md` so the resize dependency is easier to understand the next time this area is touched.

## Implementation Notes

The core design choice here is to respond to the tab strip’s actual rendered width instead of trying to infer pane changes from window resize events or storing extra Dockview layout state. That keeps the fix narrow and tied to the real UI seam that was drifting.

The relayout is deferred intentionally. Dockview can update pane geometry asynchronously relative to Vue rendering, so calling `doLayout()` immediately would risk measuring stale dimensions.