### PR TITLE
fix: Avoid duplicate layout processing during load

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -5618,13 +5618,6 @@ async function load() {
 
   selectedElement.value =
     score.value.staff.elements[score.value.staff.elements.length - 1];
-
-  pages.value = LayoutService.processPages(
-    selectedWorkspace.value,
-    shouldCollectLayoutDiagnostics.value
-      ? { collectDiagnostics: true }
-      : undefined,
-  );
 }
 
 /**


### PR DESCRIPTION
Remove the extra LayoutService.processPages call at the end of editor  startup. The shared workspace/page update flow already refreshes pages after selecting the loaded workspace, so running layout again during load adds unnecessary work.

Fixes #2435