### PR TITLE
Fix running elaphron lyrics alignment

### DIFF
--- a/src/assets/fonts/neanes.metadata.json
+++ b/src/assets/fonts/neanes.metadata.json
@@ -6,7 +6,17 @@
     "descent": 0.2,
     "winAscent": 1.4,
     "winDescent": 0.466,
-    "oligonMidpoint": 0.307
+    "oligonMidpoint": 0.307,
+    "elafronBounds": {
+      "runningElafron": {
+        "left": 0.59,
+        "right": 1.696
+      },
+      "petastiRunningElafron": {
+        "left": 0.425,
+        "right": 1.431
+      }
+    }
   },
   "glyphsWithAnchors": {
     "ison": {

--- a/src/assets/fonts/neanesengraving.metadata.json
+++ b/src/assets/fonts/neanesengraving.metadata.json
@@ -6,7 +6,17 @@
     "descent": 0.2,
     "winAscent": 1.4,
     "winDescent": 0.466,
-    "oligonMidpoint": 0.307
+    "oligonMidpoint": 0.307,
+    "elafronBounds": {
+      "runningElafron": {
+        "left": 0.542,
+        "right": 1.648
+      },
+      "petastiRunningElafron": {
+        "left": 0.502,
+        "right": 1.508
+      }
+    }
   },
   "glyphsWithAnchors": {
     "ison": {

--- a/src/assets/fonts/neanesrtl.metadata.json
+++ b/src/assets/fonts/neanesrtl.metadata.json
@@ -6,7 +6,17 @@
     "descent": 0.2,
     "winAscent": 1.4,
     "winDescent": 0.466,
-    "oligonMidpoint": 0.307
+    "oligonMidpoint": 0.307,
+    "elafronBounds": {
+      "runningElafron": {
+        "left": 0.08,
+        "right": 1.185
+      },
+      "petastiRunningElafron": {
+        "left": 0.085,
+        "right": 1.091
+      }
+    }
   },
   "glyphsWithAnchors": {
     "ison": {

--- a/src/assets/fonts/neanesrtlengraving.metadata.json
+++ b/src/assets/fonts/neanesrtlengraving.metadata.json
@@ -6,7 +6,17 @@
     "descent": 0.2,
     "winAscent": 1.4,
     "winDescent": 0.466,
-    "oligonMidpoint": 0.307
+    "oligonMidpoint": 0.307,
+    "elafronBounds": {
+      "runningElafron": {
+        "left": -0.002,
+        "right": 1.104
+      },
+      "petastiRunningElafron": {
+        "left": 0.019,
+        "right": 1.024
+      }
+    }
   },
   "glyphsWithAnchors": {
     "ison": {

--- a/src/assets/fonts/neanesstathisseries.metadata.json
+++ b/src/assets/fonts/neanesstathisseries.metadata.json
@@ -6,7 +6,17 @@
     "descent": 0.2,
     "winAscent": 1.4,
     "winDescent": 0.466,
-    "oligonMidpoint": 0.309
+    "oligonMidpoint": 0.309,
+    "elafronBounds": {
+      "runningElafron": {
+        "left": 0.72,
+        "right": 1.772
+      },
+      "petastiRunningElafron": {
+        "left": 0.389,
+        "right": 1.515
+      }
+    }
   },
   "glyphsWithAnchors": {
     "ison": {

--- a/src/assets/fonts/neanesstathisseriesengraving.metadata.json
+++ b/src/assets/fonts/neanesstathisseriesengraving.metadata.json
@@ -6,7 +6,17 @@
     "descent": 0.2,
     "winAscent": 1.4,
     "winDescent": 0.466,
-    "oligonMidpoint": 0.309
+    "oligonMidpoint": 0.309,
+    "elafronBounds": {
+      "runningElafron": {
+        "left": 0.72,
+        "right": 1.772
+      },
+      "petastiRunningElafron": {
+        "left": 0.721,
+        "right": 1.847
+      }
+    }
   },
   "glyphsWithAnchors": {
     "ison": {

--- a/src/models/Neumes.ts
+++ b/src/models/Neumes.ts
@@ -477,6 +477,11 @@ export type Neume =
   | Tie
   | Letter;
 
+export const runningElaphronNeumes: ReadonlyArray<QuantitativeNeume> = [
+  QuantitativeNeume.RunningElaphron,
+  QuantitativeNeume.PetastiPlusRunningElaphron,
+];
+
 export const petastiNeumes: ReadonlyArray<QuantitativeNeume> = [
   QuantitativeNeume.PetastiWithIson,
   QuantitativeNeume.Petasti,

--- a/src/services/FontService.test.ts
+++ b/src/services/FontService.test.ts
@@ -2,6 +2,45 @@ import { describe, expect, it } from 'vitest';
 
 import { fontService } from './FontService';
 
+describe('FontService.getLyricsHorizontalOffset', () => {
+  it.each([
+    ['Neanes', 'runningElafron', 0.544],
+    ['Neanes', 'petastiRunningElafron', 0.504],
+    ['NeanesLegacy', 'runningElafron', 0.534],
+    ['NeanesLegacy', 'petastiRunningElafron', 0.342],
+    ['NeanesRTL', 'runningElafron', -0.389],
+    ['NeanesRTL', 'petastiRunningElafron', -0.32],
+    ['NeanesRTLLegacy', 'runningElafron', -0.487],
+    ['NeanesRTLLegacy', 'petastiRunningElafron', -0.338],
+    ['NeanesStathisSeries', 'runningElafron', 0.72],
+    ['NeanesStathisSeries', 'petastiRunningElafron', 0.721],
+    ['NeanesStathisSeriesLegacy', 'runningElafron', 0.74],
+    ['NeanesStathisSeriesLegacy', 'petastiRunningElafron', 0.39],
+  ] as const)('derives the offset for %s %s', (font, glyph, offset) => {
+    expect(fontService.getLyricsHorizontalOffset(font, glyph)).toBeCloseTo(
+      offset,
+      3,
+    );
+  });
+});
+
+describe('FontService.getElafronBounds', () => {
+  it.each([
+    ['NeanesStathisSeries', 'runningElafron', 0.72, 1.772],
+    ['NeanesStathisSeries', 'petastiRunningElafron', 0.721, 1.847],
+    ['NeanesRTL', 'runningElafron', -0.002, 1.104],
+    ['NeanesRTL', 'petastiRunningElafron', 0.019, 1.024],
+  ] as const)(
+    'returns the generated bounds for %s %s',
+    (font, glyph, left, right) => {
+      expect(fontService.getElafronBounds(font, glyph)).toEqual({
+        left,
+        right,
+      });
+    },
+  );
+});
+
 describe('FontService.resolveContextualSubstitutions', () => {
   it('applies a yporroi gorgon substitution across an unrelated mark', () => {
     expect(

--- a/src/services/FontService.ts
+++ b/src/services/FontService.ts
@@ -12,6 +12,12 @@ interface Metrics {
   winAscent: number;
   winDescent: number;
   oligonMidpoint: number;
+  elafronBounds: Partial<Record<SbmuflGlyphName, HorizontalBounds>>;
+}
+
+interface HorizontalBounds {
+  left: number;
+  right: number;
 }
 
 interface EngravingGlue {
@@ -62,6 +68,27 @@ class FontService {
 
   getMetrics(fontFamily: string) {
     return this.getMetadata(fontFamily).metrics as Metrics;
+  }
+
+  getLyricsHorizontalOffset(
+    fontFamily: string,
+    glyph: SbmuflGlyphName,
+  ): number {
+    const { left, right } = this.getElafronBounds(fontFamily, glyph);
+    return left + right - this.getAdvanceWidth(fontFamily, glyph);
+  }
+
+  getElafronBounds(
+    fontFamily: string,
+    glyph: SbmuflGlyphName,
+  ): HorizontalBounds {
+    const bounds = this.getMetrics(fontFamily).elafronBounds[glyph];
+
+    if (bounds == null) {
+      throw new Error(`Missing elafron bounds for ${glyph}`);
+    }
+
+    return bounds;
   }
 
   getAdvanceWidth(fontFamily: string, glyph: SbmuflGlyphName) {

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -55,6 +55,7 @@ import {
   QuantitativeNeume,
   restNeumes,
   RootSign,
+  runningElaphronNeumes,
   TimeNeume,
   VocalExpressionNeume,
 } from '@/models/Neumes';
@@ -143,6 +144,8 @@ const kentemataSet = new Set<QuantitativeNeume>([
   QuantitativeNeume.Kentemata,
   QuantitativeNeume.KentemataPlusOligon,
 ]);
+
+const runningElaphronSet = new Set(runningElaphronNeumes);
 
 const beatStealingSet = new Set<QuantitativeNeume>([
   QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata,
@@ -5180,16 +5183,18 @@ export class LayoutService {
       noteElement.neumeWidth += measureBarRightWidth;
     }
 
-    // Handle special case for running elaphron: shift the lyrics toward the
+    // Handle special cases for running elaphron: shift the lyrics toward the
     // elaphron so that they remain centered beneath it.
-    if (noteElement.quantitativeNeume === QuantitativeNeume.RunningElaphron) {
-      const offset = this.getRunningElaphronOffset(pageSetup);
-
-      if (pageSetup.melkiteRtl) {
-        noteElement.lyricsHorizontalOffset -= offset;
-      } else {
-        noteElement.lyricsHorizontalOffset += offset;
-      }
+    if (runningElaphronSet.has(noteElement.quantitativeNeume)) {
+      const glyphName = NeumeMappingService.getMapping(
+        noteElement.quantitativeNeume,
+      ).glyphName;
+      noteElement.lyricsHorizontalOffset +=
+        pageSetup.neumeDefaultFontSize *
+        fontService.getLyricsHorizontalOffset(
+          pageSetup.neumeDefaultFontFamily,
+          glyphName,
+        );
     }
 
     return this.getNoteBoxAdvance(noteElement);
@@ -5281,11 +5286,23 @@ export class LayoutService {
       defaultLyricsFontCss,
     );
 
-    const elaphronWidth = this.getNeumeWidthFromCache(
-      QuantitativeNeume.Elaphron,
-      pageSetup,
-    );
-    const runningElaphronOffset = this.getRunningElaphronOffset(pageSetup);
+    const runningElaphronGeometry = new Map<
+      QuantitativeNeume,
+      { left: number; width: number }
+    >();
+
+    for (const quantitativeNeume of runningElaphronSet) {
+      const glyphName =
+        NeumeMappingService.getMapping(quantitativeNeume).glyphName;
+      const bounds = fontService.getElafronBounds(
+        pageSetup.neumeDefaultFontFamily,
+        glyphName,
+      );
+      runningElaphronGeometry.set(quantitativeNeume, {
+        left: bounds.left * pageSetup.neumeDefaultFontSize,
+        width: (bounds.right - bounds.left) * pageSetup.neumeDefaultFontSize,
+      });
+    }
 
     let melismaSyllables: MelismaSyllables | null = null;
     let melismaLyricsEnd: number | null = null;
@@ -5584,37 +5601,38 @@ export class LayoutService {
               }
             } else if (!pageSetup.melkiteRtl) {
               // Else not a hyphen, so an underscore
-              const nextElementIsRunningElaphron =
-                nextElement &&
-                nextElement.elementType === ElementType.Note &&
-                (nextElement as NoteElement).quantitativeNeume ===
-                  QuantitativeNeume.RunningElaphron;
+              const nextRunningElaphronGeometry =
+                nextNoteElement != null
+                  ? runningElaphronGeometry.get(
+                      nextNoteElement.quantitativeNeume,
+                    )
+                  : undefined;
 
               // Note the special case for when the next neume is a running elaphron.
               // The melisma, which by convention must always be a final melisma,
               // should run all the way to the elaphron, instead of stopping at
               // the apostrophos.
 
-              if (nextNoteElement != null && nextElementIsRunningElaphron) {
-                end = nextNoteElement.x + runningElaphronOffset;
+              if (
+                nextNoteElement != null &&
+                nextRunningElaphronGeometry != null
+              ) {
+                const { left: elaphronLeft, width: elaphronWidth } =
+                  nextRunningElaphronGeometry;
+                const elaphronLeftInNote =
+                  this.getNoteLeftBarReserve(
+                    nextNoteElement,
+                    measureBarWidthMap,
+                  ) + elaphronLeft;
+                end = nextNoteElement.x + elaphronLeftInNote;
 
                 if (nextNoteElement.lyricsWidth > elaphronWidth) {
-                  if (nextNoteElement.alignLeft) {
-                    end = Math.min(
-                      end,
-                      nextNoteElement.x +
-                        runningElaphronOffset -
-                        pageSetup.lyricsMinimumSpacing,
-                    );
-                  } else {
-                    end = Math.min(
-                      end,
-                      nextNoteElement.x +
-                        runningElaphronOffset -
-                        (nextNoteElement.lyricsWidth - elaphronWidth) / 2 -
-                        pageSetup.lyricsMinimumSpacing,
-                    );
-                  }
+                  end = Math.min(
+                    end,
+                    nextNoteElement.x +
+                      this.getLyricTextLeft(nextNoteElement) -
+                      pageSetup.lyricsMinimumSpacing,
+                  );
                 }
               } else {
                 if (finalElement == null) {
@@ -7580,19 +7598,6 @@ export class LayoutService {
 
   private static getNeumeWidthFromCache(neume: Neume, pageSetup: PageSetup) {
     return this.getNeumeSequenceWidthFromCache([neume], pageSetup);
-  }
-
-  // The stand-alone apostrophos is not the same width as the apostrophos in
-  // the running elaphron, but the elaphrons are the same width in both
-  // neumes, so this offset locates the elaphron body inside the composite
-  // glyph.
-  private static getRunningElaphronOffset(pageSetup: PageSetup) {
-    return (
-      this.getNeumeWidthFromCache(
-        QuantitativeNeume.RunningElaphron,
-        pageSetup,
-      ) - this.getNeumeWidthFromCache(QuantitativeNeume.Elaphron, pageSetup)
-    );
   }
 
   private static getNeumeSequenceWidthFromCache(

--- a/src/services/LyricService.test.ts
+++ b/src/services/LyricService.test.ts
@@ -235,7 +235,13 @@ describe('LyricService (English)', () => {
     ).toMatchSnapshot();
   });
 
-  it('should assign running elafron correctly', () => {
+  it.each([
+    ['running elafron', QuantitativeNeume.RunningElaphron],
+    [
+      'petasti plus running elafron',
+      QuantitativeNeume.PetastiPlusRunningElaphron,
+    ],
+  ] as const)('should assign %s correctly', (_, runningElaphron) => {
     const lyricService = new LyricService();
 
     const scoreElements: ScoreElement[] = [];
@@ -244,13 +250,13 @@ describe('LyricService (English)', () => {
     ison1.quantitativeNeume = QuantitativeNeume.Ison;
 
     const runningElafron1 = new NoteElement();
-    runningElafron1.quantitativeNeume = QuantitativeNeume.RunningElaphron;
+    runningElafron1.quantitativeNeume = runningElaphron;
 
     const ison2 = new NoteElement();
     ison2.quantitativeNeume = QuantitativeNeume.Ison;
 
     const runningElafron2 = new NoteElement();
-    runningElafron2.quantitativeNeume = QuantitativeNeume.RunningElaphron;
+    runningElafron2.quantitativeNeume = runningElaphron;
 
     scoreElements.push(ison1);
     scoreElements.push(runningElafron1);

--- a/src/services/LyricService.ts
+++ b/src/services/LyricService.ts
@@ -6,7 +6,7 @@ import type {
   ScoreElement,
 } from '@/models/Element';
 import { AcceptsLyricsOption, ElementType } from '@/models/Element';
-import { QuantitativeNeume } from '@/models/Neumes';
+import { QuantitativeNeume, runningElaphronNeumes } from '@/models/Neumes';
 import { TATWEEL } from '@/utils/constants';
 
 import type { MelismaSyllables } from './MelismaHelperGreek';
@@ -350,7 +350,7 @@ export class LyricService {
               : false;
           const nextNoteIsRunningElaphron =
             nextNote != null
-              ? nextNote.quantitativeNeume === QuantitativeNeume.RunningElaphron
+              ? runningElaphronNeumes.includes(nextNote.quantitativeNeume)
               : false;
 
           // Finally, we check the next note to handle some special cases.


### PR DESCRIPTION
Fixes #2640.

Center Running Elaphron lyrics using generated glyph bounds and keep melisma endpoints aligned, including Petasti variants and inline left measure bars.