### PR TITLE
fix: double apostrofos neume select order

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -815,12 +815,7 @@ const selectedElement = computed({
       selectedLyrics.value = null;
       selectionRange.value = null;
       selectedHeaderFooterElement.value = null;
-      toolbarInnerNeume.value =
-        element.elementType === ElementType.Note &&
-        (element as NoteElement).quantitativeNeume ===
-          QuantitativeNeume.DoubleApostrophos
-          ? NeumeSelection.Secondary
-          : NeumeSelection.Primary;
+      toolbarInnerNeume.value = NeumeSelection.Primary;
 
       if (audioService.state === AudioState.Playing) {
         const event = playbackEvents.value.find(

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -516,7 +516,6 @@
             />
           </ToolbarToggleItem>
           <ToolbarToggleItem
-            v-if="!isDoubleApostrophos"
             :value="NeumeSelection.Secondary"
             class="chrome-button neume-select-button"
             :aria-label="NeumeSelection.Secondary"
@@ -533,17 +532,6 @@
           >
             <Neume
               :neume="primaryNeume!"
-              :font-family="pageSetup.neumeDefaultFontFamily"
-            />
-          </ToolbarToggleItem>
-          <ToolbarToggleItem
-            v-if="isDoubleApostrophos"
-            :value="NeumeSelection.Secondary"
-            class="chrome-button neume-select-button"
-            :aria-label="NeumeSelection.Secondary"
-          >
-            <Neume
-              :neume="secondaryNeume"
               :font-family="pageSetup.neumeDefaultFontFamily"
             />
           </ToolbarToggleItem>
@@ -947,10 +935,6 @@ const secondaryNeume = computed(() =>
 
 const tertiaryNeume = computed(() =>
   getTertiaryNeume(props.element.quantitativeNeume),
-);
-
-const isDoubleApostrophos = computed(
-  () => props.element.quantitativeNeume === QuantitativeNeume.DoubleApostrophos,
 );
 
 const fthoresDisabled = computed(() =>


### PR DESCRIPTION
#2455 tried to make things too clever by swapping the order of the neume buttons in the Neume Select toolbar. This restores the default behavior so that the gorgon can be assigned easily. The entry for diesis is now perhaps slightly counter-intuitive, but that's just the way it's going to be for now.