### PR TITLE
Fix substitution resolution

### DIFF
--- a/src/assets/fonts/neanes.metadata.json
+++ b/src/assets/fonts/neanes.metadata.json
@@ -7898,6 +7898,20 @@
       ]
     }
   },
+  "markAttachmentClasses": {
+    "gorgon": [
+      "digorgon",
+      "digorgonDottedLeftAbove",
+      "digorgonDottedLeftBelow",
+      "digorgonDottedRight",
+      "gorgonAbove",
+      "gorgonDottedLeft",
+      "gorgonDottedRight",
+      "trigorgon",
+      "trigorgonDottedLeftAbove",
+      "trigorgonDottedRight"
+    ]
+  },
   "contextualSubstitutions": [
     {
       "inputGlyphs": [
@@ -7964,7 +7978,8 @@
           "from": "yporroi",
           "to": "yporroi.gorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -7987,7 +8002,8 @@
           "from": "yporroi",
           "to": "yporroi.digorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -8009,7 +8025,8 @@
           "from": "yporroi",
           "to": "yporroi.trigorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [

--- a/src/assets/fonts/neanesengraving.metadata.json
+++ b/src/assets/fonts/neanesengraving.metadata.json
@@ -7898,6 +7898,20 @@
       ]
     }
   },
+  "markAttachmentClasses": {
+    "gorgon": [
+      "digorgon",
+      "digorgonDottedLeftAbove",
+      "digorgonDottedLeftBelow",
+      "digorgonDottedRight",
+      "gorgonAbove",
+      "gorgonDottedLeft",
+      "gorgonDottedRight",
+      "trigorgon",
+      "trigorgonDottedLeftAbove",
+      "trigorgonDottedRight"
+    ]
+  },
   "contextualSubstitutions": [
     {
       "inputGlyphs": [
@@ -7964,7 +7978,8 @@
           "from": "yporroi",
           "to": "yporroi.gorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -7987,7 +8002,8 @@
           "from": "yporroi",
           "to": "yporroi.digorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -8009,7 +8025,8 @@
           "from": "yporroi",
           "to": "yporroi.trigorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [

--- a/src/assets/fonts/neanesstathisseries.metadata.json
+++ b/src/assets/fonts/neanesstathisseries.metadata.json
@@ -7930,6 +7930,20 @@
       ]
     }
   },
+  "markAttachmentClasses": {
+    "gorgon": [
+      "digorgon",
+      "digorgonDottedLeftAbove",
+      "digorgonDottedLeftBelow",
+      "digorgonDottedRight",
+      "gorgonAbove",
+      "gorgonDottedLeft",
+      "gorgonDottedRight",
+      "trigorgon",
+      "trigorgonDottedLeftAbove",
+      "trigorgonDottedRight"
+    ]
+  },
   "contextualSubstitutions": [
     {
       "inputGlyphs": [
@@ -7996,7 +8010,8 @@
           "from": "yporroi",
           "to": "yporroi.gorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -8019,7 +8034,8 @@
           "from": "yporroi",
           "to": "yporroi.digorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -8041,7 +8057,8 @@
           "from": "yporroi",
           "to": "yporroi.trigorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [

--- a/src/assets/fonts/neanesstathisseriesengraving.metadata.json
+++ b/src/assets/fonts/neanesstathisseriesengraving.metadata.json
@@ -7930,6 +7930,20 @@
       ]
     }
   },
