### PR TITLE
fix: ask to save before updating

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -126,6 +126,7 @@ const fakeUpdateMode = process.env.FAKE_UPDATE_AVAILABLE === '1';
 
 let win: BrowserWindow | null = null;
 let readyToExit = false;
+let pendingUpdateInstall = false;
 let creatingWindow = false;
 let quitting = false;
 let developerPaneEnabled = false;
@@ -2585,6 +2586,22 @@ ipcMain.handle(IpcRendererChannels.ExitApplication, async () => {
     }
   }
 
+  if (pendingUpdateInstall) {
+    pendingUpdateInstall = false;
+
+    if (fakeUpdateMode) {
+      console.info(
+        'FAKE_UPDATE_AVAILABLE=1: update shutdown completed; skipping quitAndInstall().',
+      );
+      app.exit();
+      return;
+    }
+
+    readyToExit = true;
+    autoUpdater.quitAndInstall(false, true);
+    return;
+  }
+
   // In macOS, there is a distinction between "close" and "quit".
   if (quitting) {
     app.exit();
@@ -2641,19 +2658,13 @@ ipcMain.handle(IpcRendererChannels.RestartToInstallUpdate, async () => {
     return;
   }
 
-  if (fakeUpdateMode) {
-    console.info(
-      'FAKE_UPDATE_AVAILABLE=1: restart-and-install requested; skipping quitAndInstall().',
-    );
-    return;
-  }
-
-  readyToExit = true;
-  autoUpdater.quitAndInstall(false, true);
+  pendingUpdateInstall = true;
+  win?.webContents.send(IpcMainChannels.CloseApplication);
 });
 
 ipcMain.handle(IpcRendererChannels.CancelExit, async () => {
   quitting = false;
+  pendingUpdateInstall = false;
 });
 
 ipcMain.handle(


### PR DESCRIPTION
## Summary

Routes update installation through the application’s normal shutdown flow so users can save or cancel before Neanes restarts.

## Motivation

Previously, selecting “Restart to Install” immediately allowed Electron to exit and invoked the updater. This bypassed the editor’s unsaved-work checks and could close the application without giving users an opportunity to save their work.

## Major Changes

- Defers update installation until the renderer completes the standard workspace shutdown flow.
- Reuses the existing save, discard, and cancel prompts before restarting.
- Cancels the pending installation when the user cancels shutdown.
- Enables `readyToExit` only after shutdown succeeds, allowing `quitAndInstall()` to close the application without re-entering the prompt flow.
- Runs fake-update mode through the same shutdown path while continuing to skip the real installer.

## Implementation Notes

- A main-process `pendingUpdateInstall` flag distinguishes an update restart from an ordinary application exit.
- The restart request now sends `CloseApplication` to the renderer instead of invoking the updater immediately.
- `ExitApplication` performs the installation only after renderer cleanup completes.
- Normal close and quit behavior remains unchanged when no update installation is pending.