### PR TITLE
fix: Vitest native config compatibility

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
   test: {


### PR DESCRIPTION
> Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
>
> - ESM syntax in a file loaded as CommonJS (vitest.config.ts:1:1). Use a `.mjs` extension or set `"type": "module"` in the closest package.json
>
> Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.