+  "markAttachmentClasses": {
+    "gorgon": [
+      "digorgon",
+      "digorgonDottedLeftAbove",
+      "digorgonDottedLeftBelow",
+      "digorgonDottedRight",
+      "gorgonAbove",
+      "gorgonDottedLeft",
+      "gorgonDottedRight",
+      "trigorgon",
+      "trigorgonDottedLeftAbove",
+      "trigorgonDottedRight"
+    ]
+  },
   "contextualSubstitutions": [
     {
       "inputGlyphs": [
@@ -7996,7 +8010,8 @@
           "from": "yporroi",
           "to": "yporroi.gorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -8019,7 +8034,8 @@
           "from": "yporroi",
           "to": "yporroi.digorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [
@@ -8041,7 +8057,8 @@
           "from": "yporroi",
           "to": "yporroi.trigorgon"
         }
-      ]
+      ],
+      "markAttachmentClass": "gorgon"
     },
     {
       "inputGlyphs": [

--- a/src/services/FontService.test.ts
+++ b/src/services/FontService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { fontService } from './FontService';
+
+describe('FontService.resolveContextualSubstitutions', () => {
+  it('applies a yporroi gorgon substitution across an unrelated mark', () => {
+    expect(
+      fontService.resolveContextualSubstitutions('Neanes', [
+        'yporroi',
+        'apli',
+        'gorgonAbove',
+      ]),
+    ).toEqual(['yporroi.gorgon', 'apli', 'gorgonAbove']);
+  });
+
+  it('does not skip a mark in the gorgon attachment class', () => {
+    expect(
+      fontService.resolveContextualSubstitutions('Neanes', [
+        'yporroi',
+        'digorgon',
+        'gorgonAbove',
+      ]),
+    ).toEqual(['yporroi.digorgon', 'digorgon', 'gorgonAbove']);
+  });
+
+  it('keeps marks significant for lookups without a mark attachment type', () => {
+    expect(
+      fontService.resolveContextualSubstitutions('Neanes', [
+        'yporroi',
+        'apli',
+        'antikenoma',
+      ]),
+    ).toEqual(['yporroi', 'apli', 'antikenoma']);
+  });
+});

--- a/src/services/FontService.ts
+++ b/src/services/FontService.ts
@@ -39,6 +39,7 @@ interface ContextualSubstitution {
   inputGlyphs: SbmuflGlyphName[][];
   backtrackGlyphs: SbmuflGlyphName[][];
   lookaheadGlyphs: SbmuflGlyphName[][];
+  markAttachmentClass?: string;
   substitutions: Array<{
     index: number;
     from: SbmuflGlyphName;
@@ -87,21 +88,34 @@ class FontService {
     glyphs: SbmuflGlyphName[],
   ) {
     const resolvedGlyphs = [...glyphs];
+    const markAttachmentClasses = this.getMetadata(fontFamily)
+      .markAttachmentClasses as Record<string, SbmuflGlyphName[]> | undefined;
 
     for (const rule of this.getContextualSubstitutions(fontFamily)) {
+      const markAttachmentGlyphs =
+        rule.markAttachmentClass != null
+          ? markAttachmentClasses?.[rule.markAttachmentClass]
+          : undefined;
+
       for (
         let inputStart = 0;
         inputStart <= resolvedGlyphs.length - rule.inputGlyphs.length;
         inputStart++
       ) {
-        if (
-          !this.contextualSubstitutionMatches(rule, resolvedGlyphs, inputStart)
-        ) {
+        const inputIndexes = this.contextualSubstitutionMatchIndexes(
+          fontFamily,
+          rule,
+          resolvedGlyphs,
+          inputStart,
+          markAttachmentGlyphs,
+        );
+
+        if (inputIndexes == null) {
           continue;
         }
 
         for (const substitution of rule.substitutions) {
-          const glyphIndex = inputStart + substitution.index;
+          const glyphIndex = inputIndexes[substitution.index];
           if (resolvedGlyphs[glyphIndex] === substitution.from) {
             resolvedGlyphs[glyphIndex] = substitution.to;
           }
@@ -112,37 +126,92 @@ class FontService {
     return resolvedGlyphs;
   }
 
-  private contextualSubstitutionMatches(
+  private contextualSubstitutionMatchIndexes(
+    fontFamily: string,
     rule: ContextualSubstitution,
     glyphs: SbmuflGlyphName[],
     inputStart: number,
+    markAttachmentGlyphs: SbmuflGlyphName[] | undefined,
   ) {
-    return (
-      this.glyphClassesMatch(
-        rule.backtrackGlyphs,
-        glyphs,
-        inputStart - rule.backtrackGlyphs.length,
-      ) &&
-      this.glyphClassesMatch(rule.inputGlyphs, glyphs, inputStart) &&
-      this.glyphClassesMatch(
-        rule.lookaheadGlyphs,
-        glyphs,
-        inputStart + rule.inputGlyphs.length,
-      )
+    const inputIndexes = this.glyphClassesMatch(
+      fontFamily,
+      markAttachmentGlyphs,
+      rule.inputGlyphs,
+      glyphs,
+      inputStart,
+      1,
     );
+
+    if (inputIndexes == null || inputIndexes[0] !== inputStart) {
+      return null;
+    }
+
+    const backtrackIndexes = this.glyphClassesMatch(
+      fontFamily,
+      markAttachmentGlyphs,
+      [...rule.backtrackGlyphs].reverse(),
+      glyphs,
+      inputStart - 1,
+      -1,
+    );
+    const lookaheadIndexes = this.glyphClassesMatch(
+      fontFamily,
+      markAttachmentGlyphs,
+      rule.lookaheadGlyphs,
+      glyphs,
+      inputIndexes.at(-1)! + 1,
+      1,
+    );
+
+    return backtrackIndexes != null && lookaheadIndexes != null
+      ? inputIndexes
+      : null;
   }
 
   private glyphClassesMatch(
+    fontFamily: string,
+    markAttachmentGlyphs: SbmuflGlyphName[] | undefined,
     glyphClasses: SbmuflGlyphName[][],
     glyphs: SbmuflGlyphName[],
     start: number,
+    direction: 1 | -1,
   ) {
-    if (start < 0 || start + glyphClasses.length > glyphs.length) {
-      return false;
+    const indexes: number[] = [];
+    let glyphIndex = start;
+
+    for (const glyphClass of glyphClasses) {
+      while (
+        glyphIndex >= 0 &&
+        glyphIndex < glyphs.length &&
+        this.isIgnoredMark(fontFamily, markAttachmentGlyphs, glyphs[glyphIndex])
+      ) {
+        glyphIndex += direction;
+      }
+
+      if (
+        glyphIndex < 0 ||
+        glyphIndex >= glyphs.length ||
+        !glyphClass.includes(glyphs[glyphIndex])
+      ) {
+        return null;
+      }
+
+      indexes.push(glyphIndex);
+      glyphIndex += direction;
     }
 
-    return glyphClasses.every((glyphClass, index) =>
-      glyphClass.includes(glyphs[start + index]),
+    return indexes;
+  }
+
+  private isIgnoredMark(
+    fontFamily: string,
+    markAttachmentGlyphs: SbmuflGlyphName[] | undefined,
+    glyph: SbmuflGlyphName,
+  ) {
+    return (
+      markAttachmentGlyphs != null &&
+      this.getAdvanceWidth(fontFamily, glyph) === 0 &&
+      !markAttachmentGlyphs.includes(glyph)
     );
   }
 


### PR DESCRIPTION
Fixes #2639.

**Summary**
Fix contextual substitution so yporroi + apli + gorgonAbove correctly produces yporroi.gorgon. Metadata now preserves the font’s mark-attachment class, allowing unrelated marks such as apli to be skipped during matching.

**Testing**
Added regression coverage for intervening and attachment-class marks.