### PR TITLE
fix: Vite native config compatibility

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,7 +9,7 @@ import electron from 'vite-plugin-electron';
 import { VitePWA } from 'vite-plugin-pwa';
 import VueDevTools from 'vite-plugin-vue-devtools';
 
-import pkg from './package.json';
+import pkg from './package.json' with { type: 'json' };
 
 // lib-font probes for Node's fs and zlib at module load, behind runtime
 // guards that never fire in the renderer: the fetch shim only activates when
@@ -57,7 +57,7 @@ export default defineConfig(({ command, mode }) => {
   return {
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, './src'),
+        '@': path.resolve(import.meta.dirname, './src'),
       },
     },
     define: {


### PR DESCRIPTION
> Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
> 
> - `__dirname` (vite.config.mjs:60:27). Use `import.meta.dirname` instead
> - JSON import "./package.json" without import attributes (vite.config.mjs:12:17). Add `with { type: 'json' }`
> 
> Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.