### PR TITLE
fix: Refine Knuth-Plass spacing constraints and consolidate layout geometry

### DIFF
--- a/notes/knuth_plass.md
+++ b/notes/knuth_plass.md
@@ -24,7 +24,7 @@ In their seminal 1981 paper "[Breaking Paragraphs into Lines](https://gwern.net/
 This "optimum-fit" algorithm can choose an earlier breakpoint strategically in order to eliminate especially unattractive breakpoints later in the paragraph.
 The result is not only fewer overly wide spaces, but also more even spacing and fewer abrupt changes between adjacent lines.
 The Knuth-Plass approach is based on three simple primitives, _boxes,_ _glue,_ and _penalties,_
-and scores candidate layouts using a function based on the squared lengths of the spaces at the ends of lines.
+and scores candidate layouts from cubic adjustment-ratio badness, breakpoint costs, and squared line demerits.
 Its flagship implementation is in the $\TeX$ typesetting system, where the source code describes it as "probably the most interesting algorithm of $\TeX$."
 Adobe InDesign includes a related approach called the [Adobe Paragraph Composer](https://helpx.adobe.com/indesign/using/text-composition.html).
 
@@ -67,7 +67,7 @@ From many examples in classical 19th-century publications, we derive the followi
 
 A line break is prohibited in the following cases:
 
-1. Between a martyria and the preceding neume. We add a penalty of `MAX_COST`.
+1. Between a note and a following martyria. We add a penalty of `MAX_COST`.
 2. Between two neumes tied by a connecting heteron, connecting homalon, or yfen. We add a penalty of `MAX_COST`.
 
 ### Strongly discouraged breaks
@@ -81,7 +81,7 @@ A line break is strongly discouraged in the following cases:
 
 In addition to the strongly discouraged cases, we identify several breaks that are permissible but undesirable:
 
-1. A line that begins with a gorgon steals half a beat from the neume at the end of the previous line. Although this is not uncommon in the classical 19th-century publications, it requires the reader to look one line ahead. This is manageable within a page, but more annoying at a page boundary, so it is better to avoid such breaks when possible.
+1. A line that begins with a supported primary or secondary time mark on a configured quantitative neume takes time from the neume at the end of the previous line. The current sets cover selected gorgon-family combinations; digorgon and trigorgon remain TODOs in the implementation. Although such breaks are not uncommon in the classical 19th-century publications, they require the reader to look one line ahead. This is manageable within a page, but more annoying at a page boundary, so it is better to avoid such breaks when possible.
 2. Between a running elaphron and the preceding neume. Like the gorgon, a running elaphron steals a beat from the preceding neume, so a break before it is awkward.
 3. Immediately after a melisma start, before its first continuation neume, that is, between notes 0 and 1 of the melisma, 0-indexed. The melisma-start syllable extends to the right under subsequent neumes, and breaking here can isolate it on a line where the lyric may overflow. Long melismas may legitimately break later on, so only the break immediately after the start is discouraged. The penalty-width mechanism described below handles overflow at any breakpoint inside the melisma.
 4. Between the second-to-last and last notes of a melisma, that is, between notes $n-2$ and $n-1$, 0-indexed. This is the converse of the previous rule: just as the melisma start should stay with its first continuation, the penultimate note should stay with the final note that closes the melisma. Breaking here would strand a single melisma note at the start of a line. Interior melisma breaks, between notes 1 and $n-2$, remain free.
@@ -105,16 +105,16 @@ The three weaker penalties can stack only to 0.45 of `MAX_COST` ($0.2 + 0.15 + 0
 
 ### Summary of penalties
 
-|               Cost | Break location                                         | $\TeX$ analogue |
-| -----------------: | ------------------------------------------------------ | --------------- |
-|         `MAX_COST` | Before a martyria                                      | none            |
-|         `MAX_COST` | Across a tie (heteron, homalon, yfen)                  | none            |
-|  0.5 of `MAX_COST` | After a vareia                                         | `\relpenalty`   |
-|  0.5 of `MAX_COST` | Before kentēmata                                       | `\relpenalty`   |
-|  0.1 of `MAX_COST` | Before beat-stealing neumes (gorgon, running elaphron) | none            |
-|  0.2 of `MAX_COST` | Melisma start to first continuation (0 to 1)           | `\clubpenalty`  |
-| 0.15 of `MAX_COST` | Penultimate to last melisma note ($n-2$ to $n-1$)      | `\widowpenalty` |
-|                  0 | All other inter-note breaks                            | none            |
+|               Cost | Break location                                    | $\TeX$ analogue |
+| -----------------: | ------------------------------------------------- | --------------- |
+|         `MAX_COST` | From a note to a following martyria               | none            |
+|         `MAX_COST` | Across a tie (heteron, homalon, yfen)             | none            |
+|  0.5 of `MAX_COST` | After a vareia                                    | `\relpenalty`   |
+|  0.5 of `MAX_COST` | Before kentēmata                                  | `\relpenalty`   |
+|  0.1 of `MAX_COST` | Before configured beat-stealing neumes/time marks | none            |
+|  0.2 of `MAX_COST` | Melisma start to first continuation (0 to 1)      | `\clubpenalty`  |
+| 0.15 of `MAX_COST` | Penultimate to last melisma note ($n-2$ to $n-1$) | `\widowpenalty` |
+|                  0 | All other inter-note breaks                       | none            |
 
 ### Classical compression techniques
 
@@ -132,19 +132,24 @@ Layout proceeds in two phases. In Phase 1, the code builds the box/glue/penalty 
 ### Lyricless scores
 
 Consider first a lyricless score of Byzantine music.
-Each neume group, for example a simple oligon or an ison with kentēmata over a supporting oligon, and each martyria can be modeled as a box whose width is simply the width of the notated group itself.
+Each neume group, for example a simple oligon or an ison with kentēmata over a supporting oligon, and each martyria is modeled as a box.
+A note box uses the layout advance `neumeWidth + spaceAfter`; `neumeWidth` already includes owned prefixes and inline measure bars.
+A martyria box similarly includes the notated group, its `spaceAfter`, and any horizontal spacing owned inside the element.
 The space between ordinary neumes is modeled as glue.
 Its natural width is `neumeDefaultFontSize * standardGlue.width + neumeDefaultSpacing`, where `standardGlue` comes from the active font's `engravingDefaults`.
 The font-size-scaled engraving default supplies the default gap, and `neumeDefaultSpacing` remains a user-configurable adjustment.
-The stretch and shrink budgets are also scaled from the active font's `standardGlue` defaults.
+The standard-glue stretch and shrink use the active font's default elasticity ratios, applied to the full natural width $s_0$, including `neumeDefaultSpacing`.
+If the engraving defaults are $(d_w, d^+, d^-)$ and $d_w \ne 0$, the ratios are $d^+/d_w$ and $d^-/d_w$; when $d_w = 0$, the code falls back to $0.5$ and $1/3$.
+Thus the actual budgets are $\max(s_0 d^+/d_w, 0.1\text{ px})$ and $\max(s_0 d^-/d_w, 0)$, with the fallback ratios substituted when necessary.
 Users may also set the inter-note spacing adjustment to a negative value, so that successive neumes visibly overlap and the layout becomes tighter.
 When the computed inline spacing is negative, the glue keeps its negative natural width so that the overlap remains visible, but the stretch and shrink budgets are floored at small non-negative values: stretch at 0.1 px and shrink at 0.
-The same floors apply uniformly to every inter-element spacing glue: the standard glue's stretch and shrink, the note post-break glue's stretch and shrink, the martyria glue's stretch and shrink, and the right-martyria glue's shrink.
-The martyria glue's base width, stretch, and shrink come from the martyria engraving defaults described below rather than from the inline spacing.
-These floors preserve the Knuth-Plass invariants while keeping the user-chosen overlap intact, because ordinary glues no longer stretch enough to push neumes apart and any line-end slack is absorbed by the right-martyria glue's `MAX_COST` stretch instead.
-The 0.1 px stretch floor is a tiny positive epsilon rather than zero so that every line has at least some stretchability, which keeps the adjustment ratio finite and the line-breaking problem well-defined.
-Without this floor, a line that contains no martyria would have a total stretch of zero, and `breakLines` could only treat its natural width as feasible.
-At 0.1 px per glue, the cumulative stretch across a typical line is far below the neume scale and so has no visible effect on the layout.
+Ordinary note-to-note post-break glue inherits these standard budgets without an additional shrink cap.
+A note immediately before a martyria instead emits fixed post-break glue with zero stretch and shrink, because the martyria path replaces that glue and owns the boundary elasticity.
+Martyria glue applies the same non-negative floors to its own font-size-scaled engraving defaults, while right-martyria glue uses `MAX_COST` stretch and inherits the martyria shrink.
+These floors preserve conventional adjustment-ratio semantics while keeping the user-chosen negative natural width intact.
+The 0.1 px stretch floor is a small positive epsilon rather than zero so that an underfull line without other stretchable glue still has a finite adjustment ratio.
+Under the preferred cap $r \le 1$, each floored glue grows by at most 0.1 px, so the contribution is negligible.
+If no solution exists under that cap, the cap search described below may magnify the epsilon; a right-aligned martyria's `MAX_COST` stretch dominates the slack allocation whenever that glue is present.
 
 The active font's OpenType shaping is applied implicitly when each note's neume text run is measured, so contextual substitutions contribute their actual rendered widths without separately resolving the substitutions first.
 Layout resolves contextual substitutions explicitly where it needs the substituted glyph identities themselves, for example when measuring collision ink, but inter-neume spacing comes from the fixed inline spacing rather than from substituted glyph leading or trailing metadata.
@@ -152,27 +157,29 @@ A vareia contributes fixed internal spacing before the main neume; in right-to-l
 
 Visible barlines also participate in spacing.
 In the following formulas, $s_0$ is the fixed inline spacing described above.
-For a barline between elements $A$ and $B$, the minimum boundary width starts from fixed clearance rather than glyph bearings, then grows if note ink or configured collision regions require more room.
-If a visible barline lies between two neume anchors, the boundary reserves one fixed inline space on each side of the barline:
+For a barline between elements $A$ and $B$, the preferred boundary width starts from fixed clearance rather than glyph bearings, then grows if note ink or configured collision regions require more room.
+When $s_0 \ge 0$ and no larger collision requirement binds, a visible barline between two neume anchors has a natural boundary target of one inline space on each side of the barline:
 
 $$2s_0.$$
 
-The barline is centered in the available space while respecting that minimum.
-The trailing barline-to-$B$ clearance is modeled inside the box for a left-owned barline, so a barline at the start of a line keeps the same fixed clearance.
-The remaining minimum is preserved during justification and after lyric tucking.
+For negative $s_0$, the external glue clamp and any collision requirement may raise that target.
+At natural width, the barline is centered in the resulting available space.
+The trailing barline-to-$B$ clearance is modeled inside the box for a left-owned barline, so a barline at the start of a line keeps that fixed clearance.
+The external portion raises the preferred glue width after lyric tucking.
+At an ordinary note-to-note boundary it remains compressible through the full standard-glue shrink budget; martyria-boundary glue instead caps shrink at its computed hard visual and measure-bar floor.
 For note-to-note boundaries, the collision check uses glyph boxes for the notes, marks, and barline regions that vertically overlap; tie-like marks are ignored because adding space would break their intended connection.
 Vareia-to-barline clearance is checked separately, with a tiny vertical tolerance, so that a barline region and vareia that are effectively tangent in font metadata still reserve the normal barline spacing horizontally.
 When a right barline becomes terminal at a line break, at a paragraph ending, before an empty element, or before a right-aligned martyria, its clearance from the preceding neume is reserved as terminal width, including any note ink overhang that overlaps the barline clearance region.
 
-Ordinary martyriæ use the active font's `martyriaGlue` engraving defaults instead of standard fixed inline glue.
+Ordinary martyriæ use the active font's `martyriaGlue` engraving defaults instead of standard glue.
 Its natural width is `neumeDefaultFontSize * martyriaGlue.width`.
 This gives martyriæ font-specific surrounding space that can differ from ordinary neume spacing.
 An inline left martyria bar contributes to that box width, but a short left bar that has been converted into an above-style mark does not own horizontal side spacing.
 Above-style left bars and the central tempo mark are still measured as martyria body ink, in render order, so their visible protrusion can widen visual minimums without adding inline box width.
 During justification, stretch and shrink are based on the martyria glue defaults while the same-line width is still protected by any visual-ink and measure-bar minimums.
-Tempo-adjacent martyria boundaries are the exception: when a non-right-aligned martyria contains `tempoLeft` or `tempoRight`, or when a standalone tempo sign sits immediately beside a non-right-aligned martyria in the same paragraph, that side uses standard fixed inline glue instead of martyria glue.
+Tempo-adjacent martyria boundaries are the exception: when a non-right-aligned martyria contains `tempoLeft` or `tempoRight`, or when a standalone tempo sign sits immediately beside a non-right-aligned martyria in the same paragraph, that side uses standard glue instead of martyria glue.
 For standalone tempo-to-martyria and martyria-to-tempo boundaries, the lyric-collision spacer is also skipped; the explicit standard glue owns the base boundary spacing, while the lyric bookkeeping is still advanced for the current element.
-After the martyria box, the code inserts a zero-width pre-break glue, then a zero-cost break penalty, and finally a single trailing glue whose preferred width is usually martyria glue, or standard fixed inline glue for the tempo cases above.
+After the martyria box, the code inserts a zero-width pre-break glue, then a zero-cost break penalty, and finally a single trailing glue whose preferred width is usually martyria glue, or standard glue for the tempo cases above.
 As a result, the full trailing spacing appears after the martyria only when it stays mid-line; if a break is taken there, that spacing becomes leading glue on the next line and is skipped.
 Visible spacing around notes, martyriæ, and standalone tempo signs may be widened beyond the base glue when shaped ink overhangs would otherwise collide.
 For the ordinary non-right-aligned note-martyria-note case, where the martyria owns both sides of the boundary glue and no inline side measure bars or side tempo signs intervene, the code also balances the martyria between the nearest visible boundary on each side.
@@ -183,38 +190,43 @@ The two martyria-side glues are then assigned equal natural visible whitespace f
 During compression they keep the same shrink, so the visual balance holds under justification, but that shrink is floored by hard ink, lyric, and measure-bar clearance rather than by the natural martyria glue width.
 For plain neighboring neumes, this lets each martyria glue shrink from `martyriaGlue.width` toward ordinary `standardGlue.width`; the shrink is reduced only when a visible collision floor actually binds.
 
-When a martyria has a transferable measure bar and is followed by a note, the bar transfers to the next line's first note at a break.
-To reserve space for this, the martyria's post-break glue is narrowed by the bar width plus fixed leading clearance, and an anonymous spacer box of the same width is inserted before the following note's box.
+When a martyria has a transferable measure bar and is followed in the same paragraph by a note without its own left bar, the martyria bar transfers to that note at an automatic line break.
+To reserve space for this, the martyria's post-break glue is narrowed by the bar width plus collision-aware leading clearance, and an anonymous spacer box of the same width is inserted before the following note's box.
 On the same line the reduced glue and the spacer cancel, leaving the note's own box position unchanged.
-The post-break glue's shrink is capped so that justification cannot reduce that same-line boundary below the fixed measure-bar clearance.
-At a break the post-break glue vanishes; the spacer remains at the start of the next line and reserves fixed leading space for the transferred bar.
-In Phase 2, when the break is actually taken, the note element is shifted left by the bar width plus fixed leading clearance so that the rendered barline glyph and spacing occupy the space reserved by the spacer rather than adding extra width.
+The post-break glue's shrink is capped so that justification cannot reduce that same-line boundary below its hard, collision-aware measure-bar and visual minimum.
+At a break the post-break glue vanishes; the spacer remains at the start of the next line and reserves non-stretching leading space for the transferred bar.
+In Phase 2, when the break is actually taken, the note element is shifted left by the bar width plus the same collision-aware leading clearance so that the rendered barline glyph and spacing occupy the space reserved by the spacer rather than adding extra width.
 
-Line-start non-right-aligned martyriæ use the same spacer-and-cancel pattern for left ink overhang.
-If the martyria's body, inline left bar, or left tempo sign would protrude past the left margin, Phase 1 inserts an anonymous spacer of that overhang width before the martyria and narrows the martyria's owned leading glue by the same amount.
-On the same line these widths cancel, so ordinary inline note-to-martyria spacing is unchanged.
-When the martyria starts a line, `positionItems` skips the leading glue but keeps the spacer, so the line breaker reserves the same width that Phase 2 later adds as indentation.
+Line-start non-right-aligned martyriæ after a note or standalone tempo in the same paragraph use the same spacer-and-cancel pattern for left ink overhang.
+If the martyria's body, inline left bar, or left tempo sign would protrude past the left margin, Phase 1 inserts an anonymous spacer of that overhang width before the martyria.
+After a note or standalone tempo, the code also narrows the martyria's owned leading glue by the same amount; on the same line these widths cancel, so the original boundary spacing is unchanged.
+After another inline element type, the preceding glue is not replaced or narrowed, so the spacer remains as additional same-line width.
+At paragraph start there is no owned leading glue to narrow, so the spacer alone reserves the required indentation.
+When a break places a martyria after a note or tempo at line start, `positionItems` skips the leading glue but keeps the spacer.
+In either case the martyria's positioned offset normally contains the full reservation; Phase 2 computes indentation only for any remaining overhang deficit.
 
-When a right-aligned martyria follows existing content, its leading glue is a separate case: the code uses effectively infinite stretch (`MAX_COST`) so that this glue absorbs all remaining line slack.
+When a right-aligned martyria follows existing content, its leading glue is a separate case: the code uses dominant stretch (`MAX_COST`) so that this glue absorbs most of the remaining line slack and ordinary neume gaps stay comparatively stable.
 If a right-aligned martyria starts a paragraph, that leading glue is still encoded in the input stream, but `positionItems` skips it at line start, so Phase 2 places the martyria flush right explicitly.
 
-As in Knuth & Plass, each paragraph ends with finishing glue, preceded by a maximum-cost penalty to forbid an earlier break and followed by a minimum-cost penalty to force the paragraph break.
-When a paragraph does not end immediately after a note, the finishing glue has width 0.
-If a paragraph does end immediately after a note, `endParagraph` first materializes that note's trailing reservation into the finishing glue before removing the trailing post-break glue.
+As in Knuth & Plass, each paragraph ends with finishing glue, preceded by a maximum-cost penalty so the glue is not itself a breakpoint and followed by a minimum-cost penalty to force the paragraph break.
+When a paragraph ends immediately after a note, `endParagraph` first materializes that note's trailing reservation into the finishing glue before removing the trailing post-break glue.
+When it ends after a martyria, the finishing glue similarly reserves terminal right-barline clearance or, if there is no right barline, the martyria's right ink overhang.
+For other trailing element types, the finishing glue has width 0.
 For non-justified endings the finishing glue uses effectively infinite stretch (`MAX_COST`); for justified endings it uses stretch 0. In all cases its shrink is 0.
 
 ### Lyrics
 
 Lyrics introduce additional complexity because they can collide when they extend beyond the width of the neume.
-We handle lyrics in the same way as Western staff notation in LilyPond, using the Hegazy-Gourlay approach.
+We draw on the Hegazy-Gourlay approach used for Western staff notation in LilyPond.
 LilyPond's `LyricSpace` and `LyricHyphen` grobs both call `ly:lyric-hyphen::set-spacing-rods` to create "an invisible object that prevents lyric words from being spaced too closely."
 Here the term _rod_ is used for what Knuth & Plass call a _box._
-This is an application of the Hegazy-Gourlay technique of pre-stretching glue to a minimum extent.
+This applies the Hegazy-Gourlay pre-spacing idea to the glue's preferred natural width.
+For ordinary note boundaries, the resulting width may still shrink during justification as described below.
 
 The paragraph encoding is easiest to understand one note boundary at a time.
 For each boundary between note $i$ and note $i{+}1$, the code computes two quantities:
 
-- $m_i$: the minimum width required when both notes remain on the same line.
+- $m_i$: the preferred width when both notes remain on the same line.
 - $w_i$: extra width that matters only if a line break is taken at that boundary.
 
 The paragraph encoding itself is fixed.
@@ -242,26 +254,32 @@ Rewriting the centered projections to apply $h_i$ at full width (for example $L_
 
 ### Paragraph encoding
 
-Let $B_i = W^n_i$ be the neume width, $c_i$ the break cost, $w_i$ the break-only reservation at breakpoint $i$, and $m_i$ the minimum same-line width between notes $i$ and $i{+}1$.
+Let $a_i$ be note $i$'s `spaceAfter` and $B_i = W^n_i + a_i$ be its layout advance.
+Let $c_i$ be the break cost, $w_i$ the break-only reservation at breakpoint $i$, and $m_i$ the preferred same-line width between notes $i$ and $i{+}1$.
 Let $s_0$ be the fixed inline spacing between successive notes, `neumeDefaultFontSize * standardGlue.width + neumeDefaultSpacing`, and let $s^+$ and $s^-$ be the stretch and shrink budgets for an inter-note gap.
 
-Each note is encoded in the paragraph as
+For an ordinary note-to-note boundary, note $i$ is encoded in the paragraph as
 
 $$\text{penalty}(\infty) \quad \text{glue}(L_i, 0, 0) \quad \text{box}(B_i) \quad \text{penalty}(c_i, w_i) \quad \text{glue}(m_i, s^+, s^-).$$
 
 Here:
 
-- $B_i$ is the neume width. An anonymous spacer box may be inserted before $B_i$ to hold a break-only leading reservation: the bar width plus fixed leading clearance when the preceding martyria has a transferable bar (see above), and a leading-hyphen reservation when the preceding note is hyphenated (see below). $B_i$ itself is unchanged.
+- $B_i$ is the note's layout advance, including `spaceAfter`. An anonymous spacer box may be inserted before $B_i$ to hold a break-only leading reservation: the bar width plus collision-aware leading clearance when the preceding martyria has a transferable bar (see above), and a leading-hyphen reservation when the preceding note is hyphenated (see below). $B_i$ itself is unchanged.
 - $L_i$ is the left projection, fixed and unbreakable, and omitted when zero.
 - The leading $\text{penalty}(\infty)$ is an unbreakable barrier that protects $L_i$ at a line start. `positionItems` discards leading glue after a break only up to the first box or forbidden ($\infty$) penalty, so the leading penalty keeps $\text{glue}(L_i, 0, 0)$ out of the discarded region and it is counted rather than skipped. It is emitted together with $L_i$ and omitted when $L_i$ is zero; the note's first box then stops the discard scan instead.
 - $s^+$ and $s^-$ are the standard stretch and shrink budgets for an inter-note gap.
 - $c_i$ is the break cost: 0 for a normal break, $\infty$ to prohibit a break, or an intermediate value to discourage one.
-- $w_i$ is the penalty width, a conditional width counted only when a break occurs at this point. It reserves space for the current note's right projection, any melisma overhang that would extend past the right margin, terminal right-barline clearance, and measure-bar transfers, when the next note's left measure bar moves to this note's right side at a line break.
-- $m_i$ is the minimum same-line width required between notes $i$ and $i{+}1$.
+- $w_i$ is the penalty width, a conditional width counted only when a break occurs at this point. It reserves space for the current note's right projection, any melisma overhang that would extend past the right margin, terminal right-barline clearance, and a following note's left measure-bar transfer.
+- $m_i$ is the preferred same-line width between notes $i$ and $i{+}1$.
 
-On the same line, each inter-note gap contributes $m_i$ of width plus $s^+$ of stretch for distributed justification.
-The candidate penalty sits immediately after the neume; the post-break glue $\text{glue}(m_i, s^+, s^-)$ contributes both the fixed minimum distance and the stretch or shrink budget.
-The current implementation allows negative values only in the width $m_i$, when tuck absorption exceeds the base spacing; stretch and shrink are never negative.
+On the same line, each inter-note gap starts at $m_i$ and may use $s^+$ of stretch or $s^-$ of shrink during distributed justification.
+The candidate penalty sits immediately after the neume; the post-break glue $\text{glue}(m_i, s^+, s^-)$ carries both the preferred distance and its elasticity.
+Ordinary note-to-note spacing retains the full standard-glue shrink budget.
+Visual collision, measure-bar, lyric, and melisma clearance affect the preferred width $m_i$ but remain compressible during justification.
+The current implementation keeps stretch and shrink non-negative, but item widths may be negative.
+Negative glue widths can come from tuck absorption, user-requested negative inline spacing, or glue reductions paired with line-start reservation boxes.
+Because `spaceAfter` is part of a note, martyria, or tempo box advance and may itself be negative, an extreme value can also make that box width negative.
+It also preserves a negative user spacing adjustment for ordinary note pairs when the visual helper has only its generic zero clamp rather than a real positive collision requirement; lyric and measure-bar preferences still take precedence when computing $m_i$.
 In other words, all stretchability lives in the same glue that carries the same-line boundary width.
 The implementation does not use a second glue of the form $\text{glue}(m_i, -s^+, -s^-)$.
 
@@ -270,8 +288,11 @@ This prevents positive adjustment ratio from being spent as invisible stretch af
 The next note's left projection $\text{glue}(L_{i+1}, 0, 0)$ lies past that barrier, so it is not discarded and protects the left edge of the new line.
 The penalty width $w_i$ remains the break-only quantity: it cannot live in the post-break glue, because that glue disappears at breaks.
 Its job is to reserve space for the right projection, melisma lyric overhang, terminal right-barline clearance, and measure-bar transfers that matter only at line end.
+`getBreakPenaltyWidth` also calculates the left-bar transfer for a following martyria, but the automatic note-to-martyria breakpoint has `MAX_COST` and cannot select that width.
+When an explicit break starts the next paragraph with that martyria, Phase 2 performs the visual transfer directly.
 
-When a hyphenated note is immediately followed by a note that carries lyrics, and a break is taken between them, a lyric hyphen is drawn at the start of the next line, before that lyric.
+When a hyphenated note is eligible for a leading hyphen, is immediately followed by a note that carries lyrics, and a break is taken between them, a lyric hyphen is drawn at the start of the next line, before that lyric.
+Eligibility depends on the Greek-melisma settings and the active lyric run; `mayShowLeadingLyricHyphen` contains the exact test.
 Like the measure-bar transfer, this reserves space at the start of the next line rather than at the end of the current one, so it uses a spacer-and-cancel pattern rather than the penalty width $w_i$.
 The boundary's post-break glue is narrowed by the extra leading width the line-start hyphen needs, and an anonymous spacer box of that width is inserted before the next note's box.
 On the same line the narrowed glue and the spacer cancel, leaving the note's position unchanged.
@@ -283,13 +304,13 @@ If a paragraph ends immediately after a note, `endParagraph` materializes that n
 It also reserves the clearance before a terminal right barline.
 It must do this because `removeGlue` strips the trailing post-break glue, while the forced break itself contributes penalty width 0.
 
-When a martyria follows a note, the martyria path replaces the note's trailing post-break glue with martyria glue: font-default martyria glue in the usual case, or the infinite-stretch right-martyria glue when the martyria is right-aligned.
+When a martyria follows a note, the martyria path replaces the note's trailing post-break glue: with font-default martyria glue in the usual case, standard glue when the martyria has a left tempo sign, or the dominant-stretch right-martyria glue when the martyria is right-aligned.
 When a non-right-aligned martyria follows a standalone tempo sign, the same replacement path uses standard glue and skips the pre-martyria lyric-collision spacer.
 Ordinary note-to-martyria lyric collision is still handled by `addLyricReservation`.
 However, if a melisma lyric overhang extends past the last neume, that remaining overhang is first materialized into the replacement martyria glue width so that it is not lost when the note's post-break glue is removed.
 A right-aligned martyria also preserves terminal right-barline clearance when it replaces the note's trailing glue.
 
-### Computing the minimum same-line width
+### Computing the preferred same-line width
 
 The code computes $m_i$ directly, rather than trying to force all lyric behavior into a single "reserve the full overshoot" rule.
 Conceptually,
@@ -305,7 +326,7 @@ First, some reservation can be _reclaimed_ when lyrics tuck under neighboring ne
 
 Second, if the resulting lyric gap is still too small, a collision correction is added back.
 So the code does not reserve lyric overshoot mechanically.
-It reserves only the width that is actually needed on the same line after tuck opportunities have been taken into account.
+It reserves only the preferred natural width needed on the same line after tuck opportunities have been taken into account.
 
 Before applying visual-ink and measure-bar floors, the same-line width is computed as
 
@@ -321,7 +342,7 @@ There is one deliberate exception to the ordinary base expression.
 When `exitsMelismaIntoCenteredLyric` is true, a carried melisma is ending at a non-melisma note whose centered lyric has a positive left projection.
 In that case the current cursor is already after the previous note's `spaceAfter`, so the code starts from base width 0 instead of $s_0 + R_i - T_i^\text{left} - T_i^\text{right}$.
 This aligns the next centered lyric's left edge with that cursor while preserving the user-defined extra spacing already included in the cursor position.
-The collision correction $\ell_i$ still runs afterward, including the carried-melisma check against `melismaLyricsEndPx`, and the final result is still floored by the visible note and measure-bar minimums.
+The collision correction $\ell_i$ still runs afterward, including the carried-melisma check against `melismaLyricsEndPx`, and the final result is still raised to the preferred visible-note and measure-bar widths.
 
 The collision check is geometry-based.
 When both notes carry lyrics, the code computes the actual visual gap between them from the neume overhangs relative to their lyrics, then adds back only the missing amount.
@@ -330,12 +351,12 @@ If the hyphen extends past the current neume, it appears in the carried melisma 
 If the hyphen fits entirely inside a wide current neume, there is no positive line-end overhang to reserve, so the same-line collision correction must still reserve enough visible gap for the hyphen glyph plus the ordinary lyric spacing.
 The same mechanism also handles melisma-to-non-melisma transitions.
 For same-line spacing, the carried lyric end is treated as a signed distance from the current cursor, so the next syllable is pushed right only as much as necessary whether the carried lyric ends before or after that cursor.
-After this lyric calculation, the boundary is floored by any visible note collision minimum and by any visible measure-bar minimum, with the next note's absorbed left projection subtracted so that long lyrics can still tuck left on the same line.
+After this lyric calculation, the boundary is raised to any larger preferred visible-note or measure-bar width, with the next note's absorbed left projection subtracted so that long lyrics can still tuck left on the same line.
 
 ### Break-only reservation
 
 The break-only reservation is simpler.
-Let $\textit{melismaOverhang}_i$ be the distance by which the current syllable, tracked by `melismaLyricsEndPx`, still extends past the current neume; let $\textit{terminalBarline}_i$ be the clearance reserved when the current note's right barline remains terminal at a break; and let $\textit{measureBarTransfer}_i$ be the width that must be reserved when a left measure bar on the next note transfers to the right side of the current note at a break:
+Let $\textit{melismaOverhang}_i$ be the distance by which the current syllable, tracked by `melismaLyricsEndPx`, still extends past the current neume; let $\textit{terminalBarline}_i$ be the clearance reserved when the current note's right barline remains terminal at a break; and let $\textit{measureBarTransfer}_i$ be the width that must be reserved when the following note's left measure bar transfers to the right side of the current note at a break:
 
 $$w_i = \max(R_i, \textit{melismaOverhang}_i) + \textit{terminalBarline}_i + \textit{measureBarTransfer}_i.$$
 
@@ -351,7 +372,7 @@ After all of the lyric geometry has been reduced to these quantities:
 ### Melismas
 
 Melisma lyrics require special treatment.
-When a melisma starts with a lyric wider than the neume, the lyric is left-aligned and extends to the right under subsequent melisma neumes.
+When an eligible melisma start passes `shouldAlignLeft`'s lyric-vs-neume width test, the lyric is left-aligned and extends to the right under subsequent melisma neumes.
 Therefore the code does _not_ encode the entire excess width as a right projection on the start note.
 
 Instead:
@@ -372,31 +393,31 @@ The `tex-linebreak` library exposes this through `initialMaxAdjustmentRatio` and
 We use those parameters, but not in the library's built-in "try one pass, then relax and accept the first feasible answer" style.
 Since Byzantine notation has no analogue of hyphenation, the candidate note sequence is the same on every pass, so we can search over the ratio cap itself.
 
-The optimization is therefore lexicographic:
+The policy is tiered rather than globally lexicographic:
 
-1. Minimize the worst positive adjustment ratio in the paragraph.
-2. Subject to that minimal cap, minimize the ordinary Knuth-Plass demerits.
+1. If a solution exists with every positive adjustment ratio at or below 1, minimize the ordinary Knuth-Plass demerits within that cap. The code does not try to minimize the worst ratio below 1.
+2. Otherwise, approximate the smallest feasible cap above 1, round it up to a small bucket, and minimize ordinary demerits within that relaxed cap.
 
 In code, we first ask whether the paragraph can be broken with $r \le 1$ by setting
 `maxAdjustmentRatio = 1` and `initialMaxAdjustmentRatio = 1`.
-If that fails, we search for the smallest finite cap $R > 1$ for which the paragraph becomes feasible.
+If that fails, we search for an approximation to the smallest finite cap $R > 1$ for which the paragraph becomes feasible.
 We do this by doubling upward until a feasible cap is found and then binary-searching that interval.
-Once the minimal feasible cap has been located, we round it up to the next small bucket before the final solve.
+Once the search has narrowed the feasible cap, we round the best feasible solution's maximum positive ratio up to the next small bucket before the final solve.
 At present that bucket size is `0.05`, so a paragraph whose true minimum is, say, `1.12` is finally solved at cap `1.15`.
 This deliberately gives the optimizer a small tolerance band in which breakpoint penalties can still break ties, rather than forcing it to spend a strong semantic penalty merely to shave a few hundredths off the worst line.
 
 The important point is that, whenever a finite cap is in force, we set both ratio options to the same value.
 This library takes the effective cap to be the minimum of `initialMaxAdjustmentRatio` and `maxAdjustmentRatio`, so leaving the initial pass at a different value would quietly impose a different threshold than the one we are searching for.
-If the upward search fails to find any finite feasible cap before the hard ceiling (currently `4096`), the code falls back to an uncapped solve by using `maxAdjustmentRatio = null` and `initialMaxAdjustmentRatio = Infinity`.
+If the upward search fails to find any finite feasible cap at or below the hard ceiling (currently `4096`), the code falls back to an uncapped solve by using `maxAdjustmentRatio = null` and `initialMaxAdjustmentRatio = Infinity`.
 
 This formulation cleanly separates the two use cases we care about:
 
-- when all candidate lines can stay at or below $r = 1$, the solver fully uses the breakpoint penalties to choose among those tight and neutral layouts;
+- when the paragraph has a feasible layout at or below $r = 1$, the solver fully uses the ordinary demerits and breakpoint penalties to choose among all layouts under that cap;
 - once every solution requires some looseness, the primary objective becomes keeping the maximum ratio as small as possible, so a breakpoint that yields $r = 1.1$ can beat one that yields $r = 1.3$ even if the former is discouraged.
 
-Within a fixed cap, the ordinary Knuth-Plass scoring still applies.
-That means breakpoint penalties continue to matter as tie-breakers among layouts whose worst line is equally loose, and `adjacentLooseTightPenalty` still discourages abrupt fitness-class jumps between neighboring lines.
-The `0.05` bucket makes this tie-breaking zone slightly wider on purpose.
+Within a fixed cap, the ordinary Knuth-Plass scoring applies across all layouts that satisfy the cap; it does not separately prefer the smallest maximum ratio inside that feasible set.
+Breakpoint penalties therefore can select a semantically preferable layout with a slightly larger ratio inside the same bucket, and `adjacentLooseTightPenalty` still discourages abrupt fitness-class jumps between neighboring lines.
+The `0.05` bucket creates this small tradeoff zone on purpose.
 
 ## Relaxing $\TeX$'s Restriction 1
 
@@ -510,7 +531,8 @@ $$F(c) > L + a.\text{totalWidth} - a.\text{totalShrink},$$
 then every later segment floor satisfies $F_a(c) > L$, so every such line remains overfull.
 In that case no future breakpoint can rescue $a$, and pruning is safe.
 
-This is exactly what the implementation computes: the suffix minimum of $F(b)$ over strictly later breakpoints, followed by a comparison with the node-dependent threshold.
+For ordinary active nodes, this is what the implementation computes: the suffix minimum of $F(b)$ over strictly later breakpoints, followed by a comparison with the node-dependent threshold.
+There is one conservative exception: if the paragraph contains any negative width, fallback active nodes are not pruned with this test.
 
 ### What can go wrong
 
@@ -557,7 +579,7 @@ For that reason the implementation also disables the optimization whenever any g
 
 ### Implementation
 
-The relaxation adds a small $O(n)$ precomputation ahead of the usual dynamic-programming pass:
+When no glue has negative stretch or shrink, the relaxation adds a small $O(n)$ precomputation ahead of the usual dynamic-programming pass:
 
 1. A forward pass walks the paragraph once and records the floor
 
@@ -571,6 +593,7 @@ During the main search, the pruning rule becomes:
 
 - keep the classic $\TeX$ check $r < -1$ for the current breakpoint;
 - prune only if the suffix-minimum floor is still above the active node's overfull threshold;
+- do not apply the pruning test to a fallback active node if any item in the paragraph has negative width;
 - disable the optimization entirely if any glue has negative stretch or negative shrink.
 
 This preserves the original asymptotic complexity.
@@ -578,15 +601,15 @@ The extra work is linear in the number of items and requires one additional arra
 
 ### Results
 
-For the Byzantine music inputs that motivated this work, the relaxation preserves the useful $\TeX$ pruning behavior even when negative widths appear in the paragraph encoding.
+For the Byzantine music inputs that motivated this work, the relaxation preserves useful $\TeX$ pruning behavior for ordinary active nodes even when negative widths appear in the paragraph encoding.
 The old "any negative value disables pruning" rule was safe, but it threw away pruning in exactly the cases where a later breakpoint could still rescue the line.
-The new rule keeps those rescuing cases alive while still pruning nodes that are genuinely irrecoverable.
+The new rule keeps those rescuing cases alive while still pruning ordinary nodes that are genuinely irrecoverable; fallback nodes remain conservative when any width is negative.
 
 The asymptotic worst-case bound does not change.
 With or without the relaxation, the dynamic-programming search is still worst-case $O(\min(wn, n^2))$.
 What changes is the practical behavior on negative-width inputs.
 Under the old rule, any negative value disabled pruning entirely, so those inputs were pushed much more often toward the unpruned quadratic search.
-Under the new rule, the supported negative-width cases recover the same pruning logic used in the ordinary non-negative setting, so they avoid that needless loss of pruning.
+Under the new rule, the supported negative-width cases recover the ordinary pruning logic for non-fallback active nodes, so they avoid much of that needless loss of pruning.
 In other words, the relaxation does not improve the formal worst-case bound; it prevents negative-width music inputs from suffering an avoidable practical degradation toward that worst case.
 
 ## Future work

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -937,7 +937,6 @@ export class TextBoxElement extends ScoreElement {
   public minHeight: number = 10;
 
   // Re-render helpers
-  public heightPrevious: number = 0;
   public computedFontFamilyPrevious: string = '';
   public computedFontSizePrevious: number = Unit.fromPt(20);
   public computedFontWeightPrevious: string = '400';

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -74,8 +74,10 @@ import {
 } from '@/services/NeumeMappingService';
 import { TATWEEL } from '@/utils/constants';
 import { resolveFontCss, resolveFontStyle } from '@/utils/fontStyle';
+import type { ResolvedPageMargins } from '@/utils/PageMargins';
 import { resolvePageMargins } from '@/utils/PageMargins';
-import { resolveRunningMarkerPageMetadata } from '@/utils/runningMarkers';
+import type { RunningMarkerPageMetadata } from '@/utils/runningMarkers';
+import { resolveNextRunningMarkerPageMetadata } from '@/utils/runningMarkers';
 import { Unit } from '@/utils/Unit';
 
 import { fontService } from './FontService';
@@ -96,24 +98,22 @@ const idealMaxAdjustmentRatio = 1;
 const adjustmentRatioCapStep = 0.05;
 const maxAdjustmentRatioSearchLimit = 4096;
 const maxAdjustmentRatioSearchIterations = 24;
-// A tiny positive epsilon, used to floor the stretch of any glue derived from
-// possibly non-positive inline spacing. Keeps the adjustment ratio finite for
-// paragraphs that contain no martyria, while being far below the neume scale so
-// it has no visible effect.
+// A small positive lower bound for stretch budgets. Under the preferred
+// adjustment-ratio cap of 1, each glue raised to this floor grows by at most
+// this amount. A relaxed cap can multiply the contribution.
 const minGlueStretch = 0.1;
 const minGlueShrink = 0;
 
-const tieSet = new Set<VocalExpressionNeume | Tie>([
-  VocalExpressionNeume.HeteronConnecting,
-  VocalExpressionNeume.HeteronConnectingLong,
-  VocalExpressionNeume.HomalonConnecting,
-  Tie.YfenAbove,
-  Tie.YfenBelow,
-]);
+interface BalancedMartyriaBoundary {
+  leadingWidth: number;
+  shrink: number;
+  trailingWidth: number;
+}
 
-// These marks tie two notes together. So collisions should not cause
-// extra space between the neumes because that would ruin the position of the ties.
-const collisionSpacingIgnoredMarkSet = new Set<VocalExpressionNeume | Tie>([
+// These marks tie two notes together. Automatic breaks across them are
+// prohibited, and collisions with them should not add space between the neumes
+// because that would ruin the position of the ties.
+const tieSet = new Set<VocalExpressionNeume | Tie>([
   VocalExpressionNeume.HeteronConnecting,
   VocalExpressionNeume.HeteronConnectingLong,
   VocalExpressionNeume.HomalonConnecting,
@@ -222,10 +222,7 @@ const secondaryGorgonNeumeSet = new Set<GorgonNeume>([
 
 interface GetNoteWidthArgs {
   lyricsVerticalOffset: number;
-  vareiaWidth: number;
   measureBarWidthMap: Map<MeasureBar, number>;
-  runningElaphronWidth: number;
-  elaphronWidth: number;
   paragraphStyles: ParagraphStyle[];
 }
 
@@ -279,18 +276,18 @@ interface LayoutWorkspace {
   pendingDropCapWidthPx: number;
   pendingDropCapContinuationLines: number;
 
-  // When a martyria with a transferable measure bar is followed by a note,
-  // the martyria's post-break glue is reduced by the bar width plus its
-  // fixed leading clearance, and an anonymous spacer box of the same width is
-  // inserted before the note. On the same line, the reduced glue and the
-  // spacer cancel, leaving the note's own box position unchanged. At a break
-  // the post-break glue vanishes; the spacer remains at the start of the next
-  // line and reserves fixed leading space for the transferred bar.
+  // When a martyria with a transferable measure bar is followed in the same
+  // paragraph by a note without its own left bar, the martyria's post-break glue
+  // is reduced by the bar width plus its collision-aware leading clearance, and
+  // an anonymous spacer box of the same width is inserted before the note. On
+  // the same line, the reduced glue and spacer cancel. At an automatic break,
+  // the glue vanishes and the spacer reserves non-stretching leading space for
+  // the transferred bar.
   pendingMartyriaBarTransferWidth: number;
 
-  // When a hyphenated note is followed immediately by a note with lyrics, the
-  // previous note's post-break glue is reduced by any extra leading room
-  // needed to render a line-start lyric hyphen before the next lyric.
+  // When an eligible hyphenated note is followed immediately by a note with
+  // lyrics, the previous note's post-break glue is reduced by any extra leading
+  // room needed to render a line-start lyric hyphen before the next lyric.
   // An anonymous spacer box of the same width is inserted before the next
   // note so same-line positions cancel while a broken line keeps the room.
   pendingLeadingLyricHyphenReservationWidth: number;
@@ -404,13 +401,12 @@ export class LayoutService {
     // be used later. This is so we don't unnecessarily
     // calculate them more than once during the loop.
 
-    const neumeHeight = TextMeasurementService.getFontHeight(
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
+    const neumeFont = this.getNeumeFont(pageSetup);
 
-    const neumeAscent = TextMeasurementService.getFontBoundingBoxAscent(
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
+    const neumeHeight = TextMeasurementService.getFontHeight(neumeFont);
+
+    const neumeAscent =
+      TextMeasurementService.getFontBoundingBoxAscent(neumeFont);
     const defaultLyricsFontCss = this.getDefaultLyricsFont(
       score.paragraphStyles,
     );
@@ -433,38 +429,11 @@ export class LayoutService {
     const lyricAscent =
       TextMeasurementService.getFontBoundingBoxAscent(defaultLyricsFontCss);
 
-    const vareiaMapping = NeumeMappingService.getMapping(
-      VocalExpressionNeume.Vareia,
-    );
-    const vareiaWidth = TextMeasurementService.getTextWidth(
-      vareiaMapping.text,
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
-
     const measureBarWidthMap = this.getMeasureBarWidthMap(pageSetup);
-
-    const elaphronMapping = NeumeMappingService.getMapping(
-      QuantitativeNeume.Elaphron,
-    );
-    const elaphronWidth = TextMeasurementService.getTextWidth(
-      elaphronMapping.text,
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
-
-    const runningElaphronMapping = NeumeMappingService.getMapping(
-      QuantitativeNeume.RunningElaphron,
-    );
-    const runningElaphronWidth = TextMeasurementService.getTextWidth(
-      runningElaphronMapping.text,
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
 
     const noteWidthArgs: GetNoteWidthArgs = {
       lyricsVerticalOffset,
-      vareiaWidth,
       measureBarWidthMap,
-      runningElaphronWidth,
-      elaphronWidth,
       paragraphStyles: score.paragraphStyles,
     };
 
@@ -473,85 +442,45 @@ export class LayoutService {
     // Process Header and Footers
     // Only a single text box is supported right now
     if (score.pageSetup.showHeader) {
-      this.processHeader(
+      for (const header of [
         score.headers.default,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processHeader(
         score.headers.chapterOpening,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processHeader(
         score.headers.odd,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processHeader(
         score.headers.even,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processHeader(
         score.headers.firstPage,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
+      ]) {
+        this.processHeaderFooter(
+          header,
+          pageSetup,
+          neumeHeight,
+          score.paragraphStyles,
+          defaultLyricsFontCss,
+        );
+      }
     }
 
     if (score.pageSetup.showFooter) {
-      this.processFooter(
+      for (const footer of [
         score.footers.default,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processFooter(
         score.footers.chapterOpening,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processFooter(
         score.footers.odd,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processFooter(
         score.footers.even,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
-      this.processFooter(
         score.footers.firstPage,
-        pageSetup,
-        neumeHeight,
-        score.paragraphStyles,
-        defaultLyricsFontCss,
-      );
+      ]) {
+        this.processHeaderFooter(
+          footer,
+          pageSetup,
+          neumeHeight,
+          score.paragraphStyles,
+          defaultLyricsFontCss,
+        );
+      }
     }
 
-    // Knuth-Plass requires stretch >= 0 and shrink >= 0. Floor both so
-    // negative inline spacing (which users can create to overlap neumes)
-    // doesn't break line breaking. `width` is left untouched so the overlap
-    // itself is preserved.
+    // Keep this encoding's elasticity non-negative so adjustment ratios retain
+    // their conventional meaning and tex-linebreak can use its suffix-floor
+    // pruning. `width` is left untouched, preserving negative inline spacing
+    // that users can create to overlap neumes.
     const inlineSpacing = this.getInlineSpacing(pageSetup);
     const standardGlueDefaults = fontService.getStandardGlue(
       pageSetup.neumeDefaultFontFamily,
@@ -607,44 +536,25 @@ export class LayoutService {
             defaultLyricsFontCss,
           );
 
+          this.addLyricReservation(
+            elementWidthPx,
+            elements[i],
+            layoutWorkspace,
+          );
+          this.addBox(elementWidthPx, textBoxElement, layoutWorkspace);
+
           if (isFillWidthTextBox) {
             // Phase 1 uses the textbox's intrinsic width as a lower bound.
             // Phase 2 resolves the actual fill width from the next positioned
             // item or the line end.
-            this.addLyricReservation(
-              elementWidthPx,
-              elements[i],
-              layoutWorkspace,
-            );
-            this.addBox(elementWidthPx, textBoxElement, layoutWorkspace);
             this.addFillWidthGlue(layoutWorkspace);
           } else {
-            this.addLyricReservation(
-              elementWidthPx,
-              elements[i],
-              layoutWorkspace,
-            );
-            this.addBox(elementWidthPx, textBoxElement, layoutWorkspace);
             this.addGlue(standardGlue, layoutWorkspace, 'standard');
           }
 
           if (!textBoxElement.inline && !lineBreak) {
             lineBreak = true;
             lineBreakType = LineBreakType.Justify;
-          }
-
-          // A fill-width element must terminate the paragraph so Phase 2 can
-          // resolve its width against the line end. Use Left so the rest of the
-          // line is not justified. Exception: if the next element is a
-          // right-aligned martyria, let the martyria handler terminate the
-          // paragraph instead so the box fills up to that martyria.
-          if (
-            isFillWidthTextBox &&
-            !lineBreak &&
-            this.shouldTerminateAfterFillWidthElement(elements, i)
-          ) {
-            lineBreak = true;
-            lineBreakType = LineBreakType.Left;
           }
 
           break;
@@ -664,10 +574,7 @@ export class LayoutService {
             // and match neume fonts, so it doesn't matter. If it were possible, it would be necessary to put the
             // information on each text box because it could be different for each box.
             richTextBoxElement.defaultLyricsFontHeight =
-              this.getLyricsFontHeightFromCache(
-                fontHeightCache,
-                defaultLyricsFontCss,
-              );
+              this.getLyricsFontHeightFromCache(defaultLyricsFontCss);
 
             richTextBoxElement.defaultNeumeFontAscent = neumeAscent;
 
@@ -699,20 +606,6 @@ export class LayoutService {
           if (!richTextBoxElement.inline && !lineBreak) {
             lineBreak = true;
             lineBreakType = LineBreakType.Justify;
-          }
-
-          // A fill-width element must terminate the paragraph so Phase 2 can
-          // resolve its width against the line end. Use Left so the rest of the
-          // line is not justified. Exception: if the next element is a
-          // right-aligned martyria, let the martyria handler terminate the
-          // paragraph instead so the box fills up to that martyria.
-          if (
-            isFillWidthRichTextBox &&
-            !lineBreak &&
-            this.shouldTerminateAfterFillWidthElement(elements, i)
-          ) {
-            lineBreak = true;
-            lineBreakType = LineBreakType.Left;
           }
 
           break;
@@ -785,8 +678,7 @@ export class LayoutService {
         case ElementType.Note: {
           // PROCESS NOTE
           const noteElement = elements[i] as NoteElement;
-          const elementWidthPx =
-            noteElement.spaceAfter + noteElement.neumeWidth;
+          const elementWidthPx = this.getNoteBoxAdvance(noteElement);
 
           // Consume any pending martyria bar transfer width.
           const martyriaBarTransferWidth =
@@ -818,12 +710,17 @@ export class LayoutService {
           //
           //   penalty(inf)         protect the left projection
           //   glue(L_i, 0, 0)      fixed left projection
-          //   box(B_i)             the neume
+          //   box(B_i)             note advance: neumeWidth + spaceAfter
           //   penalty(cost, w_i)   candidate breakpoint
           //   glue(m_i, s^+, s^-)  same-line spacing that vanishes at breaks
           //
-          // On the same line, each note boundary contributes m_i of width plus
-          // s^+ of stretch for justification.
+          // This is the ordinary note-to-note form. Before a martyria, the
+          // note's post-break glue is fixed because the martyria path replaces
+          // it and supplies the boundary elasticity.
+          //
+          // m_i is the preferred same-line width. For ordinary note-to-note
+          // boundaries, visual, measure-bar, lyric, and melisma minima are all
+          // preferred widths and do not cap the standard shrink budget s^-.
           //
           // At a break, the final glue becomes leading glue on the next line
           // and is skipped by positionItems, so m_i and its elasticity
@@ -833,16 +730,20 @@ export class LayoutService {
           // right-barline clearance is also reserved when the current note's
           // barline remains at line end.
           //
-          // m_i = s_0 + R_i - T_i^left - T_i^right + ell_i, where s_0 is the
-          // fixed inline spacing, floored by any fixed measure-bar clearance.
+          // m_i usually starts from
+          // s_0 + R_i - T_i^left - T_i^right + ell_i, then is raised to any
+          // larger preferred visual, measure-bar, lyric, or carried-melisma
+          // width. The carried-melisma-to-centered-lyric case starts at 0; see
+          // calculateInterNoteSpacing.
           // R_i is the right projection, ell_i is the lyric-collision
           // correction, T_i^left is the absorbed portion of L_{i+1}, and
           // T_i^right is the portion of R_i that tucks under the next neume.
           // For hyphenated melismas,
           // ell_i also enforces that the visible lyric gap is wide enough to
           // hold the hyphen glyph when that hyphen is absorbed inside the
-          // current neume and therefore contributes no overhang. m_i may be
-          // negative if a large left projection is absorbed.
+          // current neume and therefore contributes no overhang. m_i may also
+          // stay negative when the user requests overlapping notes and no real
+          // collision, lyric, or barline floor binds.
           //
           // If a paragraph ends immediately after a note, endParagraph moves
           // that note's trailing reservation (right projection, melisma
@@ -896,24 +797,21 @@ export class LayoutService {
 
           const hyphenWidthForThisElement =
             noteElement.isMelismaStart && noteElement.isHyphen
-              ? this.getTextWidthFromCache(textWidthCache, noteElement, '-')
+              ? this.getTextWidthFromCache(noteElement, '-')
               : 0;
           // In the absorbed-hyphen case, the visible gap between syllables must
           // hold both the hyphen glyph and the ordinary lyric spacing before
           // the next syllable.
           const minimumLyricGap =
             pageSetup.lyricsMinimumSpacing + hyphenWidthForThisElement;
-          if (noteElement.isMelismaStart && noteElement.isHyphen) {
+          if (noteElement.isMelismaStart) {
             layoutWorkspace.melismaLyricsEndPx =
               noteElement.spaceAfter + lyricsEnd + hyphenWidthForThisElement;
-          } else if (noteElement.isMelismaStart) {
-            layoutWorkspace.melismaLyricsEndPx =
-              noteElement.spaceAfter + lyricsEnd;
           } else if (!noteElement.isMelisma) {
             layoutWorkspace.melismaLyricsEndPx = null;
           }
 
-          // The neume box (unchanged by the bar transfer).
+          // The note box advance (unchanged by the bar transfer).
           this.addBox(elementWidthPx, noteElement, layoutWorkspace);
 
           const nextElement = this.getElementAt(elements, i + 1);
@@ -935,7 +833,6 @@ export class LayoutService {
             )
           ) {
             const leadingLyricHyphenWidth = this.getTextWidthFromCache(
-              textWidthCache,
               nextNoteElement,
               '-',
             );
@@ -984,8 +881,10 @@ export class LayoutService {
           // here. It reserves space for:
           // 1. Right projection (lyric extending past the neume).
           // 2. Melisma lyric overhang past the neume.
-          // 3. Measure bar transfer (the next note's left bar moves to this
-          //    note's right side at a break).
+          // 3. Measure bar transfer (the following note's left bar moves to
+          //    this note's right side). getBreakPenaltyWidth also calculates a
+          //    following martyria's left bar, but automatic breaks before a
+          //    martyria are prohibited; explicit transfer is handled in Phase 2.
           // 4. Terminal clearance before the current note's right barline.
           // These costs are break-conditional and cannot go in m_i (which
           // vanishes at breaks via the post-break glue).
@@ -1011,9 +910,9 @@ export class LayoutService {
 
           // Break opportunity after the neume. The candidate penalty sits
           // immediately after the box, and the post-break glue contributes
-          // same-line spacing and elasticity. When a break is taken, that glue
-          // becomes leading glue on the next line and is skipped by
-          // positionItems.
+          // same-line spacing and, ordinarily, elasticity. When a break is
+          // taken, that glue becomes leading glue on the next line and is
+          // skipped by positionItems.
           this.addPenalty(layoutWorkspace, breakCost, penaltyWidth);
           this.addGlue(postBreakGlue, layoutWorkspace);
 
@@ -1074,7 +973,7 @@ export class LayoutService {
           // the ordinary note-martyria-note case where the martyria owns both
           // sides of the boundary glue and no inline measure bars or side
           // tempo signs need their existing special-case spacing rules.
-          const isBalancedMartyriaBetweenNotes =
+          const balancedMartyriaNeighbors =
             !martyriaElement.alignRight &&
             previousNote != null &&
             nextNote != null &&
@@ -1083,10 +982,10 @@ export class LayoutService {
             LayoutService.getVisibleMeasureBarLeft(martyriaElement) == null &&
             LayoutService.getVisibleMeasureBarRight(martyriaElement) == null &&
             LayoutService.getVisibleMeasureBarRight(previousNote) == null &&
-            LayoutService.getVisibleMeasureBarLeft(nextNote) == null;
-          let sharedLeadingBoundaryWidth: number | null = null;
-          let sharedTrailingBoundaryWidth: number | null = null;
-          let sharedBoundaryShrink: number | null = null;
+            LayoutService.getVisibleMeasureBarLeft(nextNote) == null
+              ? { nextNote, previousNote }
+              : null;
+          let balancedBoundary: BalancedMartyriaBoundary | null = null;
           const skipLyricCollision =
             !martyriaElement.alignRight &&
             layoutWorkspace.pendingParagraph.length > 0 &&
@@ -1152,7 +1051,8 @@ export class LayoutService {
               leftLyricMinimum,
             );
 
-            if (isBalancedMartyriaBetweenNotes) {
+            if (balancedMartyriaNeighbors != null) {
+              const { nextNote, previousNote } = balancedMartyriaNeighbors;
               // Balance the martyria against the nearest visible boundary on
               // each side. A lyric overhang toward the martyria replaces the
               // neume ink edge for that side; otherwise the neume ink edge
@@ -1175,8 +1075,8 @@ export class LayoutService {
                 leftHardLyricMinimum,
               );
               const nextNoteLeftProjection = this.getLyricProjections(
-                nextNote!,
-                nextNote!.alignLeft,
+                nextNote,
+                nextNote.alignLeft,
               ).leftProjection;
               const rightBoundaryMinimum =
                 Math.max(
@@ -1189,44 +1089,49 @@ export class LayoutService {
                 this.getMartyriaLeftInkOverhang(martyriaElement, pageSetup) +
                 Math.max(
                   previousLyricRightOverhang,
-                  this.getElementRightInkOverhang(previousNote!, pageSetup),
+                  this.getElementRightInkOverhang(previousNote, pageSetup),
                 );
               const rightVisibleBoundaryWidth =
                 this.getMartyriaRightInkOverhang(martyriaElement, pageSetup) +
                 Math.max(
                   nextNoteLeftProjection,
-                  this.getElementLeftInkOverhang(nextNote!, pageSetup),
+                  this.getElementLeftInkOverhang(nextNote, pageSetup),
                 );
               const sharedVisibleWhitespace = Math.max(
                 leftBoundaryMinimum - leftVisibleBoundaryWidth,
                 rightBoundaryMinimum - rightVisibleBoundaryWidth,
               );
-              sharedLeadingBoundaryWidth =
+              const leadingWidth =
                 sharedVisibleWhitespace + leftVisibleBoundaryWidth;
-              sharedTrailingBoundaryWidth =
+              const trailingWidth =
                 sharedVisibleWhitespace +
                 rightVisibleBoundaryWidth -
                 nextNoteLeftProjection;
-              sharedBoundaryShrink = Math.min(
-                baseGlue.shrink,
-                Math.max(0, sharedLeadingBoundaryWidth - leftHardMinimum),
-                Math.max(
-                  0,
-                  sharedTrailingBoundaryWidth +
-                    nextNoteLeftProjection -
-                    rightHardMinimum,
+              balancedBoundary = {
+                leadingWidth,
+                shrink: Math.min(
+                  baseGlue.shrink,
+                  Math.max(0, leadingWidth - leftHardMinimum),
+                  Math.max(
+                    0,
+                    trailingWidth + nextNoteLeftProjection - rightHardMinimum,
+                  ),
                 ),
-              );
+                trailingWidth,
+              };
             }
             const newGlue =
-              sharedLeadingBoundaryWidth != null
+              balancedBoundary != null
                 ? {
                     ...this.createMartyriaLeadingGlue(
                       baseGlue,
-                      Math.max(0, sharedLeadingBoundaryWidth - baseGlue.width),
+                      Math.max(
+                        0,
+                        balancedBoundary.leadingWidth - baseGlue.width,
+                      ),
                       leftBoundaryMinimum,
                     ),
-                    shrink: sharedBoundaryShrink!,
+                    shrink: balancedBoundary.shrink,
                   }
                 : this.createMartyriaLeadingGlue(
                     baseGlue,
@@ -1237,7 +1142,7 @@ export class LayoutService {
                   );
             // Pair a fixed spacer with a matching leading-glue reduction. On the
             // same line they cancel; at line start the leading glue is skipped
-            // and the spacer makes Phase 1 reserve the later ink-overhang shift.
+            // and the spacer reserves room for the martyria's left ink overhang.
             this.addGlue(
               this.offsetGlueWidth(newGlue, lineStartMartyriaShift),
               layoutWorkspace,
@@ -1281,18 +1186,14 @@ export class LayoutService {
           this.addBox(elementWidthPx, martyriaElement, layoutWorkspace);
 
           // Compute the measure bar width that would transfer from this
-          // martyria to the next line's first note. On the same line, the
-          // reduced post-break glue is cancelled by an anonymous spacer box
-          // inserted before the note, so the note's position is unchanged.
-          // At a break, the post-break glue vanishes; the spacer remains at
-          // the start of the next line and reserves collision-aware leading
-          // space for the bar.
+          // martyria to the next line's first note at an automatic break in the
+          // same paragraph. A note with its own left bar is not eligible. On the
+          // same line, the reduced post-break glue is cancelled by an anonymous
+          // spacer before the note. At a break, the glue vanishes and the spacer
+          // reserves collision-aware leading space for the transferred bar.
           const nextNoteForBar = this.getNoteIfPresentAt(elements, i + 1);
-          const martyriaTransferBar = martyriaElement.measureBarLeft?.endsWith(
-            'Above',
-          )
-            ? measureBarAboveToLeft.get(martyriaElement.measureBarLeft)
-            : martyriaElement.measureBarRight;
+          const martyriaTransferBar =
+            this.getMartyriaTransferBar(martyriaElement);
           const martyriaBarTransferWidth =
             martyriaTransferBar &&
             nextNoteForBar &&
@@ -1308,8 +1209,8 @@ export class LayoutService {
           layoutWorkspace.pendingMartyriaBarTransferWidth =
             martyriaBarTransferWidth;
 
-          // Martyria break opportunity. Keep the fixed martyria spacing after
-          // the martyria when it stays mid-line, but make that spacing
+          // Martyria break opportunity. Keep the preferred martyria spacing
+          // after the martyria when it stays mid-line, but make that spacing
           // disappear when a break is taken here. Embedded or standalone tempo
           // cases can switch that trailing spacing to standard glue.
           // The bar transfer width is subtracted so that on the same line it
@@ -1329,18 +1230,18 @@ export class LayoutService {
             this.fixedGlue(0),
             0,
             breakPenaltyWidth,
-            sharedTrailingBoundaryWidth != null
+            balancedBoundary != null
               ? {
                   ...this.createMartyriaPostBreakGlue(
                     trailingGlue,
                     Math.max(
                       0,
-                      sharedTrailingBoundaryWidth - trailingGlue.width,
+                      balancedBoundary.trailingWidth - trailingGlue.width,
                     ),
                     martyriaBarTransferWidth,
                     rightSameLineMinimum,
                   ),
-                  shrink: sharedBoundaryShrink!,
+                  shrink: balancedBoundary.shrink,
                 }
               : this.createMartyriaPostBreakGlue(
                   trailingGlue,
@@ -1365,15 +1266,10 @@ export class LayoutService {
           // PROCESS TEMPO
           const tempoElement = elements[i] as TempoElement;
           const previousElement = this.getElementAt(elements, i - 1);
-          const tempoMapping = NeumeMappingService.getMapping(
-            tempoElement.neume,
-          );
 
           const elementWidthPx =
-            TextMeasurementService.getTextWidth(
-              tempoMapping.text,
-              `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-            ) + tempoElement.spaceAfter;
+            this.getNeumeWidthFromCache(tempoElement.neume, pageSetup) +
+            tempoElement.spaceAfter;
           tempoElement.neumeWidth = elementWidthPx;
           const skipLyricCollision =
             previousElement?.elementType === ElementType.Martyria &&
@@ -1501,30 +1397,26 @@ export class LayoutService {
           );
       }
 
+      // A fill-width element must terminate the paragraph so Phase 2 can
+      // resolve its width against the line end. Use Left so the rest of the
+      // line is not justified. Exception: if the next element is a
+      // right-aligned martyria, let the martyria handler terminate the
+      // paragraph instead so the box fills up to that martyria.
+      if (
+        this.isFillWidthElement(elements[i]) &&
+        !lineBreak &&
+        this.shouldTerminateAfterFillWidthElement(elements, i)
+      ) {
+        lineBreak = true;
+        lineBreakType = LineBreakType.Left;
+      }
+
       // A line break is implied before a block text box, rich-text box, image
       // box, or mode key element.
-      {
-        const nextElement: ScoreElement | null =
-          i + 1 < elements.length ? elements[i + 1] : null;
-        if (nextElement?.elementType === ElementType.TextBox) {
-          const textBoxElement = nextElement as TextBoxElement;
-          if (!textBoxElement.inline) {
-            lineBreak = true;
-          }
-        } else if (nextElement?.elementType === ElementType.RichTextBox) {
-          const richTextBoxElement = nextElement as RichTextBoxElement;
-          if (!richTextBoxElement.inline) {
-            lineBreak = true;
-          }
-        } else if (nextElement?.elementType === ElementType.ImageBox) {
-          const imageBoxElement = nextElement as ImageBoxElement;
-          if (!imageBoxElement.inline) {
-            lineBreak = true;
-          }
-        } else if (nextElement?.elementType === ElementType.ModeKey) {
-          // TODO support inline mode keys
-          lineBreak = true;
-        }
+      // TODO support inline mode keys
+      const nextElement = this.getElementAt(elements, i + 1);
+      if (nextElement != null && this.isBlockElement(nextElement)) {
+        lineBreak = true;
       }
 
       // Invariant: After processing each element, there should be trailing glue
@@ -1547,6 +1439,29 @@ export class LayoutService {
       number,
       { extraHeaderHeightPx: number; extraFooterHeightPx: number }
     >();
+
+    // Running-marker metadata is a left fold over pages: a page's metadata
+    // depends only on its own content and the previous page's metadata.
+    // Pages are appended in order, so fold each page exactly once when it
+    // has completed, and resolve the current, still-filling page on demand
+    // without folding it in.
+    let completedRunningMarkerPageCount = 0;
+    let completedRunningMarkerMetadata: RunningMarkerPageMetadata | null = null;
+    const resolveCurrentPageIsChapterOpening = () => {
+      while (completedRunningMarkerPageCount < pages.length - 1) {
+        completedRunningMarkerMetadata = resolveNextRunningMarkerPageMetadata(
+          pages[completedRunningMarkerPageCount],
+          completedRunningMarkerMetadata,
+        );
+        completedRunningMarkerPageCount++;
+      }
+
+      return resolveNextRunningMarkerPageMetadata(
+        page,
+        completedRunningMarkerMetadata,
+      ).isChapterOpening;
+    };
+
     // Keep header/footer overflow reservation stable within a physical page.
     // This mitigates intra-page drift when oversized headers/footers extend
     // outside the margins, but it is not a predictive pagination fix and does
@@ -1560,14 +1475,36 @@ export class LayoutService {
         return cachedHeights;
       }
 
+      // Running markers only affect header/footer selection, so skip the
+      // page scan entirely when neither is shown.
+      const isChapterOpening =
+        pageSetup.showHeader || pageSetup.showFooter
+          ? resolveCurrentPageIsChapterOpening()
+          : false;
       const extraHeights = this.getExtraHeaderFooterHeight(
         score,
         pageSetup,
-        pages,
+        physicalPageNumber,
+        isChapterOpening,
       );
       extraHeaderFooterHeightCache.set(physicalPageNumber, extraHeights);
 
       return extraHeights;
+    };
+
+    // Page margins depend only on the physical page number, so resolve them
+    // once per page instead of once per positioned element.
+    const resolvedPageMarginsCache = new Map<number, ResolvedPageMargins>();
+    const getCachedResolvedPageMargins = () => {
+      const physicalPageNumber = page.physicalPageNumber;
+      let resolvedMargins = resolvedPageMarginsCache.get(physicalPageNumber);
+
+      if (resolvedMargins == null) {
+        resolvedMargins = resolvePageMargins(pageSetup, physicalPageNumber);
+        resolvedPageMarginsCache.set(physicalPageNumber, resolvedMargins);
+      }
+
+      return resolvedMargins;
     };
 
     for (const [
@@ -1669,10 +1606,7 @@ export class LayoutService {
           continue;
         }
         const element = (item as ElementBox).element;
-        const resolvedMargins = resolvePageMargins(
-          pageSetup,
-          page.physicalPageNumber,
-        );
+        const resolvedMargins = getCachedResolvedPageMargins();
         const contentStart = pageSetup.melkiteRtl
           ? resolvedMargins.right
           : resolvedMargins.contentLeft;
@@ -1777,12 +1711,11 @@ export class LayoutService {
               // If the new line starts with a left measure, apply it to the
               // right of the previous line
               const previousNoteElement = previousElement as NoteElement;
-              if (
-                noteElement.measureBarLeft &&
-                !noteElement.measureBarLeft.endsWith('Above')
-              ) {
+              const transferredMeasureBar =
+                this.getMeasureBarTransferredFromLineStart(noteElement);
+              if (transferredMeasureBar) {
                 previousNoteElement.computedMeasureBarRight =
-                  noteElement.measureBarLeft;
+                  transferredMeasureBar;
               }
             } else if (
               previousElement?.elementType === ElementType.Martyria &&
@@ -1795,21 +1728,19 @@ export class LayoutService {
               // transferred to the next paragraph's first note.
               const previousMartyriaElement =
                 previousElement as MartyriaElement;
-              const normalizedMeasureBar =
-                previousMartyriaElement.measureBarLeft?.endsWith('Above')
-                  ? measureBarAboveToLeft.get(
-                      previousMartyriaElement.measureBarLeft,
-                    )
-                  : previousMartyriaElement.measureBarRight;
+              const normalizedMeasureBar = this.getMartyriaTransferBar(
+                previousMartyriaElement,
+              );
               // Only transfer if the note doesn't already have its own
               // measureBarLeft: getNoteWidth already accounted for the
               // explicit one in Phase 1.
               if (normalizedMeasureBar && !noteElement.measureBarLeft) {
                 noteElement.computedMeasureBarLeft = normalizedMeasureBar;
-                // Phase 1 reserved fixed leading space for this barline and its
-                // clearance via an anonymous spacer box before the note. Shift
-                // the note left so the rendered barline occupies that reserved
-                // space instead of adding extra width. Adjust neumeWidth and
+                // Phase 1 reserved non-stretching leading space for this
+                // barline and its collision-aware clearance via an anonymous
+                // spacer box before the note. Shift the note left so the
+                // rendered barline occupies that reserved space instead of
+                // adding extra width. Adjust neumeWidth and
                 // lyricsHorizontalOffset so lyrics center under the neume body.
                 const barlineWidth =
                   measureBarWidthMap.get(normalizedMeasureBar) ?? 0;
@@ -1838,9 +1769,7 @@ export class LayoutService {
             if (previousElement?.elementType === ElementType.Note) {
               const previousNoteElement = previousElement as NoteElement;
               const normalizedMeasureBar =
-                martyriaElement.measureBarLeft?.endsWith('Above')
-                  ? measureBarAboveToLeft.get(martyriaElement.measureBarLeft)
-                  : martyriaElement.measureBarLeft;
+                this.getMeasureBarTransferredFromLineStart(martyriaElement);
               if (normalizedMeasureBar) {
                 previousNoteElement.computedMeasureBarRight =
                   normalizedMeasureBar;
@@ -2105,7 +2034,7 @@ export class LayoutService {
   public static createOverlayDiagnosticsContext(
     pageSetup: PageSetup,
   ): OverlayDiagnosticsContext {
-    const font = `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`;
+    const font = this.getNeumeFont(pageSetup);
 
     return {
       measureBarWidthMap: this.getMeasureBarWidthMap(pageSetup),
@@ -2169,6 +2098,10 @@ export class LayoutService {
       default:
         return String(element.elementType);
     }
+  }
+
+  private static getNeumeFont(pageSetup: PageSetup) {
+    return `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`;
   }
 
   private static getInlineSpacing(pageSetup: PageSetup) {
@@ -2415,7 +2348,7 @@ export class LayoutService {
   }
 
   private static getMeasureBarWidthMap(pageSetup: PageSetup) {
-    const font = `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`;
+    const font = this.getNeumeFont(pageSetup);
     const measureBars = [
       MeasureBar.MeasureBarRight,
       MeasureBar.MeasureBarTop,
@@ -2492,7 +2425,6 @@ export class LayoutService {
     workspace: LayoutWorkspace,
     cost: number,
     width: number,
-    anonymous = false,
     label?: string,
   ) {
     const penalty = {
@@ -2501,11 +2433,6 @@ export class LayoutService {
       width,
       flagged: false,
     };
-
-    if (anonymous) {
-      this.pushAnonymousParagraphItem(penalty, workspace, label);
-      return;
-    }
 
     this.pushParagraphItem(penalty, workspace, undefined, false, label);
   }
@@ -2881,7 +2808,7 @@ export class LayoutService {
     // pre-break glue, so the post-break glue is skipped on the next line.
     this.preventBreak(workspace);
     this.addGlue(preBreakGlue, workspace, 'pre-break');
-    this.addPenalty(workspace, breakCost, breakWidth, false, 'break-penalty');
+    this.addPenalty(workspace, breakCost, breakWidth, 'break-penalty');
     this.addGlue(postBreakGlue, workspace, 'post-break');
   }
 
@@ -2889,8 +2816,8 @@ export class LayoutService {
     noteElement: NoteElement,
     nextNoteElement: NoteElement | null,
   ): boolean {
-    // At the start of a melisma, the syllable is aligned to the
-    // left of the neume, but only if the lyrics are wider than the neume.
+    // At an eligible melisma start, align the syllable left when its effective
+    // lyric span exceeds the adjusted neume span.
     // NOTE: a syllable ending with a hyphen is only considered a melismatic note
     // if the next note is purely melismatic (i.e. the next note contains only a hyphen),
     // despite the unfortunate property name "isMelisma" being true.
@@ -2943,7 +2870,6 @@ export class LayoutService {
       noteElement.computedLyricsFontVariantCaps =
         resolvedLyricsStyle.fontVariantCaps ?? 'normal';
       noteElement.lyricsFontHeight = this.getLyricsFontHeightFromCache(
-        fontHeightCache,
         noteElement.lyricsFontCss,
       );
       this.getNoteWidth(noteElement, pageSetup, noteWidthArgs);
@@ -3017,14 +2943,11 @@ export class LayoutService {
       ) => boolean;
     },
     pageSetup: PageSetup,
-    pages: Page[],
+    pageNumber: number,
+    isChapterOpening: boolean,
   ): { extraHeaderHeightPx: number; extraFooterHeightPx: number } {
     let extraHeaderHeightPx = 0;
     let extraFooterHeightPx = 0;
-    const pageNumber = pages.length;
-    const runningMarkerPageMetadata = resolveRunningMarkerPageMetadata(pages);
-    const isChapterOpening =
-      runningMarkerPageMetadata[pageNumber - 1]?.isChapterOpening ?? false;
 
     if (score.pageSetup.showHeader) {
       const header = score.getHeaderForPage(pageNumber, isChapterOpening);
@@ -3121,10 +3044,10 @@ export class LayoutService {
     const h = noteElement.lyricsHorizontalOffset;
 
     if (alignLeft) {
-      // alignLeft is set for melisma starts whose lyric is wider than
-      // the neume. The lyric extends to the right under subsequent
-      // melisma neumes, so rightProjection is 0: those neumes provide
-      // the space. The melisma-to-non-melisma collision check handles
+      // shouldAlignLeft selects eligible melisma starts that pass its
+      // lyric-vs-neume width test. The lyric extends to the right under
+      // subsequent melisma neumes, so rightProjection is 0: those neumes
+      // provide the space. The melisma-to-non-melisma collision check handles
       // the rare case where the lyric overflows past the melisma.
       return {
         leftProjection: Math.max(0, -h),
@@ -3214,7 +3137,23 @@ export class LayoutService {
   }
 
   private static preventBreak(workspace: LayoutWorkspace) {
-    this.addPenalty(workspace, MAX_COST, 0, false, 'prevent-break');
+    this.addPenalty(workspace, MAX_COST, 0, 'prevent-break');
+  }
+
+  private static resolvePreferredInterNoteSpacing(
+    naturalWidth: number,
+    preferredMinimumWidths: Array<number | null>,
+  ) {
+    const preferredWidths = preferredMinimumWidths.filter(
+      (width): width is number => width != null,
+    );
+    const preferredMinimumWidth =
+      preferredWidths.length > 0 ? Math.max(...preferredWidths) : null;
+
+    return Math.max(
+      naturalWidth,
+      preferredMinimumWidth ?? Number.NEGATIVE_INFINITY,
+    );
   }
 
   private static calculateInterNoteSpacing(
@@ -3235,29 +3174,31 @@ export class LayoutService {
         this.getInlineSpacing(workspace.pageSetup) + rightProjection;
 
       if (nextElement?.elementType === ElementType.Empty) {
-        return Math.max(
-          baseWidth,
+        const terminalMeasureBarMinimum =
           this.getTerminalMeasureBarRightSpacing(
             noteElement,
             workspace.pageSetup,
             measureBarWidthMap,
-          ),
-        );
+          );
+
+        return this.resolvePreferredInterNoteSpacing(baseWidth, [
+          terminalMeasureBarMinimum,
+        ]);
       }
 
       if (!this.shouldUseMeasureBarMinimumForNonNoteSpacing(nextElement)) {
         return baseWidth;
       }
 
-      return Math.max(
-        baseWidth,
-        this.getMeasureBarMinimumGlueWidth(
-          noteElement,
-          nextElement,
-          workspace.pageSetup,
-          measureBarWidthMap,
-        ),
+      const measureBarMinimum = this.getMeasureBarMinimumGlueWidth(
+        noteElement,
+        nextElement,
+        workspace.pageSetup,
+        measureBarWidthMap,
       );
+      return this.resolvePreferredInterNoteSpacing(baseWidth, [
+        measureBarMinimum,
+      ]);
     }
 
     const currentOverhangs = this.getNeumeOverhangs(
@@ -3291,24 +3232,26 @@ export class LayoutService {
       measureBarWidthMap,
       inlineSpacing,
     );
-    const minimumBoundaryWidth = this.hasVisibleMeasureBarAtBoundary(
+    // A zero visual minimum is the collision helper's generic lower clamp,
+    // not a real geometry requirement when the user deliberately requests
+    // negative spacing.
+    const hasOnlyGenericVisualClamp =
+      inlineSpacing < 0 && noteVisualMinimumWidth <= 0;
+    const visualMinimumWidth = hasOnlyGenericVisualClamp
+      ? null
+      : noteVisualMinimumWidth - leftTuck;
+    const hasVisibleMeasureBar = this.hasVisibleMeasureBarAtBoundary(
       noteElement,
       nextNoteElement,
-    )
-      ? Math.max(
-          this.getMeasureBarMinimumGlueWidth(
-            noteElement,
-            nextNoteElement,
-            workspace.pageSetup,
-            measureBarWidthMap,
-          ),
-          noteVisualMinimumWidth,
-        )
-      : noteVisualMinimumWidth;
-    // Visual collision helpers measure the total same-line distance between
-    // note boxes. m_i intentionally excludes L_{i+1}, so convert that minimum
-    // into m_i space or long lyrics on the next note can no longer tuck left.
-    const minimumWidth = minimumBoundaryWidth - leftTuck;
+    );
+    const measureBarMinimumWidth = hasVisibleMeasureBar
+      ? this.getMeasureBarMinimumGlueWidth(
+          noteElement,
+          nextNoteElement,
+          workspace.pageSetup,
+          measureBarWidthMap,
+        ) - leftTuck
+      : null;
     const ordinaryBaseWidth =
       inlineSpacing + rightProjection - leftTuck - rightTuck;
 
@@ -3316,10 +3259,6 @@ export class LayoutService {
     // left edge with the current cursor. The current cursor is already after
     // noteElement.spaceAfter, so user-defined extra spacing is preserved.
     const baseWidth = exitsMelismaIntoCenteredLyric ? 0 : ordinaryBaseWidth;
-
-    if (nextNoteElement.lyricsWidth === 0) {
-      return Math.max(baseWidth, minimumWidth);
-    }
 
     // Lyric collision check: the visual gap between lyrics on the
     // same line includes the neume overhangs (room inside the neume
@@ -3331,51 +3270,40 @@ export class LayoutService {
     //
     // Also handles melisma transitions by measuring the carried lyric's
     // signed distance from the current cursor.
-    let collisionAdjustment = 0;
-    if (noteElement.lyricsWidth > 0) {
-      const lyricGap =
-        baseWidth +
-        currentOverhangs.right +
-        nextOverhangs.left -
+    let lyricMinimumWidth: number | null = null;
+    if (nextNoteElement.lyricsWidth > 0 && noteElement.lyricsWidth > 0) {
+      lyricMinimumWidth =
+        minimumLyricGap -
+        currentOverhangs.right -
+        nextOverhangs.left +
         rightProjection;
-      if (lyricGap < minimumLyricGap) {
-        collisionAdjustment = minimumLyricGap - lyricGap;
-      }
     }
 
-    collisionAdjustment = Math.max(
-      collisionAdjustment,
-      this.getMelismaCollisionAdjustment(
-        workspace,
-        nextNoteElement,
-        baseWidth,
-        nextOverhangs.left,
-      ),
-    );
+    const melismaMinimumWidth =
+      nextNoteElement.lyricsWidth > 0
+        ? this.getMelismaMinimumSpacing(
+            workspace,
+            nextNoteElement,
+            nextOverhangs.left,
+          )
+        : null;
 
-    return Math.max(baseWidth + collisionAdjustment, minimumWidth);
+    return this.resolvePreferredInterNoteSpacing(baseWidth, [
+      visualMinimumWidth,
+      measureBarMinimumWidth,
+      lyricMinimumWidth,
+      melismaMinimumWidth,
+    ]);
   }
 
   private static shouldUseMeasureBarMinimumForNonNoteSpacing(
     element: ScoreElement | null,
   ) {
-    if (element == null) {
-      return false;
-    }
-
-    switch (element.elementType) {
-      case ElementType.Tempo:
-      case ElementType.DropCap:
-        return true;
-      case ElementType.TextBox:
-        return (element as TextBoxElement).inline;
-      case ElementType.RichTextBox:
-        return (element as RichTextBoxElement).inline;
-      case ElementType.ImageBox:
-        return (element as ImageBoxElement).inline;
-      default:
-        return false;
-    }
+    return (
+      element != null &&
+      this.isMeasureBarAnchorElement(element) &&
+      !this.isMeasureBarOwner(element)
+    );
   }
 
   private static getMelismaOverhang(
@@ -3421,17 +3349,16 @@ export class LayoutService {
     };
   }
 
-  private static getMelismaCollisionAdjustment(
+  private static getMelismaMinimumSpacing(
     workspace: LayoutWorkspace,
     nextNoteElement: NoteElement,
-    baseWidth: number,
     nextLeftOverhang: number,
   ) {
     if (
       workspace.melismaLyricsEndPx == null ||
       (nextNoteElement.isMelisma && !nextNoteElement.isMelismaStart)
     ) {
-      return 0;
+      return null;
     }
 
     // Signed distance from the current cursor to the carried melisma lyric's
@@ -3442,8 +3369,11 @@ export class LayoutService {
 
     // T_i^left and L_{i+1} cancel, so the same-line gap is independent
     // of the next note's left projection.
-    const melismaGap = baseWidth + nextLeftOverhang - carriedLyricEndFromCursor;
-    return Math.max(0, workspace.pageSetup.lyricsMinimumSpacing - melismaGap);
+    return (
+      workspace.pageSetup.lyricsMinimumSpacing -
+      nextLeftOverhang +
+      carriedLyricEndFromCursor
+    );
   }
 
   private static getNoteVisualMinimumSpacing(
@@ -3469,10 +3399,23 @@ export class LayoutService {
     );
 
     return this.getMinimumSpacingForNoteGlyphBoxes(
-      left.neumeWidth,
+      this.getNoteBoxAdvance(left),
       leftBoxes,
       rightBoxes,
       clearance,
+    );
+  }
+
+  private static getNoteBoxAdvance(noteElement: NoteElement) {
+    return noteElement.neumeWidth + noteElement.spaceAfter;
+  }
+
+  private static getMartyriaBoxAdvance(martyriaElement: MartyriaElement) {
+    return (
+      martyriaElement.neumeWidth +
+      martyriaElement.computedMeasureBarLeftLeadingSpacing +
+      martyriaElement.padding +
+      martyriaElement.spaceAfter
     );
   }
 
@@ -3481,12 +3424,19 @@ export class LayoutService {
     leftBoxes: NoteGlyphBox[],
     rightBoxes: NoteGlyphBox[],
     clearance: number,
+    verticalTolerance = 0,
   ) {
     let spacing = 0;
 
     for (const leftBox of leftBoxes) {
       for (const rightBox of rightBoxes) {
-        if (!this.noteGlyphBoxesVerticallyOverlap(leftBox, rightBox)) {
+        if (
+          !this.noteGlyphBoxesVerticallyOverlapWithTolerance(
+            leftBox,
+            rightBox,
+            verticalTolerance,
+          )
+        ) {
           continue;
         }
 
@@ -3579,15 +3529,10 @@ export class LayoutService {
       measureBarWidthMap,
       leftBarReserveOverride,
     );
-    const vareiaWidth = this.getNeumeWidthFromCache(
-      neumeWidthCache,
-      VocalExpressionNeume.Vareia,
-      pageSetup,
-    );
     const bodyLeft =
       leftBarReserve +
-      (!pageSetup.melkiteRtl && noteElement.vareia
-        ? vareiaWidth + noteElement.vareiaInternalSpacing
+      (!pageSetup.melkiteRtl
+        ? this.getVareiaPrefixWidth(noteElement, pageSetup)
         : 0);
 
     if (noteElement.vareia && !pageSetup.melkiteRtl) {
@@ -3616,19 +3561,31 @@ export class LayoutService {
     }
 
     if (noteElement.vareia && pageSetup.melkiteRtl) {
-      const bodyWidth = this.getNeumeSequenceWidthFromCache(
-        neumeWidthCache,
-        this.getNoteNeumesForMeasurement(noteElement),
-        pageSetup,
-      );
-      const vareiaLeft =
-        bodyLeft + bodyWidth + noteElement.vareiaInternalSpacing;
       glyphs.push(
-        this.getVareiaCollisionGlyph(noteElement, vareiaLeft, fontSize),
+        this.getVareiaCollisionGlyph(
+          noteElement,
+          this.getRtlVareiaX(noteElement, bodyLeft, pageSetup),
+          fontSize,
+        ),
       );
     }
 
     return glyphs;
+  }
+
+  // In Melkite RTL layout the vareia renders after the note body instead of
+  // prefixing it.
+  private static getRtlVareiaX(
+    noteElement: NoteElement,
+    bodyLeft: number,
+    pageSetup: PageSetup,
+  ) {
+    const bodyWidth = this.getNeumeSequenceWidthFromCache(
+      this.getNoteNeumesForMeasurement(noteElement),
+      pageSetup,
+    );
+
+    return bodyLeft + bodyWidth + noteElement.vareiaInternalSpacing;
   }
 
   private static getVareiaCollisionGlyph(
@@ -3662,17 +3619,9 @@ export class LayoutService {
       measureBarWidthMap,
       leftBarReserveOverride,
     );
-    let vareiaLeft = leftBarReserve;
-
-    if (pageSetup.melkiteRtl) {
-      const bodyWidth = this.getNeumeSequenceWidthFromCache(
-        neumeWidthCache,
-        this.getNoteNeumesForMeasurement(noteElement),
-        pageSetup,
-      );
-      vareiaLeft =
-        leftBarReserve + bodyWidth + noteElement.vareiaInternalSpacing;
-    }
+    const vareiaLeft = pageSetup.melkiteRtl
+      ? this.getRtlVareiaX(noteElement, leftBarReserve, pageSetup)
+      : leftBarReserve;
 
     const glyph = this.getVareiaCollisionGlyph(
       noteElement,
@@ -3722,90 +3671,18 @@ export class LayoutService {
       offsetX?: number | null,
       offsetY?: number | null,
     ) => {
-      if (
-        neume != null &&
-        !collisionSpacingIgnoredMarkSet.has(neume as VocalExpressionNeume | Tie)
-      ) {
+      if (neume != null && !tieSet.has(neume as VocalExpressionNeume | Tie)) {
         marks.push({ neume, offsetX, offsetY });
       }
     };
 
-    add(
-      noteElement.stavros ? VocalExpressionNeume.Cross_Top : null,
-      noteElement.stavrosOffsetX,
-      noteElement.stavrosOffsetY,
-    );
-    add(
-      noteElement.vocalExpressionNeume,
-      noteElement.vocalExpressionNeumeOffsetX,
-      noteElement.vocalExpressionNeumeOffsetY,
-    );
-    add(
-      noteElement.timeNeume,
-      noteElement.timeNeumeOffsetX,
-      noteElement.timeNeumeOffsetY,
-    );
-    add(
-      noteElement.koronis ? TimeNeume.Koronis : null,
-      noteElement.koronisOffsetX,
-      noteElement.koronisOffsetY,
-    );
-    add(
-      noteElement.gorgonNeume,
-      noteElement.gorgonNeumeOffsetX,
-      noteElement.gorgonNeumeOffsetY,
-    );
-    add(
-      noteElement.secondaryGorgonNeume,
-      noteElement.secondaryGorgonNeumeOffsetX,
-      noteElement.secondaryGorgonNeumeOffsetY,
-    );
-    add(
-      noteElement.fthora,
-      noteElement.fthoraOffsetX,
-      noteElement.fthoraOffsetY,
-    );
-    add(
-      noteElement.secondaryFthora,
-      noteElement.secondaryFthoraOffsetX,
-      noteElement.secondaryFthoraOffsetY,
-    );
-    add(
-      noteElement.tertiaryFthora,
-      noteElement.tertiaryFthoraOffsetX,
-      noteElement.tertiaryFthoraOffsetY,
-    );
-    add(
-      noteElement.accidental,
-      noteElement.accidentalOffsetX,
-      noteElement.accidentalOffsetY,
-    );
-    add(
-      noteElement.secondaryAccidental,
-      noteElement.secondaryAccidentalOffsetX,
-      noteElement.secondaryAccidentalOffsetY,
-    );
-    add(
-      noteElement.tertiaryAccidental,
-      noteElement.tertiaryAccidentalOffsetX,
-      noteElement.tertiaryAccidentalOffsetY,
-    );
-    add(
-      noteElement.noteIndicator ? noteElement.noteIndicatorNeume : null,
-      noteElement.noteIndicatorOffsetX,
-      noteElement.noteIndicatorOffsetY,
-    );
-    add(
-      noteElement.ison,
-      noteElement.isonOffsetX,
-      noteElement.computedIsonOffsetY,
-    );
-    add(
-      noteElement.measureNumber,
-      noteElement.measureNumberOffsetX,
-      noteElement.measureNumberOffsetY,
-    );
-    add(noteElement.tie, noteElement.tieOffsetX, noteElement.tieOffsetY);
+    for (const slot of noteMarkSlots) {
+      add(
+        slot.neume(noteElement),
+        slot.offsetX(noteElement),
+        slot.offsetY(noteElement),
+      );
+    }
 
     const measureBarLeft =
       noteElement.measureBarLeft ?? noteElement.computedMeasureBarLeft;
@@ -3816,6 +3693,8 @@ export class LayoutService {
         noteElement.measureBarLeftOffsetY,
       );
     }
+
+    add(noteElement.tie, noteElement.tieOffsetX, noteElement.tieOffsetY);
 
     return marks;
   }
@@ -3852,7 +3731,6 @@ export class LayoutService {
 
     if (this.hasInlineMeasureBarLeft(martyriaElement)) {
       x += this.getNeumeWidthFromCache(
-        neumeWidthCache,
         martyriaElement.measureBarLeft!,
         pageSetup,
       );
@@ -3867,11 +3745,7 @@ export class LayoutService {
         x: x + martyriaElement.computedTempoLeftOffsetX,
         y: 0,
       });
-      x += this.getNeumeWidthFromCache(
-        neumeWidthCache,
-        martyriaElement.tempoLeft,
-        pageSetup,
-      );
+      x += this.getNeumeWidthFromCache(martyriaElement.tempoLeft, pageSetup);
       x += martyriaElement.tempoLeftSpacing;
     }
 
@@ -3888,7 +3762,7 @@ export class LayoutService {
         x,
         y: 0,
       });
-      x += this.getNeumeWidthFromCache(neumeWidthCache, neume, pageSetup);
+      x += this.getNeumeWidthFromCache(neume, pageSetup);
     }
 
     if (!martyriaElement.error) {
@@ -4074,14 +3948,14 @@ export class LayoutService {
     pageSetup: PageSetup,
   ) {
     if (element.elementType === ElementType.Note) {
-      return this.getNoteInkBoundsFromCache(element as NoteElement, pageSetup)
-        .rightOverhang;
+      return this.getNoteRightInkOverhang(element as NoteElement, pageSetup);
     }
 
     if (element.elementType === ElementType.Tempo) {
-      return this.getSingleNeumeRightInkOverhang(
-        (element as TempoElement).neume,
-        pageSetup,
+      const tempoElement = element as TempoElement;
+      return this.getRightInkOverhangAfterSpace(
+        this.getSingleNeumeRightInkOverhang(tempoElement.neume, pageSetup),
+        tempoElement.spaceAfter,
       );
     }
 
@@ -4096,11 +3970,7 @@ export class LayoutService {
     pageSetup: PageSetup,
   ) {
     const measureBarLeftWidth = this.hasInlineMeasureBarLeft(martyriaElement)
-      ? this.getNeumeWidthFromCache(
-          neumeWidthCache,
-          martyriaElement.measureBarLeft!,
-          pageSetup,
-        )
+      ? this.getNeumeWidthFromCache(martyriaElement.measureBarLeft!, pageSetup)
       : 0;
     const measureBarLeftOverhang = this.hasInlineMeasureBarLeft(martyriaElement)
       ? this.getSingleNeumeLeftInkOverhang(
@@ -4136,12 +4006,21 @@ export class LayoutService {
     pageSetup: PageSetup,
   ) {
     const trailingNeume = this.getMartyriaTrailingNeume(martyriaElement);
+    const inkOverhang = trailingNeume
+      ? this.getSingleNeumeRightInkOverhang(trailingNeume, pageSetup)
+      : this.getMartyriaBodyInkOverhangs(martyriaElement, pageSetup).right;
 
-    if (trailingNeume) {
-      return this.getSingleNeumeRightInkOverhang(trailingNeume, pageSetup);
-    }
+    return this.getRightInkOverhangAfterSpace(
+      inkOverhang,
+      martyriaElement.spaceAfter,
+    );
+  }
 
-    return this.getMartyriaBodyInkOverhangs(martyriaElement, pageSetup).right;
+  private static getRightInkOverhangAfterSpace(
+    inkOverhang: number,
+    spaceAfter: number,
+  ) {
+    return Math.max(0, inkOverhang - spaceAfter);
   }
 
   private static hasInlineMeasureBarLeft(martyriaElement: MartyriaElement) {
@@ -4251,9 +4130,9 @@ export class LayoutService {
           nextNoteElement.secondaryGorgonNeume &&
           secondaryGorgonNeumeSet.has(nextNoteElement.secondaryGorgonNeume))
       ) {
-        // Discourage break before a beat-stealing neume (running
-        // elaphron, or a neume with a gorgon). This remains a weak
-        // penalty because such breaks are not uncommon in the
+        // Discourage a break before a configured beat-stealing quantitative
+        // neume or supported quantitative-neume/time-mark combination. This
+        // remains a weak penalty because such breaks are not uncommon in the
         // classical sources.
         breakCost += MAX_COST * 0.1;
       }
@@ -4300,6 +4179,15 @@ export class LayoutService {
     }
 
     return penaltyWidth;
+  }
+
+  // The bar a martyria donates to the note that follows it at a line break:
+  // an Above bar normalizes to its inline-left equivalent; otherwise the
+  // martyria's right bar transfers.
+  private static getMartyriaTransferBar(martyriaElement: MartyriaElement) {
+    return martyriaElement.measureBarLeft?.endsWith('Above')
+      ? measureBarAboveToLeft.get(martyriaElement.measureBarLeft)
+      : martyriaElement.measureBarRight;
   }
 
   private static getMeasureBarTransferredFromLineStart(
@@ -4619,7 +4507,7 @@ export class LayoutService {
     );
 
     // Force break and end paragraph
-    this.forceBreak(workspace, true);
+    this.forceBreak(workspace);
 
     // Compute per-line widths for multiline drop caps
     let lineLengths: number | number[];
@@ -4643,7 +4531,7 @@ export class LayoutService {
       lineLengths = pageSetup.innerPageWidth;
     }
 
-    // Run the total-fit algorithm for line breaking
+    // Run the ratio-capped optimal line breaker.
     if (workspace.loggingEnabled) {
       console.log('Breaking lines', pendingParagraph);
     }
@@ -4712,19 +4600,8 @@ export class LayoutService {
     }
   }
 
-  private static forceBreak(workspace: LayoutWorkspace, anonymous = false) {
-    if (anonymous) {
-      this.pushAnonymousParagraphItem(forcedBreak(), workspace, 'forced-break');
-      return;
-    }
-
-    this.pushParagraphItem(
-      forcedBreak(),
-      workspace,
-      undefined,
-      false,
-      'forced-break',
-    );
+  private static forceBreak(workspace: LayoutWorkspace) {
+    this.pushAnonymousParagraphItem(forcedBreak(), workspace, 'forced-break');
   }
 
   private static getLineHeight(
@@ -4802,21 +4679,21 @@ export class LayoutService {
     return defaultLineHeight;
   }
 
-  private static processHeader(
-    header: Header,
+  private static processHeaderFooter(
+    container: Header | Footer,
     pageSetup: PageSetup,
     neumeHeight: number,
     paragraphStyles: ParagraphStyle[],
     defaultLyricsFontCss: string,
   ) {
-    // Currently headers may only contain a single text box.
+    // Currently headers and footers may only contain a single text box.
     // It may be a rich textbox, but we don't need to do any
     // processing in that case.
     if (
-      header.elements.length > 0 &&
-      header.elements[0].elementType === ElementType.TextBox
+      container.elements.length > 0 &&
+      container.elements[0].elementType === ElementType.TextBox
     ) {
-      const element = header.elements[0] as TextBoxElement;
+      const element = container.elements[0] as TextBoxElement;
 
       element.width = this.processTextBoxElement(
         element,
@@ -4826,42 +4703,10 @@ export class LayoutService {
         defaultLyricsFontCss,
       );
     } else if (
-      header.elements.length > 0 &&
-      header.elements[0].elementType === ElementType.RichTextBox
+      container.elements.length > 0 &&
+      container.elements[0].elementType === ElementType.RichTextBox
     ) {
-      const element = header.elements[0] as RichTextBoxElement;
-      element.width = pageSetup.innerPageWidth;
-    }
-  }
-
-  private static processFooter(
-    footer: Footer,
-    pageSetup: PageSetup,
-    neumeHeight: number,
-    paragraphStyles: ParagraphStyle[],
-    defaultLyricsFontCss: string,
-  ) {
-    // Currently footers may only contain a single text box.
-    // It may be a rich textbox, but we don't need to do any
-    // processing in that case.
-    if (
-      footer.elements.length > 0 &&
-      footer.elements[0].elementType === ElementType.TextBox
-    ) {
-      const element = footer.elements[0] as TextBoxElement;
-
-      element.width = this.processTextBoxElement(
-        element,
-        pageSetup,
-        neumeHeight,
-        paragraphStyles,
-        defaultLyricsFontCss,
-      );
-    } else if (
-      footer.elements.length > 0 &&
-      footer.elements[0].elementType === ElementType.RichTextBox
-    ) {
-      const element = footer.elements[0] as RichTextBoxElement;
+      const element = container.elements[0] as RichTextBoxElement;
       element.width = pageSetup.innerPageWidth;
     }
   }
@@ -5009,7 +4854,6 @@ export class LayoutService {
       note.vareiaInternalSpacingPrevious = note.vareiaInternalSpacing;
     } else if (element.elementType === ElementType.TextBox) {
       const textbox = element as TextBoxElement;
-      textbox.heightPrevious = textbox.height;
       textbox.computedFontFamilyPrevious = textbox.computedFontFamily;
       textbox.computedFontSizePrevious = textbox.computedFontSize;
       textbox.computedFontWeightPrevious = textbox.computedFontWeight;
@@ -5181,20 +5025,13 @@ export class LayoutService {
     pageSetup: PageSetup,
     args: GetNoteWidthArgs,
   ) {
-    const {
-      lyricsVerticalOffset,
-      vareiaWidth,
-      measureBarWidthMap,
-      runningElaphronWidth,
-      elaphronWidth,
-    } = args;
+    const { lyricsVerticalOffset, measureBarWidthMap } = args;
 
     noteElement.lyricsVerticalOffset = lyricsVerticalOffset;
 
     // Measure the full note run so the browser applies any contextual
     // substitutions before we use the width for layout.
     noteElement.neumeWidth = this.getNeumeSequenceWidthFromCache(
-      neumeWidthCache,
       this.getNoteNeumesForMeasurement(noteElement),
       pageSetup,
     );
@@ -5204,15 +5041,11 @@ export class LayoutService {
     noteElement.lyricsLeadingPunctuationWidth = 0;
 
     if (noteElement.lyrics.length > 0) {
-      noteElement.lyricsWidth = this.getTextWidthFromCache(
-        textWidthCache,
-        noteElement,
-      );
+      noteElement.lyricsWidth = this.getTextWidthFromCache(noteElement);
 
       if (pageSetup.ignorePunctuationWhenPositioningLyrics) {
         // Adjust for leading punctuation
         noteElement.lyricsLeadingPunctuationWidth = this.getTextWidthFromCache(
-          textWidthCache,
           noteElement,
           null,
           true,
@@ -5220,7 +5053,6 @@ export class LayoutService {
 
         // Adjust for trailing punctuation
         noteElement.lyricsTrailingPunctuationWidth = this.getTextWidthFromCache(
-          textWidthCache,
           noteElement,
           null,
           false,
@@ -5238,7 +5070,10 @@ export class LayoutService {
       noteElement.vareiaInternalSpacing =
         pageSetup.neumeDefaultFontSize *
         fontService.getVareiaGap(pageSetup.neumeDefaultFontFamily);
-      const vareiaPrefixWidth = vareiaWidth + noteElement.vareiaInternalSpacing;
+      const vareiaPrefixWidth = this.getVareiaPrefixWidth(
+        noteElement,
+        pageSetup,
+      );
 
       if (pageSetup.melkiteRtl) {
         noteElement.lyricsHorizontalOffset -= vareiaPrefixWidth;
@@ -5285,7 +5120,11 @@ export class LayoutService {
       // The stand-alone apostrophos is not the same width
       // as the apostrophros in the running elaphron, but
       // the elaphrons are the same width in both neumes.
-      const offset = runningElaphronWidth - elaphronWidth;
+      const offset =
+        this.getNeumeWidthFromCache(
+          QuantitativeNeume.RunningElaphron,
+          pageSetup,
+        ) - this.getNeumeWidthFromCache(QuantitativeNeume.Elaphron, pageSetup);
 
       if (pageSetup.melkiteRtl) {
         noteElement.lyricsHorizontalOffset -= offset;
@@ -5294,33 +5133,13 @@ export class LayoutService {
       }
     }
 
-    return noteElement.spaceAfter + noteElement.neumeWidth;
+    return this.getNoteBoxAdvance(noteElement);
   }
 
   public static getMartyriaWidth(
     martyriaElement: MartyriaElement,
     pageSetup: PageSetup,
   ) {
-    const mappingNote = !martyriaElement.error
-      ? NeumeMappingService.getMapping(martyriaElement.note)
-      : NeumeMappingService.getMapping(Note.Pa);
-    const mappingMeasureBarLeft = martyriaElement.measureBarLeft
-      ? NeumeMappingService.getMapping(martyriaElement.measureBarLeft)
-      : null;
-    const mappingMeasureBarRight = martyriaElement.measureBarRight
-      ? NeumeMappingService.getMapping(martyriaElement.measureBarRight)
-      : null;
-    const mappingTempoLeft = martyriaElement.tempoLeft
-      ? NeumeMappingService.getMapping(martyriaElement.tempoLeft)
-      : null;
-    const mappingTempoRight = martyriaElement.tempoRight
-      ? NeumeMappingService.getMapping(martyriaElement.tempoRight)
-      : null;
-    const mappingQuantitativeNeume =
-      martyriaElement.alignRight && martyriaElement.quantitativeNeume
-        ? NeumeMappingService.getMapping(martyriaElement.quantitativeNeume)
-        : null;
-
     // The renderer applies padding as marginLeft on the quantitative neume in
     // NeumeBoxMartyria.vue, so only that case should keep fixed spacing inside
     // the box.
@@ -5328,10 +5147,10 @@ export class LayoutService {
       martyriaElement.alignRight && martyriaElement.quantitativeNeume
         ? this.getInlineSpacing(pageSetup)
         : 0;
-    martyriaElement.tempoLeftSpacing = mappingTempoLeft
+    martyriaElement.tempoLeftSpacing = martyriaElement.tempoLeft
       ? this.getInlineSpacing(pageSetup)
       : 0;
-    martyriaElement.tempoRightSpacing = mappingTempoRight
+    martyriaElement.tempoRightSpacing = martyriaElement.tempoRight
       ? this.getInlineSpacing(pageSetup)
       : 0;
     if (martyriaElement.tempoRight) {
@@ -5343,14 +5162,12 @@ export class LayoutService {
       : 0;
 
     martyriaElement.neumeWidth = this.getNeumeWidthFromCache(
-      neumeWidthCache,
-      martyriaElement.note,
+      !martyriaElement.error ? martyriaElement.note : Note.Pa,
       pageSetup,
     );
 
     if (martyriaElement.tempoLeft) {
       martyriaElement.neumeWidth += this.getNeumeWidthFromCache(
-        neumeWidthCache,
         martyriaElement.tempoLeft,
         pageSetup,
       );
@@ -5360,7 +5177,6 @@ export class LayoutService {
     if (martyriaElement.tempoRight) {
       martyriaElement.neumeWidth += martyriaElement.tempoRightSpacing;
       martyriaElement.neumeWidth += this.getNeumeWidthFromCache(
-        neumeWidthCache,
         martyriaElement.tempoRight,
         pageSetup,
       );
@@ -5371,7 +5187,6 @@ export class LayoutService {
 
     if (hasInlineMeasureBarLeft) {
       martyriaElement.neumeWidth += this.getNeumeWidthFromCache(
-        neumeWidthCache,
         martyriaElement.measureBarLeft!,
         pageSetup,
       );
@@ -5382,7 +5197,6 @@ export class LayoutService {
 
     if (martyriaElement.measureBarRight) {
       martyriaElement.neumeWidth += this.getNeumeWidthFromCache(
-        neumeWidthCache,
         martyriaElement.measureBarRight,
         pageSetup,
       );
@@ -5390,51 +5204,12 @@ export class LayoutService {
 
     if (martyriaElement.alignRight && martyriaElement.quantitativeNeume) {
       martyriaElement.neumeWidth += this.getNeumeWidthFromCache(
-        neumeWidthCache,
         martyriaElement.quantitativeNeume,
         pageSetup,
       );
     }
 
-    return (
-      martyriaElement.spaceAfter +
-      martyriaElement.computedMeasureBarLeftLeadingSpacing +
-      (martyriaElement.padding +
-        TextMeasurementService.getTextWidth(
-          mappingNote.text,
-          `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-        ) +
-        (hasInlineMeasureBarLeft && mappingMeasureBarLeft
-          ? TextMeasurementService.getTextWidth(
-              mappingMeasureBarLeft.text,
-              `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-            )
-          : 0) +
-        (mappingMeasureBarRight
-          ? TextMeasurementService.getTextWidth(
-              mappingMeasureBarRight.text,
-              `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-            )
-          : 0) +
-        (mappingTempoLeft
-          ? TextMeasurementService.getTextWidth(
-              mappingTempoLeft.text,
-              `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-            ) + martyriaElement.tempoLeftSpacing
-          : 0) +
-        (mappingTempoRight
-          ? TextMeasurementService.getTextWidth(
-              mappingTempoRight.text,
-              `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-            ) + martyriaElement.tempoRightSpacing
-          : 0) +
-        (mappingQuantitativeNeume
-          ? TextMeasurementService.getTextWidth(
-              mappingQuantitativeNeume.text,
-              `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-            )
-          : 0))
-    );
+    return this.getMartyriaBoxAdvance(martyriaElement);
   }
 
   public static addMelismas(
@@ -5449,38 +5224,15 @@ export class LayoutService {
       defaultLyricsFontCss,
     );
 
-    const elaphronMapping = NeumeMappingService.getMapping(
+    const elaphronWidth = this.getNeumeWidthFromCache(
       QuantitativeNeume.Elaphron,
+      pageSetup,
     );
-    const elaphronWidth = TextMeasurementService.getTextWidth(
-      elaphronMapping.text,
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
-
-    const runningElaphronMapping = NeumeMappingService.getMapping(
+    const runningElaphronWidth = this.getNeumeWidthFromCache(
       QuantitativeNeume.RunningElaphron,
+      pageSetup,
     );
-    const runningElaphronWidth = TextMeasurementService.getTextWidth(
-      runningElaphronMapping.text,
-      `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
-    );
-
-    const neumeFont = `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`;
-    const melismaMeasureBarWidthMap = new Map<MeasureBar, number>();
-    for (const bar of [
-      MeasureBar.MeasureBarRight,
-      MeasureBar.MeasureBarTop,
-      MeasureBar.MeasureBarDouble,
-      MeasureBar.MeasureBarTheseos,
-      MeasureBar.MeasureBarShortDouble,
-      MeasureBar.MeasureBarShortTheseos,
-    ]) {
-      const mapping = NeumeMappingService.getMapping(bar);
-      melismaMeasureBarWidthMap.set(
-        bar,
-        TextMeasurementService.getTextWidth(mapping.text, neumeFont),
-      );
-    }
+    const melismaMeasureBarWidthMap = this.getMeasureBarWidthMap(pageSetup);
 
     let melismaSyllables: MelismaSyllables | null = null;
     let melismaLyricsEnd: number | null = null;
@@ -5613,7 +5365,6 @@ export class LayoutService {
               //  too close to previous the lyrics
               if (melismaLyricsEnd != null) {
                 const lyricsWidth = this.getTextWidthFromCache(
-                  textWidthCache,
                   element,
                   element.melismaText,
                 );
@@ -5672,21 +5423,10 @@ export class LayoutService {
                   element.lyricsHorizontalOffset +
                   element.lyricsWidth;
               }
-            } else if (element.lyricsWidth > element.neumeWidth) {
-              if (!pageSetup.melkiteRtl) {
-                start =
-                  element.x +
-                  element.neumeWidth +
-                  element.lyricsHorizontalOffset / 2 +
-                  (element.lyricsWidth - element.neumeWidth) / 2;
-              } else {
-                start =
-                  element.x +
-                  element.neumeWidth -
-                  element.lyricsHorizontalOffset / 2 +
-                  (element.lyricsWidth - element.neumeWidth) / 2;
-              }
             } else {
+              // The lyrics are centered under the neume, so the melisma
+              // starts at the right edge of the lyrics regardless of whether
+              // the lyrics or the neume is wider.
               if (!pageSetup.melkiteRtl) {
                 start =
                   element.x +
@@ -5716,35 +5456,15 @@ export class LayoutService {
                 } else {
                   end = element.x + element.neumeWidth;
                 }
-              } else if (
-                nextNoteElement.lyricsWidth > nextNoteElement.neumeWidth
-              ) {
-                // At the start of a melisma, the syllable is aligned to the
-                // left of the neume, but only if the lyrics are wider than the neume
-                if (nextNoteElement.alignLeft) {
-                  end =
-                    nextNoteElement.x + nextNoteElement.lyricsHorizontalOffset;
-                } else {
-                  // Otherwise, the syllable is centered under the neume
-                  end =
-                    nextNoteElement.x -
-                    (nextNoteElement.lyricsWidth -
-                      nextNoteElement.neumeWidth -
-                      nextNoteElement.lyricsHorizontalOffset) /
-                      2;
-                }
               } else {
+                // End at the next syllable's rendered text start.
                 end =
-                  nextNoteElement.x +
-                  nextNoteElement.neumeWidth / 2 -
-                  nextNoteElement.lyricsWidth / 2 +
-                  nextNoteElement.lyricsHorizontalOffset / 2;
+                  nextNoteElement.x + this.getLyricTextLeft(nextNoteElement);
               }
 
               element.melismaWidth = Math.max(end - start, 0);
 
               const widthOfHyphenForThisElement = this.getTextWidthFromCache(
-                textWidthCache,
                 element,
                 '-',
               );
@@ -5884,8 +5604,8 @@ export class LayoutService {
                 }
 
                 if (nextNoteElement != null && nextNoteElement.alignLeft) {
-                  // At the start of a melisma, the syllable is aligned to the
-                  // left of the neume, but only if the lyrics are wider than the neume
+                  // This next melisma-start syllable was selected for
+                  // left alignment by shouldAlignLeft.
                   end = Math.min(
                     end,
                     nextNoteElement.x +
@@ -5917,11 +5637,8 @@ export class LayoutService {
 
               // Calculate the distance from the alphabetic baseline to the bottom of the font bounding box
               element.melismaOffsetTop =
-                -this.getLyricsFontBoundingBoxDescentFromCache(
-                  fontBoundingBoxDescentCache,
-                  element,
-                );
-            } else if (pageSetup.melkiteRtl) {
+                -this.getLyricsFontBoundingBoxDescentFromCache(element);
+            } else {
               const nextNoteElement = nextElement as NoteElement;
 
               if (
@@ -5939,16 +5656,10 @@ export class LayoutService {
                 } else {
                   end = element.x + element.neumeWidth;
                 }
-              } else if (
-                nextNoteElement.lyricsWidth > nextNoteElement.neumeWidth
-              ) {
-                end =
-                  nextNoteElement.x -
-                  (nextNoteElement.lyricsWidth -
-                    nextNoteElement.neumeWidth +
-                    nextNoteElement.lyricsHorizontalOffset) /
-                    2;
               } else {
+                // The syllable is centered under the neume, so the melisma
+                // ends at the left edge of the lyrics regardless of whether
+                // the lyrics or the neume is wider.
                 end =
                   nextNoteElement.x +
                   nextNoteElement.neumeWidth / 2 -
@@ -5957,7 +5668,6 @@ export class LayoutService {
               }
 
               const widthOfTatweelForThisElement = this.getTextWidthFromCache(
-                textWidthCache,
                 element,
                 TATWEEL,
               );
@@ -6314,26 +6024,16 @@ export class LayoutService {
 
       if (
         measureBar != null &&
-        edge === 'left' &&
-        this.getVisibleMeasureBarLeft(owner) !== measureBar
+        edge != null &&
+        (edge === 'left'
+          ? this.getVisibleMeasureBarLeft(owner) !== measureBar
+          : this.getVisibleMeasureBarRight(owner) !== measureBar)
       ) {
-        return this.getMartyriaLeftBoundsForMeasureBar(
+        return this.getMartyriaBoundsForMeasureBar(
           element as MartyriaElement,
           { left, right },
           measureBar,
-          pageSetup,
-        );
-      }
-
-      if (
-        measureBar != null &&
-        edge === 'right' &&
-        this.getVisibleMeasureBarRight(owner) !== measureBar
-      ) {
-        return this.getMartyriaRightBoundsForMeasureBar(
-          element as MartyriaElement,
-          { left, right },
-          measureBar,
+          edge,
           pageSetup,
         );
       }
@@ -6383,61 +6083,51 @@ export class LayoutService {
     };
   }
 
-  private static getNoteLeftOverhangForMeasureBar(
-    noteElement: NoteElement,
+  private static getMeasureBarInkOverhang(
+    owner: NoteElement | MartyriaElement,
     measureBar: MeasureBar,
+    edge: MeasureBarAnchorEdge,
     pageSetup: PageSetup,
     measureBarWidthMap: Map<MeasureBar, number>,
   ) {
     const fallbackBounds = this.getMeasureBarAnchorBounds(
-      noteElement,
+      owner,
       pageSetup,
       measureBarWidthMap,
     );
-    const bounds = this.getNoteBoundsForMeasureBar(
-      noteElement,
-      fallbackBounds,
-      measureBar,
-      'left',
-      pageSetup,
-      measureBarWidthMap,
-    );
+    const bounds =
+      owner.elementType === ElementType.Note
+        ? this.getNoteBoundsForMeasureBar(
+            owner as NoteElement,
+            fallbackBounds,
+            measureBar,
+            edge,
+            pageSetup,
+            measureBarWidthMap,
+          )
+        : this.getMartyriaBoundsForMeasureBar(
+            owner as MartyriaElement,
+            fallbackBounds,
+            measureBar,
+            edge,
+            pageSetup,
+          );
 
-    return Math.max(0, fallbackBounds.left - bounds.left);
+    return edge === 'left'
+      ? Math.max(0, fallbackBounds.left - bounds.left)
+      : Math.max(0, bounds.right - fallbackBounds.right);
   }
 
-  private static getNoteRightOverhangForMeasureBar(
-    noteElement: NoteElement,
-    measureBar: MeasureBar,
-    pageSetup: PageSetup,
-    measureBarWidthMap: Map<MeasureBar, number>,
-  ) {
-    const fallbackBounds = this.getMeasureBarAnchorBounds(
-      noteElement,
-      pageSetup,
-      measureBarWidthMap,
-    );
-    const bounds = this.getNoteBoundsForMeasureBar(
-      noteElement,
-      fallbackBounds,
-      measureBar,
-      'right',
-      pageSetup,
-      measureBarWidthMap,
-    );
-
-    return Math.max(0, bounds.right - fallbackBounds.right);
-  }
-
-  private static getMartyriaLeftBoundsForMeasureBar(
+  private static getMartyriaBoundsForMeasureBar(
     martyriaElement: MartyriaElement,
     fallbackBounds: { left: number; right: number },
     measureBar: MeasureBar,
+    edge: MeasureBarAnchorEdge,
     pageSetup: PageSetup,
   ) {
     const barBox = this.getMeasureBarClearanceBox(
       measureBar,
-      'left',
+      edge,
       fallbackBounds,
       martyriaElement.x,
       pageSetup,
@@ -6460,81 +6150,6 @@ export class LayoutService {
       left: Math.min(...overlappingBoxes.map((box) => box.left)),
       right: Math.max(...overlappingBoxes.map((box) => box.right)),
     };
-  }
-
-  private static getMartyriaLeftOverhangForMeasureBar(
-    martyriaElement: MartyriaElement,
-    measureBar: MeasureBar,
-    pageSetup: PageSetup,
-    measureBarWidthMap: Map<MeasureBar, number>,
-  ) {
-    const fallbackBounds = this.getMeasureBarAnchorBounds(
-      martyriaElement,
-      pageSetup,
-      measureBarWidthMap,
-    );
-    const bounds = this.getMartyriaLeftBoundsForMeasureBar(
-      martyriaElement,
-      fallbackBounds,
-      measureBar,
-      pageSetup,
-    );
-
-    return Math.max(0, fallbackBounds.left - bounds.left);
-  }
-
-  private static getMartyriaRightBoundsForMeasureBar(
-    martyriaElement: MartyriaElement,
-    fallbackBounds: { left: number; right: number },
-    measureBar: MeasureBar,
-    pageSetup: PageSetup,
-  ) {
-    const barBox = this.getMeasureBarClearanceBox(
-      measureBar,
-      'right',
-      fallbackBounds,
-      martyriaElement.x,
-      pageSetup,
-    );
-    const overlappingBoxes = this.getMartyriaCollisionGlyphBoxes(
-      martyriaElement,
-      pageSetup,
-    )
-      .filter((box) => this.noteGlyphBoxesVerticallyOverlap(box, barBox))
-      .map((box) => ({
-        left: martyriaElement.x + box.left,
-        right: martyriaElement.x + box.right,
-      }));
-
-    if (overlappingBoxes.length === 0) {
-      return fallbackBounds;
-    }
-
-    return {
-      left: Math.min(...overlappingBoxes.map((box) => box.left)),
-      right: Math.max(...overlappingBoxes.map((box) => box.right)),
-    };
-  }
-
-  private static getMartyriaRightOverhangForMeasureBar(
-    martyriaElement: MartyriaElement,
-    measureBar: MeasureBar,
-    pageSetup: PageSetup,
-    measureBarWidthMap: Map<MeasureBar, number>,
-  ) {
-    const fallbackBounds = this.getMeasureBarAnchorBounds(
-      martyriaElement,
-      pageSetup,
-      measureBarWidthMap,
-    );
-    const bounds = this.getMartyriaRightBoundsForMeasureBar(
-      martyriaElement,
-      fallbackBounds,
-      measureBar,
-      pageSetup,
-    );
-
-    return Math.max(0, bounds.right - fallbackBounds.right);
   }
 
   private static getMeasureBarClearanceBox(
@@ -6617,9 +6232,14 @@ export class LayoutService {
   }
 
   private static getMeasureBarOwnerWidth(owner: NoteElement | MartyriaElement) {
-    return owner.elementType === ElementType.Note
-      ? owner.neumeWidth
-      : owner.width - owner.spaceAfter;
+    if (owner.elementType === ElementType.Note) {
+      return owner.neumeWidth;
+    }
+
+    const martyriaElement = owner as MartyriaElement;
+    return (
+      this.getMartyriaBoxAdvance(martyriaElement) - martyriaElement.spaceAfter
+    );
   }
 
   private static getTerminalMeasureBarSpacing(pageSetup: PageSetup) {
@@ -6669,9 +6289,10 @@ export class LayoutService {
   ) {
     const inkOverhang =
       owner.elementType === ElementType.Note
-        ? this.getNoteRightOverhangForMeasureBar(
+        ? this.getMeasureBarInkOverhang(
             owner as NoteElement,
             measureBar,
+            'right',
             pageSetup,
             measureBarWidthMap,
           )
@@ -6685,15 +6306,6 @@ export class LayoutService {
     pageSetup: PageSetup,
     measureBarWidthMap: Map<MeasureBar, number>,
   ) {
-    const leadingSpacing = this.getMeasureBarBaseLeftLeadingSpacing(
-      owner,
-      pageSetup,
-    );
-
-    if (leadingSpacing === 0) {
-      return 0;
-    }
-
     const measureBar = this.getVisibleMeasureBarLeft(owner);
 
     if (measureBar == null) {
@@ -6803,44 +6415,32 @@ export class LayoutService {
     const leftCollisionMeasureBar = measureBarLeft ?? measureBarRight;
     const rightCollisionMeasureBar = measureBarRight ?? measureBarLeft;
     const rightInkOverhang =
-      rightCollisionMeasureBar != null
-        ? left?.elementType === ElementType.Note
-          ? this.getNoteRightOverhangForMeasureBar(
-              left as NoteElement,
-              rightCollisionMeasureBar,
-              pageSetup,
-              measureBarWidthMap,
-            )
-          : left?.elementType === ElementType.Martyria &&
-              right?.elementType === ElementType.Note &&
-              measureBarLeft != null
-            ? this.getMartyriaRightOverhangForMeasureBar(
-                left as MartyriaElement,
-                rightCollisionMeasureBar,
-                pageSetup,
-                measureBarWidthMap,
-              )
-            : 0
+      rightCollisionMeasureBar != null &&
+      (left?.elementType === ElementType.Note ||
+        (left?.elementType === ElementType.Martyria &&
+          right?.elementType === ElementType.Note &&
+          measureBarLeft != null))
+        ? this.getMeasureBarInkOverhang(
+            left as NoteElement | MartyriaElement,
+            rightCollisionMeasureBar,
+            'right',
+            pageSetup,
+            measureBarWidthMap,
+          )
         : 0;
     const leftInkOverhang =
-      leftCollisionMeasureBar != null
-        ? right?.elementType === ElementType.Note
-          ? this.getNoteLeftOverhangForMeasureBar(
-              right as NoteElement,
-              leftCollisionMeasureBar,
-              pageSetup,
-              measureBarWidthMap,
-            )
-          : left?.elementType === ElementType.Note &&
-              right?.elementType === ElementType.Martyria &&
-              measureBarRight != null
-            ? this.getMartyriaLeftOverhangForMeasureBar(
-                right as MartyriaElement,
-                leftCollisionMeasureBar,
-                pageSetup,
-                measureBarWidthMap,
-              )
-            : 0
+      leftCollisionMeasureBar != null &&
+      (right?.elementType === ElementType.Note ||
+        (left?.elementType === ElementType.Note &&
+          right?.elementType === ElementType.Martyria &&
+          measureBarRight != null))
+        ? this.getMeasureBarInkOverhang(
+            right as NoteElement | MartyriaElement,
+            leftCollisionMeasureBar,
+            'left',
+            pageSetup,
+            measureBarWidthMap,
+          )
         : 0;
 
     return Math.max(
@@ -6863,12 +6463,19 @@ export class LayoutService {
     barBoxes: NoteGlyphBox[],
     edge: MeasureBarAnchorEdge,
     clearance: number,
+    verticalTolerance = 0,
   ) {
     let deficit = 0;
 
     for (const noteBox of noteBoxes) {
       for (const barBox of barBoxes) {
-        if (!this.noteGlyphBoxesVerticallyOverlap(noteBox, barBox)) {
+        if (
+          !this.noteGlyphBoxesVerticallyOverlapWithTolerance(
+            noteBox,
+            barBox,
+            verticalTolerance,
+          )
+        ) {
           continue;
         }
 
@@ -6900,7 +6507,7 @@ export class LayoutService {
       leftBarReserveOverride,
     );
 
-    return this.getMeasureBarCollisionDeficitForVerticalTolerance(
+    return this.getMeasureBarCollisionDeficit(
       vareiaBoxes,
       barBoxes,
       edge,
@@ -6947,39 +6554,6 @@ export class LayoutService {
     };
   }
 
-  private static getMeasureBarCollisionDeficitForVerticalTolerance(
-    noteBoxes: NoteGlyphBox[],
-    barBoxes: NoteGlyphBox[],
-    edge: MeasureBarAnchorEdge,
-    clearance: number,
-    verticalTolerance: number,
-  ) {
-    let deficit = 0;
-
-    for (const noteBox of noteBoxes) {
-      for (const barBox of barBoxes) {
-        if (
-          !this.noteGlyphBoxesVerticallyOverlapWithTolerance(
-            noteBox,
-            barBox,
-            verticalTolerance,
-          )
-        ) {
-          continue;
-        }
-
-        deficit = Math.max(
-          deficit,
-          edge === 'left'
-            ? barBox.right + clearance - noteBox.left
-            : noteBox.right + clearance - barBox.left,
-        );
-      }
-    }
-
-    return Math.max(0, deficit);
-  }
-
   private static getMinimumSpacingForMeasureBarVareiaBoxes(
     leftAdvanceWidth: number,
     barBoxes: NoteGlyphBox[],
@@ -6993,29 +6567,14 @@ export class LayoutService {
       pageSetup,
       measureBarWidthMap,
     );
-    let spacing = 0;
-    const verticalTolerance = this.emToPx(0.01, pageSetup.neumeDefaultFontSize);
 
-    for (const barBox of barBoxes) {
-      for (const vareiaBox of vareiaBoxes) {
-        if (
-          !this.noteGlyphBoxesVerticallyOverlapWithTolerance(
-            barBox,
-            vareiaBox,
-            verticalTolerance,
-          )
-        ) {
-          continue;
-        }
-
-        spacing = Math.max(
-          spacing,
-          barBox.right + clearance - leftAdvanceWidth - vareiaBox.left,
-        );
-      }
-    }
-
-    return Math.max(0, spacing);
+    return this.getMinimumSpacingForNoteGlyphBoxes(
+      leftAdvanceWidth,
+      barBoxes,
+      vareiaBoxes,
+      clearance,
+      this.emToPx(0.01, pageSetup.neumeDefaultFontSize),
+    );
   }
 
   private static noteGlyphBoxesVerticallyOverlapWithTolerance(
@@ -7090,7 +6649,7 @@ export class LayoutService {
         measureBarRight,
         'left',
       );
-      const leftAdvance = this.getMeasureBarOwnerWidth(leftNote);
+      const leftAdvance = this.getNoteBoxAdvance(leftNote);
       const ownerBoundsRight = ownerBounds.right - leftNote.x;
       const nextBoundsLeft = nextBounds.left - rightMartyria.x;
       const centeredClampMinimum = Math.max(
@@ -7105,7 +6664,7 @@ export class LayoutService {
 
       return Math.max(
         this.getMinimumSpacingForNoteGlyphBoxes(
-          leftNote.neumeWidth,
+          leftAdvance,
           barBoxes,
           rightBoxes,
           clearance,
@@ -7137,11 +6696,11 @@ export class LayoutService {
         0,
         pageSetup,
       );
-      const leftOwnerWidth = this.getMeasureBarOwnerWidth(leftMartyria);
+      const leftAdvance = this.getMartyriaBoxAdvance(leftMartyria);
       const clearance = this.getMeasureBarCollisionSpacing(pageSetup);
 
       return this.getMinimumSpacingForNoteGlyphBoxes(
-        leftOwnerWidth,
+        leftAdvance,
         leftBoxes,
         barBoxes,
         clearance,
@@ -7160,6 +6719,7 @@ export class LayoutService {
     const measureBarRight = this.getVisibleMeasureBarRight(leftNote);
     const measureBarLeft = this.getVisibleMeasureBarLeft(rightNote);
     const clearance = this.getMeasureBarCollisionSpacing(pageSetup);
+    const leftAdvance = this.getNoteBoxAdvance(leftNote);
 
     if (measureBarRight != null) {
       const fallbackBounds = this.getMeasureBarAnchorBounds(
@@ -7181,13 +6741,13 @@ export class LayoutService {
       );
       const collisionMinimum = Math.max(
         this.getMinimumSpacingForNoteGlyphBoxes(
-          leftNote.neumeWidth,
+          leftAdvance,
           barBoxes,
           rightBoxes,
           clearance,
         ),
         this.getMinimumSpacingForMeasureBarVareiaBoxes(
-          leftNote.neumeWidth,
+          leftAdvance,
           barBoxes,
           rightNote,
           clearance,
@@ -7249,7 +6809,7 @@ export class LayoutService {
         ownerBoundsRight +
           2 * clearance -
           ownerClampExtents.left -
-          leftNote.neumeWidth -
+          leftAdvance -
           nextBoundsLeft +
           nextClampExtents.right,
       );
@@ -7272,7 +6832,7 @@ export class LayoutService {
       );
 
       return this.getMinimumSpacingForNoteGlyphBoxes(
-        leftNote.neumeWidth,
+        leftAdvance,
         leftBoxes,
         barBoxes,
         clearance,
@@ -7377,21 +6937,7 @@ export class LayoutService {
   private static getNoteNeumesForMeasurement(noteElement: NoteElement) {
     return [
       noteElement.quantitativeNeume,
-      noteElement.stavros ? VocalExpressionNeume.Cross_Top : null,
-      noteElement.vocalExpressionNeume,
-      noteElement.timeNeume,
-      noteElement.koronis ? TimeNeume.Koronis : null,
-      noteElement.gorgonNeume,
-      noteElement.secondaryGorgonNeume,
-      noteElement.fthora,
-      noteElement.secondaryFthora,
-      noteElement.tertiaryFthora,
-      noteElement.accidental,
-      noteElement.secondaryAccidental,
-      noteElement.tertiaryAccidental,
-      noteElement.noteIndicator ? noteElement.noteIndicatorNeume : null,
-      noteElement.ison,
-      noteElement.measureNumber,
+      ...noteMarkSlots.map((slot) => slot.neume(noteElement)),
     ].filter((x) => x != null);
   }
 
@@ -7445,44 +6991,30 @@ export class LayoutService {
         );
 
         // Handle fthora carries
-        if (
-          note.fthoraCarry &&
-          this.fthoraIsValid(note.fthoraCarry, currentNotesVirtual, pageSetup)
-        ) {
-          note.fthora = note.fthoraCarry;
-          note.fthoraCarry = null;
+        for (const slot of noteFthoraSlots) {
+          const carry = slot.getCarry(note);
+
+          if (
+            carry &&
+            this.fthoraIsValid(carry, currentNotesVirtual, pageSetup)
+          ) {
+            slot.setFthora(note, carry);
+            slot.setCarry(note, null);
+          }
         }
 
-        if (
-          note.secondaryFthoraCarry &&
-          this.fthoraIsValid(
-            note.secondaryFthoraCarry,
-            currentNotesVirtual,
-            pageSetup,
-          )
-        ) {
-          note.secondaryFthora = note.secondaryFthoraCarry;
-          note.secondaryFthoraCarry = null;
-        }
+        // Apply the first present fthora (primary, then secondary, then
+        // tertiary), demoting it back to a carry when it is invalid here.
+        const activeSlot = noteFthoraSlots.find((slot) => slot.getFthora(note));
 
-        if (
-          note.tertiaryFthoraCarry &&
-          this.fthoraIsValid(
-            note.tertiaryFthoraCarry,
-            currentNotesVirtual,
-            pageSetup,
-          )
-        ) {
-          note.tertiaryFthora = note.tertiaryFthoraCarry;
-          note.tertiaryFthoraCarry = null;
-        }
+        if (activeSlot) {
+          const fthora = activeSlot.getFthora(note)!;
 
-        if (note.fthora) {
-          if (this.fthoraIsValid(note.fthora, currentNotesVirtual, pageSetup)) {
+          if (this.fthoraIsValid(fthora, currentNotesVirtual, pageSetup)) {
             const spreadIndex = getSpreadIndex(
-              note.fthora,
+              fthora,
               note.quantitativeNeume,
-              NeumeSelection.Primary,
+              activeSlot.selection,
             );
             const fthoraNote =
               spreadIndex != -1 ? currentNotes[spreadIndex] : currentNote;
@@ -7494,7 +7026,7 @@ export class LayoutService {
 
             // Scale is based off the virtual note
             currentScale =
-              this.getScaleFromFthora(note.fthora, fthoraNoteVirtual) ||
+              this.getScaleFromFthora(fthora, fthoraNoteVirtual) ||
               currentScale;
 
             // Shift is based off the true note
@@ -7502,106 +7034,17 @@ export class LayoutService {
               fthoraNote,
               fthoraNoteVirtual,
               currentScale,
-              note.fthora,
-              note.chromaticFthoraNote,
+              fthora,
+              activeSlot.getChromaticFthoraNote(note),
             );
 
             note.noteIndicatorNeume = noteIndicatorMap.get(
               (((fthoraNote + currentShift) % 7) + 7) % 7,
             )!;
-            note.fthoraCarry = null;
+            activeSlot.setCarry(note, null);
           } else {
-            note.fthoraCarry = note.fthora;
-            note.fthora = null;
-          }
-        } else if (note.secondaryFthora) {
-          if (
-            this.fthoraIsValid(
-              note.secondaryFthora,
-              currentNotesVirtual,
-              pageSetup,
-            )
-          ) {
-            const spreadIndex = getSpreadIndex(
-              note.secondaryFthora,
-              note.quantitativeNeume,
-              NeumeSelection.Secondary,
-            );
-
-            const fthoraNote =
-              spreadIndex != -1 ? currentNotes[spreadIndex] : currentNote;
-
-            const fthoraNoteVirtual =
-              spreadIndex != -1
-                ? currentNotesVirtual[spreadIndex]
-                : currentNoteVirtual;
-
-            // Scale is based off the virtual note
-            currentScale =
-              this.getScaleFromFthora(
-                note.secondaryFthora,
-                fthoraNoteVirtual,
-              ) || currentScale;
-
-            // Shift is based off the true note
-            currentShift = this.getShift(
-              fthoraNote,
-              fthoraNoteVirtual,
-              currentScale,
-              note.secondaryFthora,
-              note.secondaryChromaticFthoraNote,
-            );
-
-            note.noteIndicatorNeume = noteIndicatorMap.get(
-              (((fthoraNote + currentShift) % 7) + 7) % 7,
-            )!;
-            note.secondaryFthoraCarry = null;
-          } else {
-            note.secondaryFthoraCarry = note.secondaryFthora;
-            note.secondaryFthora = null;
-          }
-        } else if (note.tertiaryFthora) {
-          if (
-            this.fthoraIsValid(
-              note.tertiaryFthora,
-              currentNotesVirtual,
-              pageSetup,
-            )
-          ) {
-            const spreadIndex = getSpreadIndex(
-              note.tertiaryFthora,
-              note.quantitativeNeume,
-              NeumeSelection.Tertiary,
-            );
-            const fthoraNote =
-              spreadIndex != -1 ? currentNotes[spreadIndex] : currentNote;
-
-            const fthoraNoteVirtual =
-              spreadIndex != -1
-                ? currentNotesVirtual[spreadIndex]
-                : currentNoteVirtual;
-
-            // Scale is based off the virtual note
-            currentScale =
-              this.getScaleFromFthora(note.tertiaryFthora, fthoraNoteVirtual) ||
-              currentScale;
-
-            // Shift is based off the true note
-            currentShift = this.getShift(
-              fthoraNote,
-              fthoraNoteVirtual,
-              currentScale,
-              note.tertiaryFthora,
-              note.tertiaryChromaticFthoraNote,
-            );
-
-            note.noteIndicatorNeume = noteIndicatorMap.get(
-              (((fthoraNote + currentShift) % 7) + 7) % 7,
-            )!;
-            note.tertiaryFthoraCarry = null;
-          } else {
-            note.tertiaryFthoraCarry = note.tertiaryFthora;
-            note.tertiaryFthora = null;
+            activeSlot.setCarry(note, fthora);
+            activeSlot.setFthora(note, null);
           }
         }
 
@@ -7621,17 +7064,15 @@ export class LayoutService {
         const modeKey = element as ModeKeyElement;
 
         if (currentModeKey) {
-          if (currentModeKey) {
-            this.assignAmbitus({
-              currentModeKey,
-              ambitusLow,
-              ambitusHigh,
-              ambitusLowScale,
-              ambitusLowShift,
-              ambitusHighScale,
-              ambitusHighShift,
-            });
-          }
+          this.assignAmbitus({
+            currentModeKey,
+            ambitusLow,
+            ambitusHigh,
+            ambitusLowScale,
+            ambitusLowShift,
+            ambitusHighScale,
+            ambitusHighShift,
+          });
         }
 
         ambitusLow = Number.MAX_SAFE_INTEGER;
@@ -7757,24 +7198,15 @@ export class LayoutService {
     }
 
     if (currentModeKey) {
-      currentModeKey.ambitusLowNote = getNoteFromValue(ambitusLow) ?? Note.Pa;
-      currentModeKey.ambitusHighNote = getNoteFromValue(ambitusHigh) ?? Note.Pa;
-      currentModeKey.ambitusLowRootSign =
-        ambitusLow !== Number.MAX_SAFE_INTEGER
-          ? this.getRootSign(
-              ambitusLowScale,
-              ambitusLow + ambitusLowShift,
-              ambitusLow,
-            )
-          : RootSign.Alpha;
-      currentModeKey.ambitusHighRootSign =
-        ambitusHigh !== Number.MIN_SAFE_INTEGER
-          ? this.getRootSign(
-              ambitusHighScale,
-              ambitusHigh + ambitusHighShift,
-              ambitusHigh,
-            )
-          : RootSign.Alpha;
+      this.assignAmbitus({
+        currentModeKey,
+        ambitusLow,
+        ambitusHigh,
+        ambitusLowScale,
+        ambitusLowShift,
+        ambitusHighScale,
+        ambitusHighShift,
+      });
     }
   }
 
@@ -7872,31 +7304,10 @@ export class LayoutService {
         currentScaleNote % 2 === 0
           ? RootSign.SoftChromaticPaRootSign
           : RootSign.SoftChromaticSquiggle;
-    } else if (currentScale === Scale.Diatonic) {
-      rootSign = diatonicRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.Zygos) {
-      rootSign = zygosRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.Kliton) {
-      rootSign = klitonRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.Spathi) {
-      rootSign = spathiKeRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.SpathiGa) {
-      rootSign = spathiGaRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.EnharmonicGa) {
+    } else {
       rootSign =
-        enharmonicGaRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.EnharmonicVou) {
-      rootSign =
-        enharmonicVouRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.EnharmonicVouHigh) {
-      rootSign =
-        enharmonicVouHighRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.EnharmonicZoHigh) {
-      rootSign =
-        enharmonicZoHighRootSignMap.get(currentScaleNote) || RootSign.Alpha;
-    } else if (currentScale === Scale.EnharmonicZo) {
-      rootSign =
-        enharmonicZoRootSignMap.get(currentScaleNote) || RootSign.Alpha;
+        scaleRootSignMaps.get(currentScale)?.get(currentScaleNote) ||
+        RootSign.Alpha;
     }
 
     if (currentNote <= getNoteValue(Note.KeLow)) {
@@ -8021,24 +7432,12 @@ export class LayoutService {
       }
 
       shift = fthoraNote - currentNote;
-    } else if (currentScale === Scale.Kliton) {
-      shift = getScaleNoteValue(ScaleNote.Thi) - currentNote;
-    } else if (currentScale === Scale.Zygos) {
-      shift = getScaleNoteValue(ScaleNote.Thi) - currentNote;
-    } else if (currentScale === Scale.Spathi) {
-      shift = getScaleNoteValue(ScaleNote.Ke) - currentNote;
-    } else if (currentScale === Scale.SpathiGa) {
-      shift = getScaleNoteValue(ScaleNote.Ga) - currentNote;
-    } else if (currentScale === Scale.EnharmonicGa) {
-      shift = getScaleNoteValue(ScaleNote.Ga) - currentNote;
-    } else if (currentScale === Scale.EnharmonicVou) {
-      shift = getScaleNoteValue(ScaleNote.Vou) - currentNote;
-    } else if (currentScale === Scale.EnharmonicVouHigh) {
-      shift = getScaleNoteValue(ScaleNote.VouHigh) - currentNote;
-    } else if (currentScale === Scale.EnharmonicZo) {
-      shift = getScaleNoteValue(ScaleNote.Zo) - currentNote;
-    } else if (currentScale === Scale.EnharmonicZoHigh) {
-      shift = getScaleNoteValue(ScaleNote.ZoHigh) - currentNote;
+    } else {
+      const anchorNote = scaleShiftAnchorMap.get(currentScale);
+
+      if (anchorNote != null) {
+        shift = getScaleNoteValue(anchorNote) - currentNote;
+      }
     }
 
     return shift;
@@ -8104,37 +7503,32 @@ export class LayoutService {
     return true;
   }
 
-  private static getNeumeWidthFromCache(
-    cache: Map<string, number>,
-    neume: Neume,
-    pageSetup: PageSetup,
-  ) {
+  private static getNeumeWidthFromCache(neume: Neume, pageSetup: PageSetup) {
     const key = `${neume} | ${pageSetup.neumeDefaultFontSize} | ${pageSetup.neumeDefaultFontFamily}`;
 
-    let width = cache.get(key);
+    let width = neumeWidthCache.get(key);
 
     if (width == null) {
       const neumeMapping = NeumeMappingService.getMapping(neume);
 
       width = TextMeasurementService.getTextWidth(
         neumeMapping.text,
-        `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
+        this.getNeumeFont(pageSetup),
       );
 
-      cache.set(key, width);
+      neumeWidthCache.set(key, width);
     }
 
     return width;
   }
 
   private static getNeumeSequenceWidthFromCache(
-    cache: Map<string, number>,
     neumes: Array<Neume>,
     pageSetup: PageSetup,
   ) {
     const key = `${neumes.join(',')} | ${pageSetup.neumeDefaultFontSize} | ${pageSetup.neumeDefaultFontFamily}`;
 
-    let width = cache.get(key);
+    let width = neumeWidthCache.get(key);
 
     if (width == null) {
       const text = neumes
@@ -8143,10 +7537,10 @@ export class LayoutService {
 
       width = TextMeasurementService.getTextWidth(
         text,
-        `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
+        this.getNeumeFont(pageSetup),
       );
 
-      cache.set(key, width);
+      neumeWidthCache.set(key, width);
     }
 
     return width;
@@ -8158,6 +7552,29 @@ export class LayoutService {
   ) {
     const neumes = this.getNoteNeumesForInkMeasurement(noteElement);
     return this.getNeumeSequenceInkBoundsFromCache(neumes, pageSetup);
+  }
+
+  private static getNoteRightInkOverhang(
+    noteElement: NoteElement,
+    pageSetup: PageSetup,
+  ) {
+    const inkBounds = this.getNoteInkBoundsFromCache(noteElement, pageSetup);
+    const measureBarLeft = this.getVisibleMeasureBarLeft(noteElement);
+    // Ink bounds are relative to the main glyph run. Translate its right edge
+    // into note-box coordinates before comparing it with the layout advance.
+    const bodyLeft =
+      (measureBarLeft != null
+        ? this.getNeumeWidthFromCache(measureBarLeft, pageSetup) +
+          noteElement.computedMeasureBarLeftLeadingSpacing
+        : 0) +
+      (!pageSetup.melkiteRtl && noteElement.vareia
+        ? this.getVareiaPrefixWidth(noteElement, pageSetup)
+        : 0);
+
+    return Math.max(
+      0,
+      bodyLeft + inkBounds.inkRight - this.getNoteBoxAdvance(noteElement),
+    );
   }
 
   private static getNeumeSequenceInkBoundsFromCache(
@@ -8172,7 +7589,7 @@ export class LayoutService {
       const text = neumes
         .map((neume) => NeumeMappingService.getMapping(neume).text)
         .join('');
-      const font = `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`;
+      const font = this.getNeumeFont(pageSetup);
 
       bounds = TextMeasurementService.getInkBounds(text, font);
 
@@ -8191,7 +7608,6 @@ export class LayoutService {
       pageSetup,
     );
     const bodyWidth = this.getNeumeSequenceWidthFromCache(
-      neumeWidthCache,
       this.getMartyriaBodyNeumesForWidthMeasurement(martyriaElement),
       pageSetup,
     );
@@ -8313,16 +7729,12 @@ export class LayoutService {
     pageSetup: PageSetup,
   ) {
     return noteElement.vareia
-      ? this.getNeumeWidthFromCache(
-          neumeWidthCache,
-          VocalExpressionNeume.Vareia,
-          pageSetup,
-        ) + noteElement.vareiaInternalSpacing
+      ? this.getNeumeWidthFromCache(VocalExpressionNeume.Vareia, pageSetup) +
+          noteElement.vareiaInternalSpacing
       : 0;
   }
 
   private static getTextWidthFromCache(
-    cache: Map<string, number>,
     element: NoteElement,
     textOverride: string | null = null,
     trimLeadingPunctuation: boolean = false,
@@ -8352,48 +7764,44 @@ export class LayoutService {
     const fontVariantCaps = element.computedLyricsFontVariantCaps;
     const key = `${text} | ${font} | ${fontVariantCaps}`;
 
-    let width = cache.get(key);
+    let width = textWidthCache.get(key);
 
     if (width == null) {
       width = TextMeasurementService.getTextWidth(text, font, fontVariantCaps);
 
-      cache.set(key, width);
+      textWidthCache.set(key, width);
     }
 
     return width;
   }
 
   private static getLyricsFontBoundingBoxDescentFromCache(
-    cache: Map<string, number>,
     element: NoteElement,
   ) {
     const font = element.lyricsFontCss;
 
     const key = font;
 
-    let descent = cache.get(key);
+    let descent = fontBoundingBoxDescentCache.get(key);
 
     if (descent == null) {
       descent = TextMeasurementService.getFontBoundingBoxDescent(font);
 
-      cache.set(key, descent);
+      fontBoundingBoxDescentCache.set(key, descent);
     }
 
     return descent;
   }
 
-  private static getLyricsFontHeightFromCache(
-    cache: Map<string, number>,
-    font: string,
-  ) {
+  private static getLyricsFontHeightFromCache(font: string) {
     const key = font;
 
-    let height = cache.get(key);
+    let height = fontHeightCache.get(key);
 
     if (height == null) {
       height = TextMeasurementService.getFontHeight(font);
 
-      cache.set(key, height);
+      fontHeightCache.set(key, height);
     }
 
     return height;
@@ -8648,3 +8056,165 @@ const highRootSignMap = new Map<RootSign, RootSign>();
 for (const [key, value] of lowRootSignMap) {
   highRootSignMap.set(value, key);
 }
+
+// Scales whose base root sign is a per-note table lookup. The chromatic scales
+// derive their base root sign separately in getRootSign via note parity.
+const scaleRootSignMaps = new Map<Scale, Map<number, RootSign>>([
+  [Scale.Diatonic, diatonicRootSignMap],
+  [Scale.Zygos, zygosRootSignMap],
+  [Scale.Kliton, klitonRootSignMap],
+  [Scale.Spathi, spathiKeRootSignMap],
+  [Scale.SpathiGa, spathiGaRootSignMap],
+  [Scale.EnharmonicGa, enharmonicGaRootSignMap],
+  [Scale.EnharmonicVou, enharmonicVouRootSignMap],
+  [Scale.EnharmonicVouHigh, enharmonicVouHighRootSignMap],
+  [Scale.EnharmonicZoHigh, enharmonicZoHighRootSignMap],
+  [Scale.EnharmonicZo, enharmonicZoRootSignMap],
+]);
+
+// Scales that shift to a fixed anchor note. The chromatic and diatonic
+// scales are handled separately in getShift.
+const scaleShiftAnchorMap = new Map<Scale, ScaleNote>([
+  [Scale.Kliton, ScaleNote.Thi],
+  [Scale.Zygos, ScaleNote.Thi],
+  [Scale.Spathi, ScaleNote.Ke],
+  [Scale.SpathiGa, ScaleNote.Ga],
+  [Scale.EnharmonicGa, ScaleNote.Ga],
+  [Scale.EnharmonicVou, ScaleNote.Vou],
+  [Scale.EnharmonicVouHigh, ScaleNote.VouHigh],
+  [Scale.EnharmonicZo, ScaleNote.Zo],
+  [Scale.EnharmonicZoHigh, ScaleNote.ZoHigh],
+]);
+
+// The three fthora slots on a note (primary, secondary, tertiary) share the
+// carry and apply logic in calculateMartyriae. Their selection and field
+// accessors identify the slot-specific state.
+const noteFthoraSlots: Array<{
+  selection: NeumeSelection;
+  getFthora: (note: NoteElement) => Fthora | null;
+  setFthora: (note: NoteElement, fthora: Fthora | null) => void;
+  getCarry: (note: NoteElement) => Fthora | null;
+  setCarry: (note: NoteElement, fthora: Fthora | null) => void;
+  getChromaticFthoraNote: (note: NoteElement) => ScaleNote | null;
+}> = [
+  {
+    selection: NeumeSelection.Primary,
+    getFthora: (note) => note.fthora,
+    setFthora: (note, fthora) => {
+      note.fthora = fthora;
+    },
+    getCarry: (note) => note.fthoraCarry,
+    setCarry: (note, fthora) => {
+      note.fthoraCarry = fthora;
+    },
+    getChromaticFthoraNote: (note) => note.chromaticFthoraNote,
+  },
+  {
+    selection: NeumeSelection.Secondary,
+    getFthora: (note) => note.secondaryFthora,
+    setFthora: (note, fthora) => {
+      note.secondaryFthora = fthora;
+    },
+    getCarry: (note) => note.secondaryFthoraCarry,
+    setCarry: (note, fthora) => {
+      note.secondaryFthoraCarry = fthora;
+    },
+    getChromaticFthoraNote: (note) => note.secondaryChromaticFthoraNote,
+  },
+  {
+    selection: NeumeSelection.Tertiary,
+    getFthora: (note) => note.tertiaryFthora,
+    setFthora: (note, fthora) => {
+      note.tertiaryFthora = fthora;
+    },
+    getCarry: (note) => note.tertiaryFthoraCarry,
+    setCarry: (note, fthora) => {
+      note.tertiaryFthoraCarry = fthora;
+    },
+    getChromaticFthoraNote: (note) => note.tertiaryChromaticFthoraNote,
+  },
+];
+
+// The ordered list of optional marks shared by the shaped-width and collision
+// paths. Each path adds or excludes its own special cases separately.
+const noteMarkSlots: Array<{
+  neume: (note: NoteElement) => Neume | null;
+  offsetX: (note: NoteElement) => number | null;
+  offsetY: (note: NoteElement) => number | null;
+}> = [
+  {
+    neume: (note) => (note.stavros ? VocalExpressionNeume.Cross_Top : null),
+    offsetX: (note) => note.stavrosOffsetX,
+    offsetY: (note) => note.stavrosOffsetY,
+  },
+  {
+    neume: (note) => note.vocalExpressionNeume,
+    offsetX: (note) => note.vocalExpressionNeumeOffsetX,
+    offsetY: (note) => note.vocalExpressionNeumeOffsetY,
+  },
+  {
+    neume: (note) => note.timeNeume,
+    offsetX: (note) => note.timeNeumeOffsetX,
+    offsetY: (note) => note.timeNeumeOffsetY,
+  },
+  {
+    neume: (note) => (note.koronis ? TimeNeume.Koronis : null),
+    offsetX: (note) => note.koronisOffsetX,
+    offsetY: (note) => note.koronisOffsetY,
+  },
+  {
+    neume: (note) => note.gorgonNeume,
+    offsetX: (note) => note.gorgonNeumeOffsetX,
+    offsetY: (note) => note.gorgonNeumeOffsetY,
+  },
+  {
+    neume: (note) => note.secondaryGorgonNeume,
+    offsetX: (note) => note.secondaryGorgonNeumeOffsetX,
+    offsetY: (note) => note.secondaryGorgonNeumeOffsetY,
+  },
+  {
+    neume: (note) => note.fthora,
+    offsetX: (note) => note.fthoraOffsetX,
+    offsetY: (note) => note.fthoraOffsetY,
+  },
+  {
+    neume: (note) => note.secondaryFthora,
+    offsetX: (note) => note.secondaryFthoraOffsetX,
+    offsetY: (note) => note.secondaryFthoraOffsetY,
+  },
+  {
+    neume: (note) => note.tertiaryFthora,
+    offsetX: (note) => note.tertiaryFthoraOffsetX,
+    offsetY: (note) => note.tertiaryFthoraOffsetY,
+  },
+  {
+    neume: (note) => note.accidental,
+    offsetX: (note) => note.accidentalOffsetX,
+    offsetY: (note) => note.accidentalOffsetY,
+  },
+  {
+    neume: (note) => note.secondaryAccidental,
+    offsetX: (note) => note.secondaryAccidentalOffsetX,
+    offsetY: (note) => note.secondaryAccidentalOffsetY,
+  },
+  {
+    neume: (note) => note.tertiaryAccidental,
+    offsetX: (note) => note.tertiaryAccidentalOffsetX,
+    offsetY: (note) => note.tertiaryAccidentalOffsetY,
+  },
+  {
+    neume: (note) => (note.noteIndicator ? note.noteIndicatorNeume : null),
+    offsetX: (note) => note.noteIndicatorOffsetX,
+    offsetY: (note) => note.noteIndicatorOffsetY,
+  },
+  {
+    neume: (note) => note.ison,
+    offsetX: (note) => note.isonOffsetX,
+    offsetY: (note) => note.computedIsonOffsetY,
+  },
+  {
+    neume: (note) => note.measureNumber,
+    offsetX: (note) => note.measureNumberOffsetX,
+    offsetY: (note) => note.measureNumberOffsetY,
+  },
+];

--- a/src/utils/runningMarkers.ts
+++ b/src/utils/runningMarkers.ts
@@ -45,38 +45,39 @@ export interface RunningMarkerPageMetadata {
   isChapterOpening: boolean;
 }
 
-interface RunningMarkerState {
-  chapter: string;
-  section: string;
+// Resolves one page against the previous page's metadata (null for the first
+// page). Page metadata is a left fold: it depends only on the page's own
+// content and the previous page's metadata, so callers that build pages
+// incrementally can resolve each page once instead of re-resolving the whole
+// array as it grows.
+export function resolveNextRunningMarkerPageMetadata(
+  page: Page,
+  previous: RunningMarkerPageMetadata | null,
+): RunningMarkerPageMetadata {
+  const firstChapter = getFirstRunningMarkerForPage(page, 'chapter');
+  const firstSection = getFirstRunningMarkerForPage(page, 'section');
+
+  const previousChapter = previous?.chapter ?? '';
+  const chapter = firstChapter ?? previousChapter;
+  const section =
+    firstSection ?? (firstChapter != null ? '' : (previous?.section ?? ''));
+
+  return {
+    chapter,
+    section,
+    isChapterOpening: firstChapter != null && chapter !== previousChapter,
+  };
 }
 
 export function resolveRunningMarkerPageMetadata(
   pages: Page[],
 ): RunningMarkerPageMetadata[] {
   const metadata: RunningMarkerPageMetadata[] = [];
-  let state: RunningMarkerState = {
-    chapter: '',
-    section: '',
-  };
+  let previous: RunningMarkerPageMetadata | null = null;
 
   for (const page of pages) {
-    const firstChapter = getFirstRunningMarkerForPage(page, 'chapter');
-    const firstSection = getFirstRunningMarkerForPage(page, 'section');
-
-    const nextChapter = firstChapter ?? state.chapter;
-    const nextSection =
-      firstSection ?? (firstChapter != null ? '' : state.section);
-
-    metadata.push({
-      chapter: nextChapter,
-      section: nextSection,
-      isChapterOpening: firstChapter != null && nextChapter !== state.chapter,
-    });
-
-    state = {
-      chapter: nextChapter,
-      section: nextSection,
-    };
+    previous = resolveNextRunningMarkerPageMetadata(page, previous);
+    metadata.push(previous);
   }
 
   return metadata;


### PR DESCRIPTION
## Summary

This PR corrects layout geometry and consolidates `LayoutService` without changing the save format, UI, or dependencies.

The functional fixes are concentrated in boundary geometry:

- collision and measure-bar calculations now use the full layout advance of a note or martyria, including `spaceAfter` and owned prefixes;
- right-side ink reservations are translated into box coordinates before extra spacing is added;
- measure-bar collision, transfer, and terminal-spacing paths share the same normalized geometry; and
- martyria line-start, terminal, and right-aligned placement use consistent Phase 1 reservations and Phase 2 positioning.

The refactor deliberately preserves `origin/master` behavior for ordinary note-boundary elasticity. Visual, measure-bar, lyric, and melisma requirements contribute to one preferred same-line width, and ordinary post-note glue retains the full standard stretch and shrink budgets. These requirements are not new hard floors.

The PR also removes repeated pagination and measurement work, replaces parallel layout branches with shared helpers and data tables, and updates `notes/knuth_plass.md` to describe the resulting box/glue/penalty model.

## Behavior relative to `origin/master`

| Area                         | `origin/master`                                                | This PR                                                                                  |
| ---------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| Ordinary boundary elasticity | One preferred width with the full standard stretch and shrink  | Preserved                                                                                |
| Preferred spacing inputs     | Visual, measure-bar, lyric, and melisma calculations           | Consolidated into `resolvePreferredInterNoteSpacing()`                                   |
| Boundary coordinates         | Some calculations used glyph width while the box included more | Calculations use the complete note or martyria layout advance                            |
| Right ink reservation        | Some paths used raw shaped-glyph overhang                      | Ink edges are translated into box coordinates and reduced by the complete layout advance |
| Martyria-owned boundaries    | Dedicated glue with structural shrink limits                   | Policy preserved; corrected geometry can change the resulting widths                     |
| Running-marker pagination    | Repeatedly resolved the completed page prefix                  | Completed pages are folded incrementally                                                 |
| Page margins                 | Repeatedly resolved for elements on the same physical page     | Cached per physical page during one layout pass                                          |

The preferred-only ordinary spacing model is an invariant preserved by this PR, not the headline behavioral change.

## User-visible effects

- Ordinary note-to-note boundaries retain the compression behavior of `origin/master`, including negative adjustment ratios on tight justified lines.
- Corrected full-box geometry can change spacing and line breaks around `spaceAfter`, ink protrusions, measure bars, and martyriae.
- Positive `spaceAfter` can satisfy part of a preferred clearance; negative `spaceAfter` increases the preferred boundary width when the box ends earlier.
- Negative configured inline spacing remains negative at ordinary note-to-note boundaries when the visual helper has only its generic zero clamp and no larger preferred geometry applies.
- Terminal `Empty` and supported non-note measure-bar paths remain preferred rather than hard, but their zero-valued minimum can still clamp a negative base width to zero.
- Measure bars transferred across line breaks reserve their glyph width and collision-aware leading clearance consistently.
- Terminal note and martyria ink is measured relative to the complete element advance.
- Multi-page scores avoid repeated running-marker and margin work during layout.

Martyria-owned boundaries are intentionally separate from ordinary post-note glue. Their dedicated structural shrink limits remain, and their visible widths may change because those limits now receive corrected full-box geometry.

There are no new controls, dialogs, commands, user-visible strings, or persisted fields.

## Implementation

### Full layout advances

The paragraph boxes and geometry helpers now share one definition of each element's horizontal advance:

| Element  | Layout advance                                                             |
| -------- | -------------------------------------------------------------------------- |
| Note     | `neumeWidth + spaceAfter`                                                  |
| Martyria | `neumeWidth + computedMeasureBarLeftLeadingSpacing + padding + spaceAfter` |

The helpers are used by box creation, visual collision spacing, measure-bar spacing, centered-bar clamping, transfer calculations, and terminal ink reservations.

This removes a coordinate mismatch where the Knuth-Plass box included `spaceAfter` but some collision calculations started from `neumeWidth` alone.

### Ordinary preferred spacing

`calculateInterNoteSpacing()` returns one preferred same-line width. `resolvePreferredInterNoteSpacing()` selects the largest applicable candidate:

```text
m = max(naturalWidth, preferredMinimums)
```

The candidates are:

- ordinary visual separation between overlapping note and mark boxes;
- visible measure-bar spacing;
- lyric-to-lyric clearance, including an absorbed hyphen; and
- carried melisma clearance before the next real syllable.

Ordinary post-note glue remains:

```text
glue(m, standard stretch, standard shrink)
```

No ordinary candidate creates a separate hard shrink cap. At a break, the post-note glue becomes leading glue and is skipped, so the same-line width and elasticity disappear as before.

The same preferred-only policy applies to terminal right-measure-bar spacing before a final `Empty` element and a visible right measure bar before a supported non-note anchor. Unlike the note-to-note visual path, these paths retain their existing zero minimum, so they can clamp negative base spacing to zero even when no bar is visible.

A note immediately before a martyria is different: the martyria replaces and owns that boundary glue, so the note contributes fixed spacing without competing elasticity.

### Right ink in box coordinates

`getNoteRightInkOverhang()` translates the shaped ink edge into note-box coordinates. It accounts for:

- an inline left measure bar and its leading spacing;
- a left-to-right vareia prefix and its internal spacing; and
- the complete note advance, including `spaceAfter`.

The final reservation is:

```text
max(0, translated ink right edge - note box advance)
```

Standalone tempo and martyria terminal overhangs use the same principle: only ink that protrudes beyond the complete layout advance produces extra spacing.

### Measure bars and martyriae

Shared helpers now handle measure-bar ink bounds, collision deficits, owner widths, transfers, and normalized above-style bars.

The line-start transfer encoding remains a spacer-and-cancel pair:

1. Phase 1 narrows post-break glue by the transferred bar width and leading clearance.
2. An anonymous spacer of the same width is inserted before the receiving note.
3. On the same line, the glue reduction and spacer cancel.
4. At a break, the post-break glue is skipped and the spacer survives at line start.
5. Phase 2 shifts the receiving note so the rendered bar occupies the reserved space.

`getMartyriaBoxAdvance()` supplies one martyria width for paragraph construction and measure-bar geometry. Terminal spacing uses either a visible right bar or the remaining right ink overhang after `spaceAfter`.

Right-aligned martyriae retain dominant leading stretch. When one starts a paragraph and that leading glue is skipped, Phase 2 explicitly places it flush right.

### Break-only reservations

Same-line preferred spacing remains in post-break glue. Width needed only when a break is taken remains in penalty widths or fixed line-start spacer boxes.

Break-only reservations include:

- the current lyric's right projection;
- melisma overhang past the last note;
- terminal right-bar clearance;
- transferred measure bars; and
- leading lyric hyphens.

This keeps break-only geometry from consuming ordinary same-line spacing or elasticity.

### Pagination and measurement work

`resolveNextRunningMarkerPageMetadata(page, previous)` extracts the one-page running-marker transition. `processPages()` folds each completed page once and resolves the still-mutable current page on demand. The scan is skipped when both headers and footers are disabled.

Resolved margins are cached by physical page number for the duration of one layout pass.

Measurement helpers now own the existing caches directly. Neume, lyric, tempo, vareia, elaphron, martyria, and melisma paths reuse those helpers instead of rebuilding equivalent font strings and measurement sequences.

### Structural consolidation

The remaining changes reduce parallel code without intentionally changing semantics:

- `noteMarkSlots` keeps shaped-width measurement and collision mark lists in the same order.
- `noteFthoraSlots` preserves primary, secondary, and tertiary fthora priority and carry restoration.
- scale root-sign and fixed-shift branches use lookup tables where their behavior is data-driven.
- repeated ambitus, header/footer, fill-width, block-element, and forced-break paths use shared helpers.
- equivalent LTR and RTL melisma formulas use the same lyric-edge helpers.
- `processHeader()` and `processFooter()` are consolidated.
- the unused transient `TextBoxElement.heightPrevious` field is removed; it was not part of the save model.

## Files changed

### `src/services/LayoutService.ts`

- Corrects note, martyria, ink-overhang, and measure-bar coordinate handling.
- Preserves preferred-only ordinary spacing and full standard elasticity.
- Consolidates break reservations, transfers, measurement, fthora, mark, scale, header/footer, and melisma paths.
- Resolves running-marker state incrementally and caches page margins.

### `src/utils/runningMarkers.ts`

- Adds the one-page metadata transition used by the incremental fold.
- Preserves the existing array resolver as a left fold over the new helper.

### `src/models/Element.ts`

- Removes the unused transient `TextBoxElement.heightPrevious` field.

### `notes/knuth_plass.md`

- Documents full layout advances, preferred ordinary spacing, standard elasticity, break-only reservations, martyria behavior, adjustment-ratio caps, and negative-width pruning caveats.

## Risks

| Risk                                | Impact                                                                | Mitigation or review focus                                                                        |
| ----------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| Broad geometry changes              | A width change can move a line break and cascade through a paragraph. | Compare representative scores with `origin/master`, especially boundaries involving `spaceAfter`. |
| Martyria and measure-bar regression | These boundaries retain structural limits and use font-specific ink.  | Review the shared Phase 1 reservation and Phase 2 transfer geometry together.                     |
| Negative-spacing behavior           | Generic zero minima can unintentionally erase requested overlap.      | Note-to-note generic zero is ignored; explicitly review terminal and non-note zero clamps.        |
| Refactor semantic drift             | Fthora and scale ordering affects pitch state, not just presentation. | Compare table order and slot-specific fields with the removed branches.                           |
| Font-specific collision changes     | Ink bounds differ among supported neume fonts.                        | Exercise representative bars, vareia, martyriae, lyrics, and melismas across active fonts.        |
| Incomplete visual coverage          | Unit tests do not provide screenshot comparison for layout changes.   | Treat systematic visual comparison with `origin/master` as remaining release validation.          |

## Compatibility

- No `.byz` or `.byzx` schema change.
- No score version bump or migration.
- No IPC or Electron/browser platform-interface change.
- No dependency change.
- No locale or user-visible string change.
- Reverting the PR requires no data rollback.

## Testing done

- `npm test` - 28 test files passed, with 429 tests passed and 6 skipped.
- `npm run lint` - passed.
- Manual visual inspection - several dozen Axion Estin scores were inspected after layout.

There is not yet a systematic screenshot comparison against `origin/master` across page widths and fonts.

## Reviewer guide

1. Review `getNoteBoxAdvance()`, `getMartyriaBoxAdvance()`, and `getNoteRightInkOverhang()` first; these define the corrected coordinate system.
2. Follow `calculateInterNoteSpacing()` into post-note glue and verify that all ordinary candidates remain preferred with full standard shrink.
3. Review martyria-owned glue separately; its structural shrink limits are intentional and can receive changed geometry.
4. Review measure-bar normalization, Phase 1 reservations, and Phase 2 transfers as one path.
5. Review the incremental running-marker fold and page-margin cache independently from musical geometry.
6. Compare the mark, fthora, scale, header/footer, and melisma tables and helpers with the removed branches.
7. Use `notes/knuth_plass.md` for the detailed box/glue/penalty invariants.