### PR TITLE
Revert "chore: bump dockview-vue from 7.0.2 to 7.0.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ckeditor5": "^48.3.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dockview-vue": "^7.0.3",
+        "dockview-vue": "^7.0.2",
         "electron": "^43.2.0",
         "electron-builder": "^26.15.3",
         "eslint": "^10.7.0",
@@ -8883,30 +8883,30 @@
       }
     },
     "node_modules/dockview": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/dockview/-/dockview-7.0.4.tgz",
-      "integrity": "sha512-n6n9WpYZgp/WY8SgvP4hr9qh01ZXhSGIRmlhoJXxRU3f34bwxCbFyOhBArV4W8quolX8OQe1yPfAUwUUjdnZPA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dockview/-/dockview-7.0.2.tgz",
+      "integrity": "sha512-QhgbJ7RTFsWvrs1lQZKPGCLTGjKU7kI5ZWX5lwU03arM9lIoQlbfv1b/uQ7V5zTkRw7JDndEqjKMgEFw2I8Kow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dockview-core": "^7.0.4"
+        "dockview-core": "^7.0.2"
       }
     },
     "node_modules/dockview-core": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-7.0.4.tgz",
-      "integrity": "sha512-AiIzD6ov153L/VuhqVBg5KD5oSAgJGH7L1xvzV/X+ghIEOTFfEQYEBGNd/ys+ZjQfdGRogHSeQ0v9JF/L6JrPg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-7.0.2.tgz",
+      "integrity": "sha512-i666ndkUdT4U+Bo2Yu3d6KwCJNqe21VJ0oschdgcXucZ5TquzBFX94zcUBEfg4IewTv2BuiPJ7r/2JTGLLv6ig==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dockview-vue": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/dockview-vue/-/dockview-vue-7.0.3.tgz",
-      "integrity": "sha512-OrqHcHUPL0RauS+abF8L2D+NkpTBWBCCqkWZ/tavMiQ8UhNdeoWfkMl0PiwdzgTym54jT5N6qmMlbrnKilBgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dockview-vue/-/dockview-vue-7.0.2.tgz",
+      "integrity": "sha512-O1ta/OhISPSu6sF1VQBWdDLyRbmJC0I2onixqXH/ZSSk8/t9OUsB9X9VuXP3g3D+a3THI3eRJEJyDazTAxEF8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dockview": "^7.0.3"
+        "dockview": "^7.0.2"
       },
       "peerDependencies": {
         "vue": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ckeditor5": "^48.3.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dockview-vue": "^7.0.3",
+    "dockview-vue": "^7.0.2",
     "electron": "^43.2.0",
     "electron-builder": "^26.15.3",
     "eslint": "^10.7.0",


### PR DESCRIPTION
Reverts neanes/neanes#2533

Seems to break the app; I will debug later.