### PR TITLE
fix: use exact printing

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -899,6 +899,7 @@ async function exportWorkspaceAsPdf(
             args.pageHeightInches,
           ),
           landscape: args.landscape,
+          printBackground: true,
         });
         const newPath = replaceExtension(args.filePath!, 'pdf');
 
@@ -949,6 +950,7 @@ async function exportWorkspaceAsPdf(
             args.pageHeightInches,
           ),
           landscape: args.landscape,
+          printBackground: true,
         });
         await fs.writeFile(filePath, data);
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -231,6 +231,10 @@ onBeforeUnmount(() => {
     overflow: visible !important;
   }
 
+  .page {
+    print-color-adjust: exact;
+  }
+
   /*
    * Reka/Vue portal components leave teleport anchor elements as direct body
    * children. If any remain after #app, Blink may honor the final printed


### PR DESCRIPTION
Fixes #2523.

Maybe fixes #2369, although I was never able to reproduce that issue.

Uses `exact` printing. See [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/print-color-adjust).