### PR TITLE
fix: restore space between mode key note and neume

### DIFF
--- a/src/components/ModeKey.vue
+++ b/src/components/ModeKey.vue
@@ -29,6 +29,7 @@
     <Neume
       v-if="element.quantitativeNeumeRight != null"
       :neume="element.quantitativeNeumeRight"
+      :style="quantitativeNeumeRightStyle"
     />
     <Neume
       v-if="element.fthoraAboveQuantitativeNeumeRight != null"
@@ -71,6 +72,7 @@ import Neume from '@/components/NeumeGlyph.vue';
 import type { ModeKeyElement } from '@/models/Element';
 import { ModeSign } from '@/models/Neumes';
 import type { PageSetup } from '@/models/PageSetup';
+import { fontService } from '@/services/FontService';
 import { NeumeMappingService } from '@/services/NeumeMappingService';
 import { TextMeasurementService } from '@/services/TextMeasurementService';
 import { withZoom } from '@/utils/withZoom';
@@ -110,6 +112,15 @@ const tempoStyle = computed(() => {
   } as StyleValue;
 
   return style;
+});
+
+const quantitativeNeumeRightStyle = computed(() => {
+  return {
+    marginLeft: withZoom(
+      props.element.computedFontSize *
+        fontService.getStandardGlue(props.element.computedFontFamily).width,
+    ),
+  } as CSSProperties;
 });
 
 const ambitusStyle = computed(() => {


### PR DESCRIPTION
Fixes a regression related to the newer "tight" fonts.

Reintroduces the spacing formerly encoded in the legacy quantitative-neume glyphs by applying the active font’s standard engraving glue before quantitativeNeumeRight.

Before:
<img width="185" height="59" alt="image" src="https://github.com/user-attachments/assets/e04e9da2-122e-4c18-9d26-7e3139531244" />


After:
<img width="231" height="65" alt="image" src="https://github.com/user-attachments/assets/e35f4107-241e-4f3a-9d3d-aeffbdb13f39" />
