### PR TITLE
fix: Synchronize rich text language updates

### DIFF
--- a/src/components/RichTextEditor.vue
+++ b/src/components/RichTextEditor.vue
@@ -24,6 +24,7 @@ import {
   unregisterEditor,
 } from '@/composables/useRichTextEditorRegistry';
 import InlineEditor from '@/customEditor';
+import { inferRichTextEditorDirection } from '@/utils/richTextLanguage';
 
 defineOptions({
   inheritAttrs: false,
@@ -94,10 +95,30 @@ onBeforeUnmount(() => {
   unregisterRichTextEditor();
 });
 
+// CKEditor writes the editable root's `dir` from `config.language.content` when
+// it renders, so on its own the base direction only catches up with the text on
+// a remount. That direction is what `text-align: justify` resolves its last line
+// against, and the `<span dir="rtl">` the language dropdown applies cannot supply
+// it -- an inline span is bidi-isolated, so it reorders its own glyphs and
+// contributes nothing to the block. Keep the root in step with the text instead.
+function refreshBaseDirection(editor: InlineEditor) {
+  const view = editor.editing.view;
+  const direction =
+    inferRichTextEditorDirection(editor) ??
+    editor.locale.contentLanguageDirection;
+
+  view.change((writer) => {
+    writer.setAttribute('dir', direction, view.document.getRoot()!);
+  });
+}
+
 function onReady(editor: InlineEditor) {
   registerEditor(editor, props.owner);
   registeredEditor = editor;
   editorIsFocused = editor.ui.focusTracker.isFocused;
+
+  refreshBaseDirection(editor);
+  editor.model.document.on('change:data', () => refreshBaseDirection(editor));
 
   const onFocusChanged = (
     _event: unknown,

--- a/src/utils/richTextLanguage.test.ts
+++ b/src/utils/richTextLanguage.test.ts
@@ -6,6 +6,7 @@ import {
   getRichTextLanguage,
   getRichTextLanguageAttributes,
   hasMeaningfulRichTextEditorContent,
+  inferRichTextEditorDirection,
   inferRichTextEditorLanguage,
   inferSharedRichTextEditorLanguage,
   setRichTextLanguage,
@@ -55,6 +56,24 @@ describe('richTextLanguage', () => {
           element([text('Hello', 'ar:rtl'), text('Kyrie', 'el:ltr')]),
         ]),
       ),
+    ).toBeNull();
+  });
+
+  it('infers the direction from the editor language', () => {
+    expect(
+      inferRichTextEditorDirection(
+        createEditor([element([text('Hello', 'ar:rtl')])]),
+      ),
+    ).toBe('rtl');
+
+    expect(
+      inferRichTextEditorDirection(
+        createEditor([element([text('Hello', 'en:ltr')])]),
+      ),
+    ).toBe('ltr');
+
+    expect(
+      inferRichTextEditorDirection(createEditor([element([text('Hello')])])),
     ).toBeNull();
   });
 

--- a/src/utils/richTextLanguage.ts
+++ b/src/utils/richTextLanguage.ts
@@ -104,6 +104,14 @@ export function inferRichTextEditorLanguage(
   return isMixedOrMissing ? null : inferred;
 }
 
+export function inferRichTextEditorDirection(
+  editor: Pick<Editor, 'model'>,
+): LanguageDirection | null {
+  const language = inferRichTextEditorLanguage(editor);
+
+  return language == null ? null : getRichTextLanguageDirection(language);
+}
+
 export function hasMeaningfulRichTextEditorContent(
   editor: Pick<Editor, 'model'>,
 ): boolean {


### PR DESCRIPTION
Keep CKEditor's editable root direction synchronized with the language direction of its rich text content. This fixes right-to-left text, particularly Arabic text, continuing to use the editor's original left-to-right block direction after its language is changed. The stale root direction affected bidirectional layout and caused justified text's final line to align against the wrong edge until the editor was remounted.

## Problem

CKEditor initializes the editable root's `dir` attribute from `config.language.content` when the editor renders. Applying a language through the rich text language control updates the model and produces an inline language span, but it does not update that root attribute.

The inline `dir="rtl"` span is enough to reorder its own glyphs, but it is bidirectionally isolated and cannot establish the surrounding block's base direction. Block-level behavior such as the final line of `text-align: justify` therefore continued to use the old direction. The root direction only became correct after an operation that remounted the editor.

## Changes

- Add `inferRichTextEditorDirection()` to derive `ltr` or `rtl` from the language shared by the editor's meaningful text.
- Refresh the editable view root's `dir` attribute as soon as CKEditor is ready.
- Refresh the root direction after every model `change:data` event so language changes, content replacement, and undo/redo remain synchronized without requiring a remount.
- Fall back to CKEditor's configured content-language direction when the editor has no single inferable language, including empty, unlabeled, or mixed-language content.
- Add unit test coverage for right-to-left inference, left-to-right inference, and the missing-language fallback signal.

## User-visible result

Changing rich text to an RTL language now updates both the inline text metadata and the editor's block-level base direction immediately. Arabic justified text consequently places its final line according to RTL layout, while LTR content continues to behave as before. This change affects editor rendering only. It does not change the saved score format or require a data migration.

## Testing Done

Created a new rich text box, set language to Arabic, pasted Arabic paragraph and clicked Justify. Before this PR the last line was on the left until clicking out of the rich text box; after this PR, the last line is on the right immediately.

Fixes #2504