### PR TITLE
feat: Penalize runts

### DIFF
--- a/src/services/LayoutService.test.ts
+++ b/src/services/LayoutService.test.ts
@@ -1,3 +1,5 @@
+import type { Box, InputItem, Penalty } from 'tex-linebreak';
+import { MAX_COST } from 'tex-linebreak';
 import { describe, expect, it } from 'vitest';
 
 import type { ScoreElement } from '../models/Element';
@@ -7,6 +9,7 @@ import {
   TempoElement,
   TextBoxElement,
 } from '../models/Element';
+import { QuantitativeNeume, restNeumes } from '../models/Neumes';
 import { Line } from '../models/Page';
 import { PageSetup } from '../models/PageSetup';
 import { LayoutService } from './LayoutService';
@@ -271,6 +274,179 @@ describe.each([true, false])(
   },
 );
 
+describe('LayoutService.applyRuntPenalty', () => {
+  it.each(restNeumes)(
+    'discourages a break that leaves one %s rest',
+    (restNeume) => {
+      const { items, notes, breakPenalties } = getRuntPenaltyItems(3);
+      notes[2].quantitativeNeume = restNeume;
+
+      LayoutService.applyRuntPenalty(items, null);
+
+      expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([
+        0,
+        MAX_COST * 0.15,
+        0,
+      ]);
+    },
+  );
+
+  it('discourages a break that leaves two notes', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(4);
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([
+      0,
+      MAX_COST * 0.15,
+      0,
+      0,
+    ]);
+  });
+
+  it('applies the penalty to the end of a melisma', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(3);
+    notes[0].isMelisma = true;
+    notes[0].isMelismaStart = true;
+    notes[1].isMelisma = true;
+    notes[2].isMelisma = true;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    // Only the last note of the melisma qualifies. The two-note breakpoint
+    // would begin the final line with notes[1], which is mid-melisma.
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([
+      0,
+      MAX_COST * 0.15,
+      0,
+    ]);
+  });
+
+  it('does not apply the penalty to ordinary notes', () => {
+    const { items, breakPenalties } = getRuntPenaltyItems(3);
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([0, 0, 0]);
+  });
+
+  it('penalizes a two-note paragraph without reading past the first item', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(2);
+    notes[1].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([
+      MAX_COST * 0.15,
+      0,
+    ]);
+  });
+
+  it('leaves a one-note paragraph alone', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(1);
+    notes[0].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([0]);
+  });
+
+  it('adds to an existing penalty', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(3);
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+    breakPenalties[1].cost = MAX_COST * 0.5;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties[1].cost).toBe(MAX_COST * 0.65);
+  });
+
+  it('caps the total at the worst cost the break rules produce', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(3);
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+    breakPenalties[1].cost = MAX_COST * 0.85;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties[1].cost).toBe(MAX_COST * 0.95);
+  });
+
+  it('leaves a breakpoint that is already at the cap alone', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(3);
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+    breakPenalties[1].cost = MAX_COST * 0.95;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties[1].cost).toBe(MAX_COST * 0.95);
+  });
+
+  it('does not weaken a prohibited breakpoint', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(3);
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+    breakPenalties[1].cost = MAX_COST;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    expect(breakPenalties[1].cost).toBe(MAX_COST);
+  });
+
+  it('does not count a terminal non-note element as a tail element', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(
+      3,
+      new MartyriaElement(),
+    );
+    notes[1].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    // Were the martyria counted, it would consume a tail slot and the
+    // two-note breakpoint would fall one note earlier, leaving this one at 0.
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([
+      MAX_COST * 0.15,
+      MAX_COST * 0.15,
+      0,
+    ]);
+  });
+
+  it('sees through a non-note box between the tail notes', () => {
+    const { items, notes, breakPenalties } = getRuntPenaltyItems(
+      3,
+      undefined,
+      new TempoElement(),
+    );
+    notes[1].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    // Were the tempo counted, it would consume a tail slot and the walk would
+    // stop one note earlier, leaving the two-note breakpoint at 0.
+    expect(breakPenalties.map((penalty) => penalty.cost)).toEqual([
+      MAX_COST * 0.15,
+      MAX_COST * 0.15,
+      0,
+    ]);
+  });
+
+  it('leaves the martyria breakpoint itself unpenalized', () => {
+    const { items, notes, terminalBreakPenalty } = getRuntPenaltyItems(
+      3,
+      new MartyriaElement(),
+    );
+    notes[2].quantitativeNeume = QuantitativeNeume.VareiaDotted;
+
+    LayoutService.applyRuntPenalty(items, null);
+
+    // The martyria's breakpoint is preceded by its pre-break glue rather than
+    // a note box, so the rule does not reach it even though breaking there
+    // would strand the trailing rest.
+    expect(terminalBreakPenalty!.cost).toBe(0);
+  });
+});
+
 describe('LayoutService.mayShowLeadingLyricHyphen', () => {
   it('suppresses Greek start hyphens when Greek melismata are enabled', () => {
     const pageSetup = getMockPageSetup();
@@ -368,6 +544,79 @@ function getLine(...elements: ScoreElement[]) {
   const line = new Line();
   line.elements = elements;
   return line;
+}
+
+function elementBox(element: ScoreElement): Box & { element: ScoreElement } {
+  return { type: 'box', width: 10, element };
+}
+
+function penaltyItem(cost: number): Penalty {
+  return { type: 'penalty', cost, width: 0, flagged: false };
+}
+
+function glueItem(width: number, stretch: number, shrink: number): InputItem {
+  return { type: 'glue', width, stretch, shrink };
+}
+
+function getRuntPenaltyItems(
+  noteCount: number,
+  terminalElement?: ScoreElement,
+  elementBeforeLastNote?: ScoreElement,
+) {
+  const items: InputItem[] = [];
+  const notes: NoteElement[] = [];
+  const breakPenalties: Penalty[] = [];
+  // The martyria's own breakpoint, when a terminal element is present. It is
+  // not preceded by a note box, so applyRuntPenalty never reaches it.
+  let terminalBreakPenalty: Penalty | null = null;
+
+  for (let i = 0; i < noteCount; i++) {
+    if (elementBeforeLastNote != null && i === noteCount - 1) {
+      // A tempo or inline text box between two notes: a box followed by
+      // standard glue, contributing no penalty of its own.
+      items.push(elementBox(elementBeforeLastNote), glueItem(5, 5, 5));
+    }
+
+    const note = new NoteElement();
+    notes.push(note);
+    items.push(elementBox(note));
+
+    // Break opportunity after the neume: an unlabeled penalty immediately
+    // after the box, then the post-break glue.
+    const penalty = penaltyItem(0);
+    breakPenalties.push(penalty);
+    items.push(penalty, glueItem(5, 5, 5));
+  }
+
+  if (terminalElement != null) {
+    // addProtectedBreakpointEncoding: the break must occur at the penalty
+    // rather than before the pre-break glue, so the post-break glue is
+    // skipped on the next line.
+    terminalBreakPenalty = penaltyItem(0);
+    items.push(
+      elementBox(terminalElement),
+      penaltyItem(MAX_COST),
+      glueItem(0, 0, 0),
+      terminalBreakPenalty,
+      glueItem(5, 5, 5),
+    );
+  }
+
+  // removeGlue strips the paragraph's trailing glue before the finishing glue
+  // is applied.
+  while (items[items.length - 1].type === 'glue') {
+    items.pop();
+  }
+
+  // The paragraph terminator that endParagraph appends before the penalties
+  // are applied: prevent-break, finishing glue, forced break.
+  items.push(
+    penaltyItem(MAX_COST),
+    glueItem(0, MAX_COST, 0),
+    penaltyItem(-MAX_COST),
+  );
+
+  return { items, notes, breakPenalties, terminalBreakPenalty };
 }
 
 function getMockPageSetup() {

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -44,6 +44,7 @@ import {
   Note,
   NoteIndicator,
   QuantitativeNeume,
+  restNeumes,
   RootSign,
   Tie,
   TimeNeume,
@@ -4360,6 +4361,108 @@ export class LayoutService {
     return this.breakParagraphWithRatioCap(items, lineLengths, relaxedCap);
   }
 
+  private static isNoteBox(
+    item: InputItem,
+  ): item is ElementBox & { element: NoteElement } {
+    return (
+      item.type === 'box' &&
+      'element' in item &&
+      (item as ElementBox).element.elementType === ElementType.Note
+    );
+  }
+
+  private static isRuntPenaltyNote(
+    noteElement: NoteElement,
+    nextNoteElement: NoteElement | null,
+  ) {
+    return (
+      restNeumes.includes(noteElement.quantitativeNeume) ||
+      (this.isPartOfSameMelisma(noteElement) &&
+        !this.isPartOfSameMelisma(nextNoteElement))
+    );
+  }
+
+  /**
+   * Penalizes breakpoints that would leave only one or two notes on the
+   * paragraph's final line, walking the tail backwards until both candidate
+   * breakpoints have been passed.
+   *
+   * At each candidate breakpoint exactly one note is tested: the note that
+   * would begin the final line. It earns a penalty only when it is a rest or
+   * the last continuation note of a melisma. Breakpoints that are already
+   * prohibited (cost >= MAX_COST) are left untouched.
+   *
+   * Only breakpoints that immediately follow a note box are considered, so the
+   * free breakpoint after a martyria is out of scope even though it can strand
+   * a tail of its own.
+   *
+   * Only note boxes count toward the tail. Every other box is transparent to
+   * this rule, including a terminal right-aligned martyria, which is visually
+   * the last element but is not part of the short musical tail being measured.
+   *
+   * @param items The paragraph's items, mutated in place.
+   * @param diagnosticItems The parallel diagnostics mirror, or null when
+   *   diagnostics are not being collected.
+   */
+  public static applyRuntPenalty(
+    items: InputItem[],
+    diagnosticItems: LayoutDiagnosticItem[] | null,
+  ) {
+    let tailNoteCount = 0;
+    let tailNote: NoteElement | null = null;
+    let nextTailNote: NoteElement | null = null;
+
+    for (let i = items.length - 1; i >= 1; i--) {
+      const item = items[i];
+
+      if (this.isNoteBox(item)) {
+        tailNoteCount++;
+
+        if (tailNoteCount > 2) {
+          return;
+        }
+
+        nextTailNote = tailNote;
+        tailNote = item.element;
+        continue;
+      }
+
+      if (
+        tailNote == null ||
+        item.type !== 'penalty' ||
+        item.cost >= MAX_COST ||
+        !this.isNoteBox(items[i - 1]) ||
+        !this.isRuntPenaltyNote(tailNote, nextTailNote)
+      ) {
+        continue;
+      }
+
+      // Discourage a short tail with a flat penalty, weighted like the melisma
+      // penalties in getBreakCost. This deliberately stacks with those rules
+      // when the tail is a melisma tail: they describe the shape of the
+      // melisma, this one describes the shape of the final line.
+      //
+      // The total is capped at 0.95 * MAX_COST, the worst cost getBreakCost
+      // can assign to a breakpoint that is still a legal break: one strong
+      // penalty (0.5) plus all three weaker ones (0.45). That keeps the break
+      // a preference rather than a prohibition, keeps the result inside the
+      // range the break rules themselves use, and keeps it monotone in the
+      // base cost, so an intrinsically worse breakpoint never ends up cheaper.
+      if (item.cost < MAX_COST * 0.95) {
+        item.cost = Math.min(item.cost + MAX_COST * 0.15, MAX_COST * 0.95);
+      }
+
+      if (diagnosticItems != null) {
+        // The only penalty that can immediately follow a note box is the
+        // unlabeled break opportunity pushed after the neume, so there is no
+        // existing label to preserve here.
+        const diagnosticItem = diagnosticItems[i];
+        diagnosticItem.cost = item.cost;
+        diagnosticItem.label = `runt-${tailNoteCount}-note`;
+      }
+    }
+  }
+
   private static endParagraph(
     lineBreakType: LineBreakType,
     workspace: LayoutWorkspace,
@@ -4407,6 +4510,12 @@ export class LayoutService {
 
     // Force break and end paragraph
     this.forceBreak(workspace);
+
+    // Discourage breakpoints that leave a one- or two-note final line.
+    this.applyRuntPenalty(
+      pendingParagraph,
+      workspace.diagnostics?.items ?? null,
+    );
 
     // Compute per-line widths for multiline drop caps
     let lineLengths: number | number[];


### PR DESCRIPTION
Penalizes breakpoints that would leave only one or two notes on a paragraph's final line. At each candidate breakpoint, the note that would begin the final line earns a penalty when it is a rest or the last continuation note of a melisma.

The runt penalty is weighted at 15% of `MAX_COST` and stacks with existing breakpoint penalties. The total is capped at 95% of `MAX_COST`, matching the highest cost produced by the existing break rules while keeping the breakpoint legal. Prohibited breakpoints are left untouched.

Only note boxes count toward the tail. Other boxes are transparent to the rule, including inline elements and a terminal right-aligned martyria. The martyria's own breakpoint is outside the rule because it does not immediately follow a note box.

My goal with this was to be gentle enough that it could be enabled by default without an option to disable it. Rather than codify a more aggressive policy algorithmically and add a checkbox, I think it should suffice to integrate #2574 and allow users to fine-tune individual cases with **Keep with Next.**

I tested this with my scores, many of which had a rest at the beginning of the last line. That problem has been fixed with this PR. I did not notice any aggressive or improper final lines; it was a strict improvement over the status quo in every case I checked.

Fixes #2272